### PR TITLE
feat: use `eip7732-support` image for dora when eip7732 is scheduled for activation (ePBS)

### DIFF
--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -125,6 +125,8 @@ def get_config(
     if dora_params.image == constants.DEFAULT_DORA_IMAGE:
         if network_params.fulu_fork_epoch < constants.FULU_FORK_EPOCH:
             IMAGE_NAME = "ethpandaops/dora:fulu-support"
+        if network_params.fulu_fork_epoch < constants.EIP7732_FORK_EPOCH:
+            IMAGE_NAME = "ethpandaops/dora:eip7732-support"
 
     return ServiceConfig(
         image=IMAGE_NAME,

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -125,7 +125,7 @@ def get_config(
     if dora_params.image == constants.DEFAULT_DORA_IMAGE:
         if network_params.fulu_fork_epoch < constants.FULU_FORK_EPOCH:
             IMAGE_NAME = "ethpandaops/dora:fulu-support"
-        if network_params.fulu_fork_epoch < constants.EIP7732_FORK_EPOCH:
+        if network_params.eip7732_fork_epoch < constants.EIP7732_FORK_EPOCH:
             IMAGE_NAME = "ethpandaops/dora:eip7732-support"
 
     return ServiceConfig(


### PR DESCRIPTION
uses the `eip7732-support` branch from dora: https://github.com/ethpandaops/dora/pull/227