### PR TITLE
fix: DNS-1035 label

### DIFF
--- a/src/network_launcher/devnet.star
+++ b/src/network_launcher/devnet.star
@@ -12,7 +12,7 @@ def launch(plan, network, prague_time, repo):
         name="el_cl_genesis",
     )
     el_cl_genesis_data_uuid = plan.run_sh(
-        name="move_genesis_data",
+        name="move-genesis-data",
         description="Creating network configs",
         run="mkdir -p /network-configs/ && mv /opt/* /network-configs/",
         store=[StoreSpec(src="/network-configs/", name="el_cl_genesis_data")],

--- a/src/network_launcher/ephemery.star
+++ b/src/network_launcher/ephemery.star
@@ -6,7 +6,7 @@ el_cl_genesis_data = import_module(
 
 def launch(plan, prague_time):
     el_cl_genesis_data_uuid = plan.run_sh(
-        name="fetch_ephemery_genesis_data",
+        name="fetch-ephemery-genesis_data",
         description="Creating network configs",
         run="mkdir -p /network-configs/ && \
             curl -o latest.tar.gz https://ephemery.dev/latest.tar.gz && \

--- a/src/network_launcher/ephemery.star
+++ b/src/network_launcher/ephemery.star
@@ -6,7 +6,7 @@ el_cl_genesis_data = import_module(
 
 def launch(plan, prague_time):
     el_cl_genesis_data_uuid = plan.run_sh(
-        name="fetch-ephemery-genesis_data",
+        name="fetch-ephemery-genesis-data",
         description="Creating network configs",
         run="mkdir -p /network-configs/ && \
             curl -o latest.tar.gz https://ephemery.dev/latest.tar.gz && \

--- a/src/network_launcher/public_network.star
+++ b/src/network_launcher/public_network.star
@@ -8,7 +8,7 @@ constants = import_module("../package_io/constants.star")
 def launch(plan, network, prague_time):
     # We are running a public network
     dummy_genesis_data = plan.run_sh(
-        name="dummy_genesis_data",
+        name="dummy-genesis_data",
         description="Creating network configs folder",
         run="mkdir /network-configs",
         store=[StoreSpec(src="/network-configs/", name="el_cl_genesis_data")],

--- a/src/network_launcher/public_network.star
+++ b/src/network_launcher/public_network.star
@@ -8,7 +8,7 @@ constants = import_module("../package_io/constants.star")
 def launch(plan, network, prague_time):
     # We are running a public network
     dummy_genesis_data = plan.run_sh(
-        name="dummy-genesis_data",
+        name="dummy-genesis-data",
         description="Creating network configs folder",
         run="mkdir /network-configs",
         store=[StoreSpec(src="/network-configs/", name="el_cl_genesis_data")],

--- a/src/network_launcher/shadowfork.star
+++ b/src/network_launcher/shadowfork.star
@@ -15,7 +15,7 @@ def shadowfork_prep(
     # overload the network name to remove the shadowfork suffix
     if constants.NETWORK_NAME.ephemery in base_network:
         chain_id = plan.run_sh(
-            name="fetch_chain_id",
+            name="fetch-chain-id",
             description="Fetching the chain id",
             run="curl -s https://ephemery.dev/latest/config.yaml | yq .DEPOSIT_CHAIN_ID | tr -d '\n'",
             image="linuxserver/yq",
@@ -26,7 +26,7 @@ def shadowfork_prep(
             base_network
         ]  # overload the network id to match the network name
     latest_block = plan.run_sh(
-        name="fetch_latest_block",
+        name="fetch-latest-block",
         description="Fetching the latest block",
         run="mkdir -p /shadowfork && \
             curl -o /shadowfork/latest_block.json "

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1149,7 +1149,7 @@ def deep_copy_participant(participant):
 
 def get_public_ip(plan):
     response = plan.run_sh(
-        name="get_public_ip",
+        name="get-public-ip",
         description="Get the public IP address of the current machine",
         run="curl -s https://ident.me",
     )

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -47,7 +47,7 @@ def generate_el_cl_genesis_data(
     files[GENESIS_VALUES_PATH] = genesis_generation_config_artifact_name
 
     genesis = plan.run_sh(
-        name="run_generate_genesis",
+        name="run-generate-genesis",
         description="Creating genesis",
         run="cp /opt/values.env /config/values.env && ./entrypoint.sh all && mkdir /network-configs && mv /data/metadata/* /network-configs/",
         image=image,
@@ -63,7 +63,7 @@ def generate_el_cl_genesis_data(
     )
 
     genesis_validators_root = plan.run_sh(
-        name="read_genesis_validators_root",
+        name="read-genesis-validators-root",
         description="Reading genesis validators root",
         run="cat /data/genesis_validators_root.txt",
         files={"/data": genesis.files_artifacts[1]},
@@ -71,7 +71,7 @@ def generate_el_cl_genesis_data(
     )
 
     prague_time = plan.run_sh(
-        name="read_prague_time",
+        name="read-prague-time",
         description="Reading prague time from genesis",
         run="jq .config.pragueTime /data/genesis.json | tr -d '\n'",
         image="badouralix/curl-jq",


### PR DESCRIPTION
Fixing: 

```
Reading genesis validators root
There was an error executing Starlark code 
An error occurred executing instruction (number 20) at github.com/ethpandaops/ethereum-package/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star[65:42]:
  run_sh(name="read_genesis_validators_root", run="cat /data/genesis_validators_root.txt", files={"/data": "genesis_validators_root"}, wait=None, description="Reading genesis validators root")
  Caused by: error occurred while creating a run_sh task with image: badouralix/curl-jq
  Caused by: Failed registering service with name: 'read_genesis_validators_root'
  Caused by: Error registering service 'read_genesis_validators_root'
  Caused by: An error occurred getting attributes for the Kubernetes service for user service 'read_genesis_validators_root'
  Caused by: Failed to get name for user service service.
  Caused by: An error occurred creating Kubernetes object name from string 'read_genesis_validators_root'
  Caused by: Object name string 'read_genesis_validators_root' doesn't pass validation of being a Kubernetes object name
  Caused by: Expected object name string 'read_genesis_validators_root' to be a valid DNS_LABEL, instead it failed validation:
  a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')

Error encountered running Starlark code.
```

Only happens when you run k8s backend. 