### PR TITLE
fix: bump assertoor memory limit to 8G

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -18,7 +18,7 @@ VALIDATOR_RANGES_ARTIFACT_NAME = "validator-ranges"
 MIN_CPU = 100
 MAX_CPU = 1000
 MIN_MEMORY = 128
-MAX_MEMORY = 2048
+MAX_MEMORY = 8192
 
 USED_PORTS = {
     HTTP_PORT_ID: shared_utils.new_port_spec(


### PR DESCRIPTION
bump the memory limit for assertoor to 8GB

increasing the limit is necessary to run child processes (like the execution spec tests) reliable.
the limit is for the whole container, which not only includes assertoor, but also all sub-processes launched by tests.
