### PR TITLE
fix: add database config to assertoor

### DIFF
--- a/static_files/assertoor-config/config.yaml.tmpl
+++ b/static_files/assertoor-config/config.yaml.tmpl
@@ -23,6 +23,11 @@ web:
   api:
     enabled: true
 
+database:
+  engine: "sqlite"
+  sqlite:
+    file: "/assertoor-database.sqlite"
+
 validatorNames:
   inventoryYaml: "/validator-ranges/validator-ranges.yaml"
 


### PR DESCRIPTION
this adds the database section to the assertoor config.
assertoor falls back to an in memory database if the database section is left out.
however, the in memory database caused issues with dora earlier, so it's better to use a non persistent file.