### PR TITLE
fix: use default image for assertoor with electra enabled

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -121,9 +121,6 @@ def get_config(
 
     IMAGE_NAME = assertoor_params.image
 
-    if network_params.electra_fork_epoch < constants.ELECTRA_FORK_EPOCH:
-        IMAGE_NAME = "ethpandaops/assertoor:electra-support"
-
     return ServiceConfig(
         image=IMAGE_NAME,
         ports=USED_PORTS,


### PR DESCRIPTION
`electra-support` as been merged into master and a new release is available too.