### PR TITLE
chore: remove deprecated flag at `prysm_launcher.star`: `enable-debug-rpc-endpoints`

### DIFF
--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -211,7 +211,6 @@ def get_beacon_config(
         "--slots-per-archive-point={0}".format(32 if constants.ARCHIVE_MODE else 8192),
         "--suggested-fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
         "--jwt-secret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
-        "--enable-debug-rpc-endpoints=true",
         # vvvvvvvvv METRICS CONFIG vvvvvvvvvvvvvvvvvvvvv
         "--disable-monitoring=false",
         "--monitoring-host=0.0.0.0",


### PR DESCRIPTION
```
2025-01-29 16:30:41 time="2025-01-29 07:30:41" level=error msg="enable-debug-rpc-endpoints is deprecated and has no effect. Do not use this flag, it will be deleted soon." prefix=flags
```

https://github.com/prysmaticlabs/prysm/pull/14015 deprecates `enable-debug-rpc-endpoints`, and by default prysm enables `debug` endpoints. This PR updates the `prysm_launcher.star` to address this change.