### PR TITLE
fix(prefunded-accounts): use pop() on PRE_FUNDED_ACCOUNTS to avoid key reuse

### DIFF
--- a/main.star
+++ b/main.star
@@ -97,6 +97,7 @@ def run(plan, args={}):
         prefunded_accounts = get_prefunded_accounts.get_accounts(
             plan, network_params.preregistered_validator_keys_mnemonic
         )
+    accounts_stack = prefunded_accounts[:]
 
     grafana_datasource_config_template = read_file(
         static_files.GRAFANA_DATASOURCE_CONFIG_TEMPLATE_FILEPATH
@@ -302,7 +303,8 @@ def run(plan, args={}):
 
         first_cl_client = all_cl_contexts[0]
         first_client_beacon_name = first_cl_client.beacon_service_name
-        contract_owner, normal_user = prefunded_accounts[6:8]
+        contract_owner = accounts_stack.pop()
+        normal_user    = accounts_stack.pop()
         mev_flood.launch_mev_flood(
             plan,
             mev_params.mev_flood_image,
@@ -652,8 +654,8 @@ def run(plan, args={}):
         elif additional_service == "custom_flood":
             mev_custom_flood.spam_in_background(
                 plan,
-                prefunded_accounts[-1].private_key,
-                prefunded_accounts[0].address,
+                accounts_stack.pop().private_key,
+                accounts_stack.pop().address,
                 fuzz_target,
                 args_with_right_defaults.custom_flood_params,
                 global_node_selectors,
@@ -667,7 +669,7 @@ def run(plan, args={}):
             spamoor.launch_spamoor(
                 plan,
                 spamoor_config_template,
-                prefunded_accounts,
+                accounts_stack,
                 all_participants,
                 args_with_right_defaults.participants,
                 args_with_right_defaults.spamoor_params,


### PR DESCRIPTION
**Suggested Commit Message**  
```
fix(prefunded-accounts): use pop() on PRE_FUNDED_ACCOUNTS to avoid key reuse

Replaces all fixed-index accesses of PRE_FUNDED_ACCOUNTS with a LIFO stack
via `.pop()`, ensuring each service receives a unique key and eliminating
collisions across services. Closes #360.
```  

---

**Pull Request Description**  

####  Goal  
Ensure that no two services ever share the same prefunded account by switching from static-index lookups to a `.pop()`-based allocation from a mutable stack.

####  What Changed  
- **Copied** the original `prefunded_accounts` list into a local `accounts_stack = prefunded_accounts[:]`.  
- **Replaced** every `prefunded_accounts[<n>]` or slice (e.g. `[6:8]`) with `accounts_stack.pop()` calls.  
- Updated MEV flood, custom-flood, and spamoor launcher invocations to pull keys/addresses from the stack.  

####  How to Test  
1. **Dry-run** your changes to validate Starlark syntax:  
   ```bash
   kurtosis run --dry-run . "{}"
   ```  
2. **Launch** the enclave for real:  
   ```bash
   kurtosis run . "{}"
   ```  
3. **Inspect** the enclave to list service IDs:  
   ```bash
   kurtosis enclave inspect <enclave-name>
   ```  
4. **Stream logs** for all services and grep for the key/address printouts:  
   ```bash
   kurtosis service logs -f -x <enclave-name> | grep PRIVATE_KEY
   ```  
   Confirm each service logs a *different* key.  
5. **Verify on-chain balances** for each popped address using your Hardhat balance task or an ethers.js script. All addresses should show the genesis allocation (e.g. 10 ETH) with no duplicates.  
6. **Clean up** once done:  
   ```bash
   kurtosis enclave rm <enclave-name>
   kurtosis clean --all
   ```  

####  Related Issue  
Closes [[#360](https://github.com/ethpandaops/ethereum-package/issues/360)](https://github.com/ethpandaops/ethereum-package/issues/360)  
---