### PR TITLE
feat: lodestar persists invalid ssz objects by default

### DIFF
--- a/src/cl/lodestar/lodestar_launcher.star
+++ b/src/cl/lodestar/lodestar_launcher.star
@@ -269,6 +269,7 @@ def get_beacon_config(
         "--port={0}".format(discovery_port),
         "--discoveryPort={0}".format(discovery_port),
         "--dataDir=" + BEACON_DATA_DIRPATH_ON_SERVICE_CONTAINER,
+        "--chain.persistInvalidSszObjects=true",
         "--eth1.depositContractDeployBlock=0",
         "--network.connectToDiscv5Bootnodes=true",
         "--discv5=true",


### PR DESCRIPTION
Would be good to have invalid ssz objects persisted by default in case there is a consensus bug or other issue. There is not much downside to this besides slight storage increase but since states / blocks are generally small on devnets this shouldn't matter, also we prune objects after some time (15 days).