### PR TITLE
fix: correctly apply extra params if builder is enabled

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1054,33 +1054,38 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
         )
 
         if participant["cl_type"] == "lighthouse":
-            participant["vc_extra_params"].append("--builder-proposals")
             participant["cl_extra_params"].append("--builder={0}".format(mev_url))
+        if participant["vc_type"] == "lighthouse":
+            participant["vc_extra_params"].append("--builder-proposals")
         if participant["cl_type"] == "lodestar":
-            participant["vc_extra_params"].append("--builder")
             participant["cl_extra_params"].append("--builder")
             participant["cl_extra_params"].append("--builder.urls={0}".format(mev_url))
+        if participant["vc_type"] == "lodestar":
+            participant["vc_extra_params"].append("--builder")
         if participant["cl_type"] == "nimbus":
-            participant["vc_extra_params"].append("--payload-builder=true")
             participant["cl_extra_params"].append("--payload-builder=true")
             participant["cl_extra_params"].append(
                 "--payload-builder-url={0}".format(mev_url)
             )
+        if participant["vc_type"] == "nimbus":
+            participant["vc_extra_params"].append("--payload-builder=true")
         if participant["cl_type"] == "teku":
-            participant["vc_extra_params"].append(
-                "--validators-builder-registration-default-enabled=true"
-            )
             participant["cl_extra_params"].append(
                 "--builder-endpoint={0}".format(mev_url)
             )
             participant["cl_extra_params"].append(
                 "--validators-builder-registration-default-enabled=true"
             )
+        if participant["vc_type"] == "teku":
+            participant["vc_extra_params"].append(
+                "--validators-builder-registration-default-enabled=true"
+            )
         if participant["cl_type"] == "prysm":
-            participant["vc_extra_params"].append("--enable-builder")
             participant["cl_extra_params"].append(
                 "--http-mev-relay={0}".format(mev_url)
             )
+        if participant["vc_type"] == "prysm":
+            participant["vc_extra_params"].append("--enable-builder")
         if participant["cl_type"] == "grandine":
             participant["cl_extra_params"].append("--builder-url={0}".format(mev_url))
 


### PR DESCRIPTION
I noticed it is not possible to run mixed vc<>bn clients if builder / mev is enabled as it applies extra flags from other clients in `vc_extra_params` as the params are applied based on `cl_type` but it should be done based on `vc_type`.

I tested this using the [following config](https://gist.github.com/nflaig/949c8b5101127961023d89de9c206b04) with both `mev_type: mock` and `mev_type: flashbots`.