### PR TITLE
fix: prometheus shouldnt use latest

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1169,7 +1169,7 @@ def get_default_prometheus_params():
         "max_cpu": 1000,
         "min_mem": 128,
         "max_mem": 2048,
-        "image": "prom/prometheus:latest",
+        "image": "prom/prometheus:3.2.1",
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1169,7 +1169,7 @@ def get_default_prometheus_params():
         "max_cpu": 1000,
         "min_mem": 128,
         "max_mem": 2048,
-        "image": "prom/prometheus:3.2.1",
+        "image": "prom/prometheus:v3.2.1",
     }
 
 


### PR DESCRIPTION
Prometheus for some reason overrides their bugfix releases for older versions of major prom versions with `latest`, breaking everything for everyone else. 