### PR TITLE
feat: add more groups to spamoor clients

### DIFF
--- a/main.star
+++ b/main.star
@@ -710,9 +710,13 @@ def run(plan, args={}):
             spamoor_config_template = read_file(
                 static_files.SPAMOOR_CONFIG_TEMPLATE_FILEPATH
             )
+            spamoor_hosts_template = read_file(
+                static_files.SPAMOOR_HOSTS_TEMPLATE_FILEPATH
+            )
             spamoor.launch_spamoor(
                 plan,
                 spamoor_config_template,
+                spamoor_hosts_template,
                 prefunded_accounts,
                 all_participants,
                 args_with_right_defaults.participants,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1380,9 +1380,9 @@ def get_default_spamoor_params():
     return {
         "image": constants.DEFAULT_SPAMOOR_IMAGE,
         "min_cpu": 100,
-        "max_cpu": 1000,
-        "min_mem": 20,
-        "max_mem": 300,
+        "max_cpu": 2000,
+        "min_mem": 100,
+        "max_mem": 800,
         "extra_args": [],
         "spammers": [
             # default spammers

--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -6,6 +6,7 @@ HTTP_PORT_ID = "http"
 HTTP_PORT_NUMBER = 8080
 
 SPAMOOR_CONFIG_FILENAME = "startup-spammers.yaml"
+SPAMOOR_HOSTS_FILENAME = "rpc-hosts.txt"
 
 SPAMOOR_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
 
@@ -21,6 +22,7 @@ USED_PORTS = {
 def launch_spamoor(
     plan,
     config_template,
+    hosts_template,
     prefunded_addresses,
     participant_contexts,
     participant_configs,
@@ -68,13 +70,25 @@ def launch_spamoor(
                 }
             )
 
-    template_data = new_config_template_data(spammers)
-
-    template_and_data = shared_utils.new_template_and_data(
-        config_template, template_data
-    )
     template_and_data_by_rel_dest_filepath = {}
-    template_and_data_by_rel_dest_filepath[SPAMOOR_CONFIG_FILENAME] = template_and_data
+
+    config_template_data = new_config_template_data(spammers)
+    config_template_and_data = shared_utils.new_template_and_data(
+        config_template, config_template_data
+    )
+    template_and_data_by_rel_dest_filepath[
+        SPAMOOR_CONFIG_FILENAME
+    ] = config_template_and_data
+
+    hosts_template_data = new_hosts_template_data(
+        participant_contexts, participant_configs
+    )
+    hosts_template_and_data = shared_utils.new_template_and_data(
+        hosts_template, hosts_template_data
+    )
+    template_and_data_by_rel_dest_filepath[
+        SPAMOOR_HOSTS_FILENAME
+    ] = hosts_template_and_data
 
     config_files_artifact_name = plan.render_templates(
         template_and_data_by_rel_dest_filepath, "spamoor-config"
@@ -84,8 +98,6 @@ def launch_spamoor(
         plan,
         config_files_artifact_name,
         prefunded_addresses,
-        participant_contexts,
-        participant_configs,
         spamoor_params,
         global_node_selectors,
         network_params,
@@ -99,8 +111,6 @@ def get_config(
     plan,
     config_files_artifact_name,
     prefunded_addresses,
-    participant_contexts,
-    participant_configs,
     spamoor_params,
     node_selectors,
     network_params,
@@ -112,35 +122,14 @@ def get_config(
         SPAMOOR_CONFIG_FILENAME,
     )
 
-    rpchosts = []
-    for index, participant in enumerate(participant_contexts):
-        (
-            full_name,
-            cl_client,
-            el_client,
-            participant_config,
-        ) = shared_utils.get_client_names(
-            participant, index, participant_contexts, participant_configs
-        )
-        if participant.snooper_el_rpc_context:
-            rpchost = "http://{0}:{1}".format(
-                participant.snooper_el_rpc_context.ip_addr,
-                participant.snooper_el_rpc_context.rpc_port_num,
-            )
-        else:
-            rpchost = "http://{0}:{1}".format(
-                el_client.ip_addr,
-                el_client.rpc_port_num,
-            )
-
-        if "builder" in full_name:
-            rpchost = "group(mevbuilder)" + rpchost
-
-        rpchosts.append(rpchost)
+    hosts_file_path = shared_utils.path_join(
+        SPAMOOR_CONFIG_MOUNT_DIRPATH_ON_SERVICE,
+        SPAMOOR_HOSTS_FILENAME,
+    )
 
     cmd = [
         "--privkey={}".format(prefunded_addresses[13].private_key),
-        "--rpchost={}".format(",".join(rpchosts)),
+        "--rpchost-file={}".format(hosts_file_path),
         "--startup-spammer={}".format(config_file_path),
     ]
 
@@ -180,4 +169,51 @@ def new_config_template_data(
 
     return {
         "StartupSpammer": startup_spammer_json,
+    }
+
+
+def new_hosts_template_data(
+    participant_contexts,
+    participant_configs,
+):
+    rpchosts = []
+    for index, participant in enumerate(participant_contexts):
+        (
+            full_name,
+            cl_client,
+            el_client,
+            participant_config,
+        ) = shared_utils.get_client_names(
+            participant, index, participant_contexts, participant_configs
+        )
+        if participant.snooper_el_rpc_context:
+            rpchost = "http://{0}:{1}".format(
+                participant.snooper_el_rpc_context.ip_addr,
+                participant.snooper_el_rpc_context.rpc_port_num,
+            )
+        else:
+            rpchost = "http://{0}:{1}".format(
+                el_client.ip_addr,
+                el_client.rpc_port_num,
+            )
+
+        index_str = shared_utils.zfill_custom(
+            index + 1, len(str(len(participant_contexts)))
+        )
+        rpchost = (
+            "group({0},{1},{2})".format(
+                index_str,
+                cl_client.client_name,
+                el_client.client_name,
+            )
+            + rpchost
+        )
+
+        if "builder" in full_name:
+            rpchost = "group(mevbuilder)" + rpchost
+
+        rpchosts.append(rpchost)
+
+    return {
+        "RPCHosts": rpchosts,
     }

--- a/src/static_files/static_files.star
+++ b/src/static_files/static_files.star
@@ -54,6 +54,9 @@ SPAMOOR_CONFIG_DIRPATH = "/spamoor-config"
 SPAMOOR_CONFIG_TEMPLATE_FILEPATH = (
     STATIC_FILES_DIRPATH + SPAMOOR_CONFIG_DIRPATH + "/startup-spammer.yaml.tmpl"
 )
+SPAMOOR_HOSTS_TEMPLATE_FILEPATH = (
+    STATIC_FILES_DIRPATH + SPAMOOR_CONFIG_DIRPATH + "/rpc-hosts.txt.tmpl"
+)
 
 # xatu-sentry config
 XATU_SENTRY_CONFIG_DIRPATH = "/xatu-sentry-config"

--- a/static_files/spamoor-config/rpc-hosts.txt.tmpl
+++ b/static_files/spamoor-config/rpc-hosts.txt.tmpl
@@ -1,0 +1,4 @@
+# spamoor rpc hosts file
+{{- range $host := .RPCHosts }}
+{{ $host }}
+{{- end }}


### PR DESCRIPTION
this PRC changes the way how rpc hosts are supplied to spamoor.
the hosts file contains additional client groups, including:
* this client index
* the el name
* the cl name

all these groups are applied as separate groups in spamoor, which supports multiple groups per client since the [v1.1.5 release](https://github.com/ethpandaops/spamoor/releases/tag/v1.1.5)