### PR TITLE
fix: rbuilder parallel safe sorting

### DIFF
--- a/static_files/mev/flashbots/mev_builder/config.toml.tmpl
+++ b/static_files/mev/flashbots/mev_builder/config.toml.tmpl
@@ -64,3 +64,4 @@ name = "parallel"
 algo = "parallel-builder"
 discard_txs = true
 num_threads = 25
+safe_sorting_only = false


### PR DESCRIPTION
fixing: https://github.com/ethpandaops/ethereum-package/actions/runs/15296185796/job/43025772045#step:5:476