### PR TITLE
docs: fixed broken links in `docs/architecture.md`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ Once the Ethereum network is up and running, verification logic will be run to e
 [enclave-context]: https://docs.kurtosistech.com/kurtosis/core-lib-documentation#enclavecontext
 [main-function]: https://github.com/ethpandaops/ethereum-package/blob/main/main.star#22
 [package-io]: https://github.com/ethpandaops/ethereum-package/tree/main/src/package_io
-[participant-network]: https://github.com/ethpandaops/ethereum-package/tree/main/src/
+[participant-network]: https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network.star
 [ethereum-genesis-generator]: https://github.com/ethpandaops/ethereum-genesis-generator
 [static-files]: https://github.com/ethpandaops/ethereum-package/tree/main/static_files
 [testnet-verifier]: https://github.com/ethpandaops/ethereum-package/tree/main/src/testnet_verifier

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,15 +63,15 @@ Then the validator keys are generated. A tool called [eth2-val-tools](https://gi
 
 ### Starting EL clients
 
-Next, we plug the generated genesis data [into EL client "launchers"](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/el) to start a mining network of EL nodes. The launchers come with a `launch` function that consumes EL genesis data and produces information about the running EL client node. Running EL node information is represented by [an `el_context` struct](https://github.com/ethpandaops/ethereum-package/blob/main/src/participant_network/el/el_context.star). Each EL client type has its own launcher (e.g. [Geth](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/el/geth), [Besu](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/el/besu)) because each EL client will require different environment variables and flags to be set when launching the client's container.
+Next, we plug the generated genesis data [into EL client "launchers"](https://github.com/ethpandaops/ethereum-package/tree/main/src/el) to start a mining network of EL nodes. The launchers come with a `launch` function that consumes EL genesis data and produces information about the running EL client node. Running EL node information is represented by [an `el_context` struct](https://github.com/ethpandaops/ethereum-package/blob/main/src/el/el_context.star). Each EL client type has its own launcher (e.g. [Geth](https://github.com/ethpandaops/ethereum-package/tree/main/src/el/geth), [Besu](https://github.com/ethpandaops/ethereum-package/tree/main/src/el/besu)) because each EL client will require different environment variables and flags to be set when launching the client's container.
 
 ### Starting CL clients
 
-Once CL genesis data and keys have been created, the CL client nodes are started via [the CL client launchers](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/cl). Just as with EL clients:
+Once CL genesis data and keys have been created, the CL client nodes are started via [the CL client launchers](https://github.com/ethpandaops/ethereum-package/tree/main/src/cl). Just as with EL clients:
 
 - CL client launchers implement come with a `launch` method
-- One CL client launcher exists per client type (e.g. [Nimbus](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/cl/nimbus), [Lighthouse](https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network/cl/lighthouse))
-- Launched CL node information is tracked in [a `cl_context` struct](https://github.com/ethpandaops/ethereum-package/blob/main/src/participant_network/cl/cl_context.star)
+- One CL client launcher exists per client type (e.g. [Nimbus](https://github.com/ethpandaops/ethereum-package/tree/main/src/cl/nimbus), [Lighthouse](https://github.com/ethpandaops/ethereum-package/tree/main/src/cl/lighthouse))
+- Launched CL node information is tracked in [a `cl_context` struct](https://github.com/ethpandaops/ethereum-package/blob/main/src/cl/cl_context.star)
 
 There are only two major difference between CL client and EL client launchers. First, the `cl_client_launcher.launch` method also consumes an `el_context`, because each CL client is connected in a 1:1 relationship with an EL client. Second, because CL clients have keys, the keystore files are passed in to the `launch` function as well.
 
@@ -93,7 +93,7 @@ Once the Ethereum network is up and running, verification logic will be run to e
 [enclave-context]: https://docs.kurtosistech.com/kurtosis/core-lib-documentation#enclavecontext
 [main-function]: https://github.com/ethpandaops/ethereum-package/blob/main/main.star#22
 [package-io]: https://github.com/ethpandaops/ethereum-package/tree/main/src/package_io
-[participant-network]: https://github.com/ethpandaops/ethereum-package/tree/main/src/participant_network
+[participant-network]: https://github.com/ethpandaops/ethereum-package/tree/main/src/
 [ethereum-genesis-generator]: https://github.com/ethpandaops/ethereum-genesis-generator
 [static-files]: https://github.com/ethpandaops/ethereum-package/tree/main/static_files
 [testnet-verifier]: https://github.com/ethpandaops/ethereum-package/tree/main/src/testnet_verifier


### PR DESCRIPTION
Hi! I fixed broken links in `docs/architecture.md` caused by recent changes in the repo structure.   The `participant_network/` directory was removed, so all links were updated to point directly to the correct paths in `src/`.