### PR TITLE
fix: prefund container suffixes for k8s

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/rebelArtists/ethereum-package"
+name: "github.com/ethpandaops/ethereum-package"

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/ethpandaops/ethereum-package"
+name: "github.com/rebelArtists/ethereum-package"

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -9,8 +9,11 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
     plan.print("mnemonic: {0}".format(mnemonic))
     for current_key in range(num_of_keys):
+        private_key_service_name = f"run-ethereal-private-key-{current_key}"
+        eth_address_service_name = f"run-ethereal-eth-address-{current_key}"
+        
         private_key = plan.run_sh(
-            name="run-ethereal-private-key",
+            name=private_key_service_name,
             image=IMAGE,
             description="Running ethereal to derive private keys of key {0}".format(
                 current_key
@@ -20,7 +23,7 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
             ),
         )
         eth_address = plan.run_sh(
-            name="run-ethereal-eth-address",
+            name=eth_address_service_name,
             image=IMAGE,
             description="Running ethereal to derive eth address of key {0}".format(
                 current_key
@@ -29,6 +32,12 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
                 mnemonic, current_key
             ),
         )
+        
+        # Clean up the private key service
+        plan.remove_service(private_key_service_name)
+
+        # Clean up the eth address service
+        plan.remove_service(eth_address_service_name)
 
         PRE_FUNDED_ACCOUNTS.append(
             new_prefunded_account.new_prefunded_account(

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -9,10 +9,8 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
     plan.print("mnemonic: {0}".format(mnemonic))
     for current_key in range(num_of_keys):
-        private_key_service_name = "run-ethereal-private-key-%s" % current_key
-        eth_address_service_name = "run-ethereal-eth-address-%s" % current_key
         private_key = plan.run_sh(
-            name=private_key_service_name,
+            name="run-ethereal-private-key",
             image=IMAGE,
             description="Running ethereal to derive private keys of key {0}".format(
                 current_key
@@ -22,7 +20,7 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
             ),
         )
         eth_address = plan.run_sh(
-            name=eth_address_service_name,
+            name="run-ethereal-eth-address",
             image=IMAGE,
             description="Running ethereal to derive eth address of key {0}".format(
                 current_key
@@ -31,12 +29,6 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
                 mnemonic, current_key
             ),
         )
-        
-        # Clean up the private key service
-        plan.remove_service(private_key_service_name)
-
-        # Clean up the eth address service
-        plan.remove_service(eth_address_service_name)
 
         PRE_FUNDED_ACCOUNTS.append(
             new_prefunded_account.new_prefunded_account(

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -11,11 +11,13 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
     for current_key in range(num_of_keys):
         private_key_service_name = "run-ethereal-private-key-{0}".format(current_key)
         eth_address_service_name = "run-ethereal-eth-address-{0}".format(current_key)
-        
+
         private_key = plan.run_sh(
             name=private_key_service_name,
             image=IMAGE,
-            description="Running ethereal to derive private keys of key {0}".format(current_key),
+            description="Running ethereal to derive private keys of key {0}".format(
+                current_key
+            ),
             run="private_key=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Private key/{{print substr($NF, 3)}}'); echo -n $private_key".format(
                 mnemonic, current_key
             ),
@@ -23,7 +25,9 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
         eth_address = plan.run_sh(
             name=eth_address_service_name,
             image=IMAGE,
-            description="Running ethereal to derive eth address of key {0}".format(current_key),
+            description="Running ethereal to derive eth address of key {0}".format(
+                current_key
+            ),
             run="eth_addr=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Ethereum address/{{print $NF}}'); echo -n $eth_addr".format(
                 mnemonic, current_key
             ),

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -9,8 +9,8 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
     plan.print("mnemonic: {0}".format(mnemonic))
     for current_key in range(num_of_keys):
-        private_key_service_name = f"run-ethereal-private-key-{current_key}"
-        eth_address_service_name = f"run-ethereal-eth-address-{current_key}"
+        private_key_service_name = "run-ethereal-private-key-{0}".format(current_key)
+        eth_address_service_name = "run-ethereal-eth-address-{0}".format(current_key)
         
         private_key = plan.run_sh(
             name=private_key_service_name,

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -9,9 +9,8 @@ def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
     plan.print("mnemonic: {0}".format(mnemonic))
     for current_key in range(num_of_keys):
-        private_key_service_name = "run-ethereal-private-key-{0}".format(current_key)
-        eth_address_service_name = "run-ethereal-eth-address-{0}".format(current_key)
-        
+        private_key_service_name = "run-ethereal-private-key-%s" % current_key
+        eth_address_service_name = "run-ethereal-eth-address-%s" % current_key
         private_key = plan.run_sh(
             name=private_key_service_name,
             image=IMAGE,

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -7,35 +7,38 @@ IMAGE = "wealdtech/ethereal:latest"
 
 def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
-    plan.print("mnemonic: {0}".format(mnemonic))
+    plan.print("mnemonic: %s" % mnemonic)
     for current_key in range(num_of_keys):
+        private_key_service_name = "run-ethereal-private-key-%s" % current_key
+        eth_address_service_name = "run-ethereal-eth-address-%s" % current_key
+        
         private_key = plan.run_sh(
-            name="run-ethereal-private-key",
+            name=private_key_service_name,
             image=IMAGE,
-            description="Running ethereal to derive private keys of key {0}".format(
-                current_key
-            ),
-            run="private_key=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Private key/{{print substr($NF, 3)}}'); echo -n $private_key".format(
+            description="Running ethereal to derive private keys of key %s" % current_key,
+            run="""private_key=$(/app/ethereal hd keys --seed="%s" --path="m/44'/60'/0'/0/%s" | awk '/Private key/{print substr($NF, 3)}'); echo -n $private_key""" % (
                 mnemonic, current_key
             ),
         )
         eth_address = plan.run_sh(
-            name="run-ethereal-eth-address",
+            name=eth_address_service_name,
             image=IMAGE,
-            description="Running ethereal to derive eth address of key {0}".format(
-                current_key
-            ),
-            run="eth_addr=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Ethereum address/{{print $NF}}'); echo -n $eth_addr".format(
+            description="Running ethereal to derive eth address of key %s" % current_key,
+            run="""eth_addr=$(/app/ethereal hd keys --seed="%s" --path="m/44'/60'/0'/0/%s" | awk '/Ethereum address/{print $NF}'); echo -n $eth_addr""" % (
                 mnemonic, current_key
             ),
         )
-
+        
+        # Clean up the private key service
+        plan.remove_service(private_key_service_name)
+    
+        # Clean up the eth address service
+        plan.remove_service(eth_address_service_name)
+    
         PRE_FUNDED_ACCOUNTS.append(
             new_prefunded_account.new_prefunded_account(
                 eth_address.output, private_key.output
             )
         )
-
-    plan.print("PRE_FUNDED_ACCOUNTS: {0}".format(PRE_FUNDED_ACCOUNTS))
-
+    
     return PRE_FUNDED_ACCOUNTS

--- a/src/prefunded_accounts/get_prefunded_accounts.star
+++ b/src/prefunded_accounts/get_prefunded_accounts.star
@@ -7,38 +7,34 @@ IMAGE = "wealdtech/ethereal:latest"
 
 def get_accounts(plan, mnemonic, num_of_keys=21):
     PRE_FUNDED_ACCOUNTS = []
-    plan.print("mnemonic: %s" % mnemonic)
+    plan.print("mnemonic: {0}".format(mnemonic))
     for current_key in range(num_of_keys):
-        private_key_service_name = "run-ethereal-private-key-%s" % current_key
-        eth_address_service_name = "run-ethereal-eth-address-%s" % current_key
+        private_key_service_name = "run-ethereal-private-key-{0}".format(current_key)
+        eth_address_service_name = "run-ethereal-eth-address-{0}".format(current_key)
         
         private_key = plan.run_sh(
             name=private_key_service_name,
             image=IMAGE,
-            description="Running ethereal to derive private keys of key %s" % current_key,
-            run="""private_key=$(/app/ethereal hd keys --seed="%s" --path="m/44'/60'/0'/0/%s" | awk '/Private key/{print substr($NF, 3)}'); echo -n $private_key""" % (
+            description="Running ethereal to derive private keys of key {0}".format(current_key),
+            run="private_key=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Private key/{{print substr($NF, 3)}}'); echo -n $private_key".format(
                 mnemonic, current_key
             ),
         )
         eth_address = plan.run_sh(
             name=eth_address_service_name,
             image=IMAGE,
-            description="Running ethereal to derive eth address of key %s" % current_key,
-            run="""eth_addr=$(/app/ethereal hd keys --seed="%s" --path="m/44'/60'/0'/0/%s" | awk '/Ethereum address/{print $NF}'); echo -n $eth_addr""" % (
+            description="Running ethereal to derive eth address of key {0}".format(current_key),
+            run="eth_addr=$(/app/ethereal hd keys --seed=\"{0}\" --path=\"m/44'/60'/0'/0/{1}\" | awk '/Ethereum address/{{print $NF}}'); echo -n $eth_addr".format(
                 mnemonic, current_key
             ),
         )
-        
-        # Clean up the private key service
-        plan.remove_service(private_key_service_name)
-    
-        # Clean up the eth address service
-        plan.remove_service(eth_address_service_name)
-    
+
         PRE_FUNDED_ACCOUNTS.append(
             new_prefunded_account.new_prefunded_account(
                 eth_address.output, private_key.output
             )
         )
-    
+
+    plan.print("PRE_FUNDED_ACCOUNTS: {0}".format(PRE_FUNDED_ACCOUNTS))
+
     return PRE_FUNDED_ACCOUNTS


### PR DESCRIPTION
**purpose:**
- fix issue when running with k8s backend, where prefunded accts services are not destroyed instantaneously and this causes 'service already exists' errors

**tests:**

original error:
```
Running ethereal to derive private keys of key 1
There was an error executing Starlark code
An error occurred executing instruction (number 9) at github.com/rebelArtists/ethereum-package/src/prefunded_accounts/get_prefunded_accounts.star[12:34]:
  run_sh(name="run-ethereal-private-key", run="private_key=$(/app/ethereal hd keys --seed=\"code code code code code code code code code code code quality\" --path=\"m/44'/60'/0'/0/1\" | awk '/Private key/{print substr($NF, 3)}'); echo -n $private_key", image="wealdtech/ethereal:latest", description="Running ethereal to derive private keys of key 1")
  Caused by: error occurred while creating a run_sh task with image: wealdtech/ethereal:latest
  Caused by: Failed registering service with name: 'run-ethereal-private-key'
  Caused by: Error registering service 'run-ethereal-private-key'
  Caused by: An error occurred creating Kubernetes service in enclave '629c500d8cda49d3b743a3d143d336b7' with ID 'run-ethereal-private-key'
  Caused by: Failed to create service 'run-ethereal-private-key' in namespace 'kt-cdk'
  Caused by: services "run-ethereal-private-key" already exists

Error encountered running Starlark code.
```

with fix (service name has key number suffix to prevent clash):
```
...
Running ethereal to derive eth address of key 19
Command returned with exit code '0' and the following output: 0x6d5821d6D50108649480A63d6f337F8473d661ef

Running ethereal to derive private keys of key 20
Command returned with exit code '0' and the following output: efa8369dbb93b8b452535ab87f526465e9441c7c5809a942908662b925eaff42

Running ethereal to derive eth address of key 20
Command returned with exit code '0' and the following output: 0x31C916e6EAD0DB63BeD514a6f292C526696F0549

Printing a message
PRE_FUNDED_ACCOUNTS: [struct(address = "0xXYZ", private_key = "ABCDEFG"),...]
```