### PR TITLE
fix: delete unnecessary port assignment for prysm

### DIFF
--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -92,7 +92,6 @@ def get_config(
 
     public_ports = {}
     public_keymanager_port_assignment = {}
-    public_gprc_port_assignment = {}
     if port_publisher.vc_enabled:
         public_ports_for_component = shared_utils.get_public_ports_for_component(
             "vc", port_publisher, vc_index
@@ -102,9 +101,6 @@ def get_config(
         }
         public_keymanager_port_assignment = {
             constants.VALIDATOR_HTTP_PORT_ID: public_ports_for_component[1]
-        }
-        public_gprc_port_assignment = {
-            constants.VALDIATOR_GRPC_PORT_ID: public_ports_for_component[2]
         }
         public_ports = shared_utils.get_port_specs(public_port_assignments)
 
@@ -118,7 +114,6 @@ def get_config(
         public_ports.update(
             shared_utils.get_port_specs(public_keymanager_port_assignment)
         )
-        public_ports.update(shared_utils.get_port_specs(public_gprc_port_assignment))
 
     config_args = {
         "image": image,


### PR DESCRIPTION
## Summary
 
There is an unnecessary port assignment in prysm validator configuration which is fixed with this PR. This was also fixed in the [keymanager fix PR](https://github.com/ethpandaops/ethereum-package/pull/789) but since the `grpc-gateway` flags are deprecated since `v5.1.1`, #789 can be closed after merging.