### PR TITLE
feat: add disk usage as a metric for ethereum-metrics-exporter

### DIFF
--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -230,6 +230,7 @@ def launch_participant_network(
                 args_with_right_defaults.port_publisher,
                 global_other_index,
                 args_with_right_defaults.docker_cache_params,
+                persistent,
             )
             global_other_index += 1
             plan.print(


### PR DESCRIPTION
If persistence is enabled it will return this: 
```
# TYPE eth_disk_usage_bytes gauge
eth_disk_usage_bytes{directory="/data/consensus-db"} 1.01329017e+08
eth_disk_usage_bytes{directory="/data/execution-db"} 3.865923027e+09
```