### PR TITLE
fix: use reth-rbuilder image as the default mev_builder_image in network_params.yaml

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -164,10 +164,10 @@ ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
 persistent: false
-mev_type: null
+mev_type: "flashbots"
 mev_params:
   mev_relay_image: ethpandaops/mev-boost-relay:main
-  mev_builder_image: ethpandaops/flashbots-builder:main
+  mev_builder_image: ethpandaops/reth-rbuilder:develop
   mev_builder_cl_image: sigp/lighthouse:latest
   mev_boost_image: ethpandaops/mev-boost:develop
   mev_boost_args: ["mev-boost", "--relay-check"]

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -164,7 +164,7 @@ ethereum_metrics_exporter_enabled: false
 parallel_keystore_generation: false
 disable_peer_scoring: false
 persistent: false
-mev_type: "flashbots"
+mev_type: null
 mev_params:
   mev_relay_image: ethpandaops/mev-boost-relay:main
   mev_builder_image: ethpandaops/reth-rbuilder:develop


### PR DESCRIPTION
When I run the following command:
`kurtosis run --enclave my-testnet github.com/ethpandaops/ethereum-package  --args-file ./network_params.yaml` with only the mev_type set as "flashbots", the enclave creation fails with the following error:
```
........
  == SERVICE 'el-3-reth-builder-lighthouse' LOGS ===================================
  invalid command: "node"
........
```
This is because the default value for the `mev_builder_image` is `ethpandaops/flashbots-builder:main` which is a geth based builder. But the builder is being launched with the configurations of that of a reth builder. The default in the [README](https://github.com/ethpandaops/ethereum-package/blob/main/README.md) is ethpandaops/reth-rbuilder:develop.

This PR just switches the mev_builder_image from ethpandaops/flashbots-builder:main -> ethpandaops/reth-rbuilder:develop