### PR TITLE
feat: dora - show more infos about all peers on client pages

### DIFF
--- a/static_files/dora-config/config.yaml.tmpl
+++ b/static_files/dora-config/config.yaml.tmpl
@@ -16,6 +16,7 @@ frontend:
   debug: false
   pprof: true
   minimize: false # minimize html templates
+  showSensitivePeerInfos: true
 
   # Name of the site, displayed in the title tag
   siteName: "Dora the Explorer"


### PR DESCRIPTION
This will enable additional peer infos (ENR/Enode, etc.) to be shown on the client pages. Implemented in https://github.com/ethpandaops/dora/pull/117 