### PR TITLE
fix: use writable path for assertoor db

### DIFF
--- a/static_files/assertoor-config/config.yaml.tmpl
+++ b/static_files/assertoor-config/config.yaml.tmpl
@@ -26,7 +26,7 @@ web:
 database:
   engine: "sqlite"
   sqlite:
-    file: "/assertoor-database.sqlite"
+    file: "/app/assertoor-database.sqlite"
 
 validatorNames:
   inventoryYaml: "/validator-ranges/validator-ranges.yaml"


### PR DESCRIPTION
The root folder `/` is not writable when running as non-root user, so we move the db to the /app folder