### PR TITLE
fix: remove deprecated http-allow-sync-stalled from LH

### DIFF
--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -224,7 +224,6 @@ def get_beacon_config(
         "--http",
         "--http-address=0.0.0.0",
         "--http-port={0}".format(BEACON_HTTP_PORT_NUM),
-        "--http-allow-sync-stalled",
         "--slots-per-restore-point={0}".format(32 if constants.ARCHIVE_MODE else 8192),
         # NOTE: This comes from:
         #   https://github.com/sigp/lighthouse/blob/7c88f582d955537f7ffff9b2c879dcf5bf80ce13/scripts/local_testnet/beacon_node.sh


### PR DESCRIPTION
The `--http-allow-sync-stalled` flag is deprecated as of Lighthouse v5.3.0, with its behaviour being enabled by default.

In v6.0.0 we would like to remove the flag entirely, which requires removing it from Kurtosis (which we run on our CI):

- https://github.com/sigp/lighthouse/pull/6490