### PR TITLE
docs: update README grafana example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,6 +961,9 @@ participants:
     cl_type: lighthouse
     count: 2
 snooper_enabled: true
+additional_services:
+  - prometheus_grafana
+ethereum_metrics_exporter_enabled: true
 ```
 
 </details>


### PR DESCRIPTION
Think the prometheus_grafana services are off by default, since I had to modify the config this way to get grafana and prometheus to start.