### PR TITLE
fix: Update Erigon docker image repo naming

### DIFF
--- a/.github/tests/pectra.yaml.norun
+++ b/.github/tests/pectra.yaml.norun
@@ -7,7 +7,7 @@ participants_matrix:
     - el_type: ethereumjs
       el_image: ethpandaops/ethereumjs:master
     - el_type: erigon
-      el_image: thorax/erigon:docker_pectra
+      el_image: erigontech/erigon:pectra_e2
     - el_type: reth
       el_image: ethpandaops/reth:onbjerg-devnet-2
     - el_type: besu

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ participants:
     # The Docker image that should be used for the EL client; leave blank to use the default for the client type
     # Defaults by client:
     # - geth: ethereum/client-go:latest
-    # - erigon: thorax/erigon:devel
+    # - erigon: ethpandaops/erigon:main
     # - nethermind: nethermind/nethermind:latest
     # - besu: hyperledger/besu:develop
     # - reth: ghcr.io/paradigmxyz/reth


### PR DESCRIPTION
Rename `thorax` -> `erigontech` for docker hub.
Not changing the `ethpandaops/erigon:main` image which appears to be the default, changing the pectra version tho. Latest published erigon images are now multi-arch tho