### PR TITLE
fix: use latest spamoor instead of blob-v1 for peerdas

### DIFF
--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -99,14 +99,6 @@ def get_config(
     node_selectors,
     network_params,
 ):
-    image_name = spamoor_params.image
-    if spamoor_params.image == constants.DEFAULT_SPAMOOR_IMAGE:
-        if (
-            "peerdas" in network_params.network
-            or network_params.fulu_fork_epoch != constants.FAR_FUTURE_EPOCH
-        ):
-            image_name = "ethpandaops/spamoor:blob-v1"
-
     config_file_path = shared_utils.path_join(
         SPAMOOR_CONFIG_MOUNT_DIRPATH_ON_SERVICE,
         SPAMOOR_CONFIG_FILENAME,
@@ -143,7 +135,7 @@ def get_config(
         cmd.append(extra_arg)
 
     return ServiceConfig(
-        image=image_name,
+        image=spamoor_params.image,
         entrypoint=["./spamoor-daemon"],
         cmd=cmd,
         ports=USED_PORTS,


### PR DESCRIPTION
The [`blob-v1`](https://github.com/ethpandaops/spamoor/pull/26) branch has been merged, and the `ethpandaops/spamoor:latest` image has been updated, so I think we can remove the `blob-v1` image now.

Tested with the following params to check that kurtosis pulled `ethpandaops/spamoor:latest` and spamoor sent v0 transactions pre-fulu and v1 transactions post-fulu:

```
network_params:
  electra_fork_epoch: 0
  fulu_fork_epoch: 1
  max_blobs_per_block_fulu: 64
  target_blobs_per_block_fulu: 32
additional_services:
  - dora
  - spamoor
spamoor_params:
  spammers:
    - scenario: blobs
      config:
        throughput: 8
        sidecars: 2
        max_pending: 40
        blob_v1_percent: 100
        rebroadcast: 0
```