### PR TITLE
chore: update release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-v-in-tag": false,
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "package-name": "ethereum-package"


### PR DESCRIPTION
This should prevent major bump when a breaking change is added. We can still do major releases manually if we want.