### PR TITLE
chore(ci): update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -24,7 +24,7 @@ runs:
 
     - name: Login to Docker Hub
       if: env.AUTH_EXISTS == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}

--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Check for typos
         uses: crate-ci/typos@11ca4583f2f3f74c7e7785c0ecb20fe2c99a4308 # v1.29.5

--- a/.github/workflows/conventional-pr-title-checker.yml
+++ b/.github/workflows/conventional-pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
   title_check:
     runs-on: self-hosted-ghr-size-s-x64
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: set-matrix
         # List all yaml files in the .github/tests directory, except for the k8s.yaml file
         run: echo "matrix=$(ls ./.github/tests/*.yaml | grep -vE 'k8s.yaml$' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -25,7 +25,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/docker-login
         with:
           username: ethpandaops
@@ -54,7 +54,7 @@ jobs:
 
       - name: Notify
         if: (cancelled() || failure()) && env.discord_webhook_set == 'true'
-        uses: nobrayner/discord-webhook@v1
+        uses: nobrayner/discord-webhook@2f38abc8877c7e8d2b0ded0cfd9599632014279f # v1
         with:
           description: "The nightly test for ${{matrix.file_name}} on ethereum-package has failed find it here ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           github-token: ${{ secrets.github_token }}
@@ -64,13 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/docker-login
         with:
           username: ethpandaops
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Kurtosis Assertoor GitHub Action
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
         with:
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           ethereum_package_branch: ""

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/docker-login
         with:
           username: ethpandaops
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/docker-login
         with:
           username: ethpandaops
@@ -54,7 +54,7 @@ jobs:
     runs-on: self-hosted-ghr-size-s-x64
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Kurtosis
         uses: ./.github/actions/kurtosis-install
       - name: Kurtosis Lint
@@ -65,13 +65,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/docker-login
         with:
           username: ethpandaops
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Kurtosis Assertoor GitHub Action
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
         with:
           ethereum_package_url: "."
           ethereum_package_branch: ""
@@ -80,7 +80,7 @@ jobs:
   #  runs-on: ubuntu-latest
   #  steps:
   #    - name: Checkout Repository
-  #      uses: actions/checkout@v4
+  #      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   #    - name: Setup Kurtosis
   #      uses: ./.github/actions/kurtosis-install
   #    - name: Run L1

--- a/.github/workflows/run-k8s.yml
+++ b/.github/workflows/run-k8s.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup minikube
         id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@cea33675329b799adccc9526aa5daccc26cd5052 # latest
 
       - name: Get kubeconfig
         id: kubeconfig
@@ -36,7 +36,7 @@ jobs:
       # run kurtosis test and assertoor
       - name: Run kurtosis testnet
         id: testnet
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
         with:
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           kurtosis_backend: "kubernetes"
@@ -62,7 +62,7 @@ jobs:
 
       - name: Notify
         if: (cancelled() || failure()) && env.discord_webhook_set == 'true'
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@08d9328877d6954120eef2b07abbc79249bb6210 # master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.