### PR TITLE
fix: `metrics-host-allowlist` for Teku

### DIFF
--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -295,7 +295,7 @@ def get_beacon_config(
         # vvvvvvvvvvvvvvvvvvv METRICS CONFIG vvvvvvvvvvvvvvvvvvvvv
         "--metrics-enabled",
         "--metrics-interface=0.0.0.0",
-        "--metrics-host-allowlist='*'",
+        "--metrics-host-allowlist=*",
         "--metrics-categories=BEACON,PROCESS,LIBP2P,JVM,NETWORK,PROCESS",
         "--metrics-port={0}".format(BEACON_METRICS_PORT_NUM),
         # ^^^^^^^^^^^^^^^^^^^ METRICS CONFIG ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently `'*'` is passed to Teku, which is not correct, so I see `Not Authorized` when trying to access Teku metrics, Prometheus says that Teku is down because of 403, and Grafana metrics are empty. 
Only `*` should be passed, which is the purpose of the fix.
I don't know how to test it, so not 100% on the fix.