### PR TITLE
fix(ci): make docker rate limits appear correctly

### DIFF
--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -43,4 +43,4 @@ runs:
             TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         fi
         echo "Rate limits:"
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest 2>&1 | grep ratelimit
+        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest 2>&1 | grep -i ratelimit

--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -29,18 +29,16 @@ runs:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
+    - name: Install regctl
+      uses: regclient/actions/regctl-installer@ce5fd131e371ffcdd7508b478cb223b3511a9183
+    - name: regctl login
+      uses: regclient/actions/regctl-login@ce5fd131e371ffcdd7508b478cb223b3511a9183
+      with:
+        registry: docker.io
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
     - name: Check Docker Hub Rate Limits
       shell: bash
-      env:
-        DOCKER_USERNAME: ${{ inputs.username }}
-        DOCKER_PASSWORD: ${{ inputs.password }}
       run: |
-        if [ "$AUTH_EXISTS" = "true" ]; then
-            echo "Authenticated."
-            TOKEN=$(curl -s --user "${DOCKER_USERNAME}:${DOCKER_PASSWORD}" "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        else
-            echo "Unauthenticated."
-            TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        fi
-        echo "Rate limits:"
-        curl -s --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest 2>&1 | grep -i ratelimit
+        regctl image ratelimit ubuntu:latest

--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -31,14 +31,7 @@ runs:
 
     - name: Install regctl
       uses: regclient/actions/regctl-installer@ce5fd131e371ffcdd7508b478cb223b3511a9183
-    - name: regctl login
-      uses: regclient/actions/regctl-login@ce5fd131e371ffcdd7508b478cb223b3511a9183
-      with:
-        registry: docker.io
-        username: ${{ inputs.username }}
-        password: ${{ inputs.password }}
 
     - name: Check Docker Hub Rate Limits
       shell: bash
-      run: |
-        regctl image ratelimit ubuntu:latest
+      run: regctl image ratelimit ubuntu:latest


### PR DESCRIPTION
This makes it more obvious if rate limits are in place. Example for an authenticated user:

```
regctl image ratelimit ubuntu:latest
{
  "Remain": 0,
  "Limit": 0,
  "Reset": 0,
  "Set": false,
  "Policies": null
}
```

Or unauthenticated:

```
regctl image ratelimit ubuntu:latest
{
  "Remain": 100,
  "Limit": 100,
  "Reset": 0,
  "Set": true,
  "Policies": [
    "100;w=21600"
  ]
}
```