### PR TITLE
chore: update vc matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ snooper_enabled: true
 | Prysm BN      | ✅            | ✅       | ✅      | ✅          | ✅
 | Teku BN       | ✅            | ✅       | ✅      | ✅          | ✅
 | Lodestar BN   | ✅            | ✅       | ✅      | ✅          | ✅
-| Nimbus BN     | ✅            | ❌       | ✅      | ❌          | ✅
+| Nimbus BN     | ✅            | ✅       | ✅      | ✅          | ✅
 | Grandine BN   | ✅            | ✅       | ✅      | ✅          | ✅
 
 ## Custom labels for Docker and Kubernetes


### PR DESCRIPTION
Nimbus BN is working with Lodestar VC and Prysm vc as of `ethpandaops/nimbus-eth2:unstable-85c2850`