### PR TITLE
feat: add params to configure spamoor resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,13 @@ checkpoint_sync_url: ""
 spamoor_params:
   # The image to use for spamoor
   image: ethpandaops/spamoor:latest
+  # Resource management for spamoor
+  # CPU is milicores
+  # RAM is in MB
+  min_cpu: 10
+  max_cpu: 1000
+  min_mem: 20
+  max_mem: 300
   # A list of spammers to launch on startup
   # example:
   # - scenario: eoatx  # The spamoor scenario to use (see https://github.com/ethpandaops/spamoor)

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -108,6 +108,10 @@ dora_params:
 tx_fuzz_params:
   tx_fuzz_extra_args: []
 spamoor_params:
+  min_cpu: 100
+  max_cpu: 1000
+  min_mem: 20
+  max_mem: 300
   extra_args: []
 prometheus_params:
   storage_tsdb_retention_time: "1d"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -471,6 +471,10 @@ def input_parser(plan, input_args):
         ),
         spamoor_params=struct(
             image=result["spamoor_params"]["image"],
+            min_cpu=result["spamoor_params"]["min_cpu"],
+            max_cpu=result["spamoor_params"]["max_cpu"],
+            min_mem=result["spamoor_params"]["min_mem"],
+            max_mem=result["spamoor_params"]["max_mem"],
             spammers=result["spamoor_params"]["spammers"],
             extra_args=result["spamoor_params"]["extra_args"],
         ),
@@ -1240,6 +1244,10 @@ def get_default_xatu_sentry_params():
 def get_default_spamoor_params():
     return {
         "image": constants.DEFAULT_SPAMOOR_IMAGE,
+        "min_cpu": 100,
+        "max_cpu": 1000,
+        "min_mem": 20,
+        "max_mem": 300,
         "extra_args": [],
         "spammers": [
             # default spammers

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -255,6 +255,10 @@ SUBCATEGORY_PARAMS = {
     ],
     "spamoor_params": [
         "image",
+        "min_cpu",
+        "max_cpu",
+        "min_mem",
+        "max_mem",
         "extra_args",
         "spammers",
     ],

--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -9,12 +9,6 @@ SPAMOOR_CONFIG_FILENAME = "startup-spammers.yaml"
 
 SPAMOOR_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
 
-# The min/max CPU/memory that spamoor can use
-MIN_CPU = 100
-MAX_CPU = 1000
-MIN_MEMORY = 20
-MAX_MEMORY = 300
-
 USED_PORTS = {
     HTTP_PORT_ID: shared_utils.new_port_spec(
         HTTP_PORT_NUMBER,
@@ -153,10 +147,10 @@ def get_config(
         entrypoint=["./spamoor-daemon"],
         cmd=cmd,
         ports=USED_PORTS,
-        min_cpu=MIN_CPU,
-        max_cpu=MAX_CPU,
-        min_memory=MIN_MEMORY,
-        max_memory=MAX_MEMORY,
+        min_cpu=spamoor_params.min_cpu,
+        max_cpu=spamoor_params.max_cpu,
+        min_memory=spamoor_params.min_mem,
+        max_memory=spamoor_params.max_mem,
         node_selectors=node_selectors,
         files={
             SPAMOOR_CONFIG_MOUNT_DIRPATH_ON_SERVICE: config_files_artifact_name,


### PR DESCRIPTION
The CPU limit on spamoor is limiting the number of v1 blob transactions I can send on my machine (possibly because cell proofs are now computed by the transaction sender). The memory limit is a secondary issue due to the higher number of pending transactions.

I chose to parameterize max/min cpu/mem since I'd expect the appropriate max will differ per-host, but let me know if you'd suggest something different!

Tested with the below params:

```
spamoor_params:
  image: ethpandaops/spamoor:latest
  max_cpu: 4000
  max_mem: 3000
  spammers:
    - scenario: blob-combined
      config:
        throughput: 20
        sidecars: 2
        max_pending: 100
        blob_v1_percent: 100
        rebroadcast: 0
    - scenario: blob-combined
      config:
        throughput: 20
        sidecars: 2
        max_pending: 100
        blob_v1_percent: 100
        rebroadcast: 0
```