### PR TITLE
fix: disable all assertoor tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,12 +607,12 @@ assertoor_params:
   # - >= 80% correct head votes
   # - no reorgs with distance > 2 blocks
   # - no more than 2 reorgs per epoch
-  run_stability_check: true
+  run_stability_check: false
 
   # Check block propöosals
   # This check monitors the chain and succeeds if:
   # - all client pairs have proposed a block
-  run_block_proposal_check: true
+  run_block_proposal_check: false
 
   # Run normal transaction test
   # This test generates random EOA transactions and checks inclusion with/from all client pairs

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -93,8 +93,8 @@ goomy_blob_params:
   goomy_blob_args: []
 assertoor_params:
   image: ""
-  run_stability_check: true
-  run_block_proposal_check: true
+  run_stability_check: false
+  run_block_proposal_check: false
   run_transaction_test: false
   run_blob_transaction_test: false
   run_opcodes_transaction_test: false

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -969,8 +969,8 @@ def get_default_goomy_blob_params():
 def get_default_assertoor_params():
     return {
         "image": "",
-        "run_stability_check": True,
-        "run_block_proposal_check": True,
+        "run_stability_check": False,
+        "run_block_proposal_check": False,
         "run_lifecycle_test": False,
         "run_transaction_test": False,
         "run_blob_transaction_test": False,


### PR DESCRIPTION
disable all assertoor tests by default to prevent accidentally running tests twice