### PR TITLE
fix: provide `--network-custom-config-path` to Vero

### DIFF
--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -159,6 +159,7 @@ def launch(
             fail("vero VC doesn't support the Keymanager API")
         config = vero.get_config(
             participant=participant,
+            el_cl_genesis_data=launcher.el_cl_genesis_data,
             image=image,
             global_log_level=global_log_level,
             beacon_http_url=beacon_http_url,

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -14,6 +14,7 @@ VERBOSITY_LEVELS = {
 
 def get_config(
     participant,
+    el_cl_genesis_data,
     image,
     global_log_level,
     beacon_http_url,
@@ -30,6 +31,10 @@ def get_config(
     )
 
     cmd = [
+        "--network=custom",
+        "--network-custom-config-path="
+        + constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER
+        + "/config.yaml",
         "--remote-signer-url={0}".format(remote_signer_context.http_url),
         "--beacon-node-urls=" + beacon_http_url,
         "--fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
@@ -42,6 +47,10 @@ def get_config(
     if len(participant.vc_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark
         cmd.extend([param for param in participant.vc_extra_params])
+
+    files = {
+        constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_genesis_data.files_artifact_uuid,
+    }
 
     public_ports = {}
     if port_publisher.vc_enabled:
@@ -61,6 +70,7 @@ def get_config(
         "ports": ports,
         "public_ports": public_ports,
         "cmd": cmd,
+        "files": files,
         "env_vars": participant.vc_extra_env_vars,
         "labels": shared_utils.label_maker(
             client=constants.VC_TYPE.vero,


### PR DESCRIPTION
As of `v0.9.0` Vero [requires a network to be specified as a CLI argument](https://github.com/serenita-org/vero/releases/tag/v0.9.0). This PR adds that to the Kurtosis definition for the Vero VC service.

(In case you're wondering - how did Vero not have a `--network` flag before? It used to load all the spec values from the connected beacon node(s) and would then dynamically create all necessary SSZ classes.)

I tested this manually with the `.github/tests/vero-all.yaml` config and have been using this version for the last few months while preparing for Pectra.