### PR TITLE
fix: prysm gRPC removal - use http server instead for keymanager

### DIFF
--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -4,16 +4,6 @@ vc_shared = import_module("./shared.star")
 
 PRYSM_PASSWORD_MOUNT_DIRPATH_ON_SERVICE_CONTAINER = "/prysm-password"
 PRYSM_BEACON_RPC_PORT = 4000
-VALIDATOR_GRPC_PORT_NUM = 7500
-
-
-EXTRA_PORTS = {
-    constants.VALDIATOR_GRPC_PORT_ID: shared_utils.new_port_spec(
-        VALIDATOR_GRPC_PORT_NUM,
-        shared_utils.TCP_PROTOCOL,
-        shared_utils.HTTP_APPLICATION_PROTOCOL,
-    )
-}
 
 
 def get_config(
@@ -67,10 +57,8 @@ def get_config(
 
     keymanager_api_cmd = [
         "--rpc",
-        "--rpc-port={0}".format(vc_shared.VALIDATOR_HTTP_PORT_NUM),
-        "--rpc-host=0.0.0.0",
-        "--grpc-gateway-port={0}".format(VALIDATOR_GRPC_PORT_NUM),
-        "--grpc-gateway-host=0.0.0.0",
+        "--http-port={0}".format(vc_shared.VALIDATOR_HTTP_PORT_NUM),
+        "--http-host=0.0.0.0",
         "--keymanager-token-file=" + constants.KEYMANAGER_MOUNT_PATH_ON_CONTAINER,
     ]
 
@@ -117,7 +105,6 @@ def get_config(
         files[constants.KEYMANAGER_MOUNT_PATH_ON_CLIENTS] = keymanager_file
         cmd.extend(keymanager_api_cmd)
         ports.update(vc_shared.VALIDATOR_KEYMANAGER_USED_PORTS)
-        ports.update(EXTRA_PORTS)
         public_ports.update(
             shared_utils.get_port_specs(public_keymanager_port_assignment)
         )


### PR DESCRIPTION
Related to the deprecation of the gRPC gateway: https://github.com/prysmaticlabs/prysm/pull/14089 

Currently the `mix-with-tools.yaml` test was failing due to the keymanager being enabled: 

```
  == FINISHED SERVICE 'vc-2-nethermind-prysm' LOGS ===================================
  Caused by: An error occurred while waiting for all TCP and UDP ports to be open
  Caused by: Unsuccessful ports check for IP '172.16.0.34' and port spec '{privatePortSpec:0xc00091a0c0}', even after '240' retries with '500' milliseconds in between retries. Timeout '2m0s' has been reached
  Caused by: An error occurred while calling network address '172.16.0.34:5056' with port protocol 'TCP' and using time out '200ms'
  Caused by: dial tcp 172.16.0.34:5056: connect: connection refused

Error encountered running Starlark code.
```
