### PR TITLE
ci: remove unnecessary docker login

### DIFF
--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -48,7 +48,6 @@ jobs:
         uses: ./.github/actions/kurtosis-install
       - name: Run Starlark
         run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           kurtosis run ${{ github.workspace }} --args-file ${{ matrix.file_name }}
 
   lint:


### PR DESCRIPTION
Causing:

```
Error: Cannot perform an interactive login from a non TTY device
Error: Process completed with exit code 1.
```