### PR TITLE
fix: get volume size recommendations when in shadowfork mode

### DIFF
--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -264,3 +264,6 @@ VOLUME_SIZE = {
         "grandine_volume_size": 1000,  # 1GB
     },
 }
+VOLUME_SIZE["mainnet-shadowfork"] = VOLUME_SIZE["mainnet"]
+VOLUME_SIZE["sepolia-shadowfork"] = VOLUME_SIZE["sepolia"]
+VOLUME_SIZE["holesky-shadowfork"] = VOLUME_SIZE["holesky"]


### PR DESCRIPTION
config:
```yaml
network_params:
  network: "holesky-shadowfork"
persistent: true
```

fixes

```
There was an error interpreting Starlark code
Evaluation error: key "holesky-shadowfork" not in dict
        at [github.com/ethpandaops/ethereum-package/main.star:143:55]: run
        at [github.com/ethpandaops/ethereum-package/src/participant_network.star:134:48]: launch_participant_network
        at [github.com/ethpandaops/ethereum-package/src/el/el_launcher.star:130:35]: launch
        at [github.com/ethpandaops/ethereum-package/src/el/geth/geth_launcher.star:59:24]: launch
        at [github.com/ethpandaops/ethereum-package/src/el/geth/geth_launcher.star:298:39]: get_config

Error encountered running Starlark code.
```