### PR TITLE
fix: shadowfork enclave edits

### DIFF
--- a/src/network_launcher/public_network.star
+++ b/src/network_launcher/public_network.star
@@ -113,7 +113,6 @@ def launch(
                 interval="1s",
                 timeout="6h",  # 6 hours should be enough for the biggest network
             )
-            plan.remove_service(name="snapshot-{0}".format(el_service_name))
 
     # We are running a public network
     dummy_genesis_data = plan.run_sh(

--- a/src/network_launcher/shadowfork.star
+++ b/src/network_launcher/shadowfork.star
@@ -135,5 +135,5 @@ def shadowfork_prep(
             interval="1s",
             timeout="6h",  # 6 hours should be enough for the biggest network
         )
-        plan.remove_service(name="shadowfork-{0}".format(el_service_name))
+        # plan.remove_service(name="shadowfork-{0}".format(el_service_name))
     return latest_block, network_id

--- a/src/network_launcher/shadowfork.star
+++ b/src/network_launcher/shadowfork.star
@@ -135,5 +135,4 @@ def shadowfork_prep(
             interval="1s",
             timeout="6h",  # 6 hours should be enough for the biggest network
         )
-        # plan.remove_service(name="shadowfork-{0}".format(el_service_name))
     return latest_block, network_id


### PR DESCRIPTION
The `remove_service` was preventing enclave edits from working on params that contained shadowforking configs such as:
```
participants:
 - el_extra_params: []
network_params:
   network: hoodi-shadowfork
persistent: true
```
Removing the `remove_service` allows the following edit to skip instructions that haven't changed (pulling shadowfork data, which is very time consuming) while still updating instructions that do change, like updating service config of el node to have the extra cmd arg flag:

```
participants:
 - el_extra_params: ["--miner.gaslimit=78000000"]
network_params:
   network: hoodi-shadowfork
persistent: true
```

![image](https://github.com/user-attachments/assets/ebd7aa83-4e75-4d2d-bc36-12036cef317f)

This is in the Kurtosis docs but it's pretty hidden:
```
It's good to callout here that a few Kurtosis instructions are fundamentally incompatible with the concept of idempotency. The use of one of those instructions in the package will make the plans not resolvable, and Kurtosis will default to the "naive" execution strategy of running the submitted plan on top of the current plan, without even trying the overlap them. Those instructions currently are:

remove_service
start_service
stop_service
```
https://docs.kurtosis.com/advanced-concepts/how-do-enclave-edits-work/

TODO: add a callout in Kurtosis CLI to inform users enclave edits won't work with `remove_service` so they don't have to read the docs