### PR TITLE
ci: run previous kurtosis version

### DIFF
--- a/.github/actions/kurtosis-install/action.yaml
+++ b/.github/actions/kurtosis-install/action.yaml
@@ -7,12 +7,15 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install kurtosis
+    - name: Install
       shell: bash
-      env:
-        VERSION: ${{ inputs.version }}
       run: |
         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
-        sudo apt install kurtosis-cli=$VERSION
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          sudo apt install kurtosis-cli
+        else
+          sudo apt install kurtosis-cli=${{ inputs.version }}
+        fi
         kurtosis analytics disable
+        echo "$(dirname $(which kurtosis))" >> $GITHUB_PATH

--- a/.github/actions/kurtosis-install/action.yaml
+++ b/.github/actions/kurtosis-install/action.yaml
@@ -1,0 +1,18 @@
+name: Kurtosis install
+inputs:
+  version:
+    description: 'Version to install'
+    required: false
+    default: '1.3.1'
+runs:
+  using: composite
+  steps:
+    - name: Install kurtosis
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt update
+        sudo apt install kurtosis-cli=$VERSION
+        kurtosis analytics disable

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Kurtosis Assertoor GitHub Action
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: "1.3.1"
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           ethereum_package_branch: ""
           ethereum_package_args: .github/tests/mix-assert.yaml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,11 +32,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
+        uses: ./.github/actions/kurtosis-install
 
       - name: Run Starlark
         run: |

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Kurtosis Assertoor GitHub Action
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: "1.3.1"
           ethereum_package_url: "."
           ethereum_package_branch: ""
           ethereum_package_args: .github/tests/mix-assert.yaml

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -19,12 +19,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
-
+        uses: ./.github/actions/kurtosis-install
       - name: Run Starlark
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -53,12 +48,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
-
+        uses: ./.github/actions/kurtosis-install
       - name: Run Starlark
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -70,12 +60,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Kurtosis
-        run: |
-          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-          sudo apt update
-          sudo apt install kurtosis-cli
-          kurtosis analytics disable
-
+        uses: ./.github/actions/kurtosis-install
       - name: Kurtosis Lint
         run: kurtosis lint ${{ github.workspace }}
 

--- a/.github/workflows/run-k8s.yml
+++ b/.github/workflows/run-k8s.yml
@@ -38,6 +38,7 @@ jobs:
         id: testnet
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
+          kurtosis_version: "1.3.1"
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           kurtosis_backend: "kubernetes"
           kubernetes_config: "${{ steps.kubeconfig.outputs.kubeconfig }}"


### PR DESCRIPTION
Rolling back to `1.3.1`, until the docker auth problems on `1.4.0` get fixed https://github.com/kurtosis-tech/kurtosis/pull/2579