### PR TITLE
Add global-tolerations for blockscout and tx-fuzz services

### DIFF
--- a/main.star
+++ b/main.star
@@ -481,6 +481,7 @@ def run(plan, args={}):
                 all_el_contexts,
                 persistent,
                 global_node_selectors,
+                global_tolerations,
                 args_with_right_defaults.port_publisher,
                 index,
                 args_with_right_defaults.docker_cache_params,

--- a/main.star
+++ b/main.star
@@ -457,6 +457,8 @@ def run(plan, args={}):
                 fuzz_target,
                 tx_fuzz_params,
                 global_node_selectors,
+                global_tolerations,
+
             )
             plan.print("Successfully launched tx-fuzz")
         elif additional_service == "forkmon":

--- a/src/blockscout/blockscout_launcher.star
+++ b/src/blockscout/blockscout_launcher.star
@@ -49,6 +49,7 @@ def launch_blockscout(
     el_contexts,
     persistent,
     global_node_selectors,
+    global_tolerations,
     port_publisher,
     additional_service_index,
     docker_cache_params,
@@ -62,6 +63,7 @@ def launch_blockscout(
         extra_configs=["max_connections=1000"],
         persistent=persistent,
         node_selectors=global_node_selectors,
+        tolerations=global_tolerations,
         image=shared_utils.docker_cache_image_calc(docker_cache_params, POSTGRES_IMAGE),
     )
 
@@ -73,6 +75,7 @@ def launch_blockscout(
 
     config_verif = get_config_verif(
         global_node_selectors,
+        global_tolerations,
         port_publisher,
         additional_service_index,
         docker_cache_params,
@@ -90,6 +93,7 @@ def launch_blockscout(
         verif_url,
         el_client_name,
         global_node_selectors,
+        global_tolerations,
         port_publisher,
         additional_service_index,
         docker_cache_params,
@@ -109,6 +113,7 @@ def launch_blockscout(
         blockscout_params,
         network_params,
         global_node_selectors,
+        global_tolerations,
         blockscout_service,
     )
     plan.add_service(SERVICE_NAME_FRONTEND, config_frontend)
@@ -117,6 +122,7 @@ def launch_blockscout(
 
 def get_config_verif(
     node_selectors,
+    tolerations,
     port_publisher,
     additional_service_index,
     docker_cache_params,
@@ -146,6 +152,7 @@ def get_config_verif(
         min_memory=BLOCKSCOUT_VERIF_MIN_MEMORY,
         max_memory=BLOCKSCOUT_VERIF_MAX_MEMORY,
         node_selectors=node_selectors,
+        tolerations=tolerations,
     )
 
 
@@ -155,6 +162,7 @@ def get_config_backend(
     verif_url,
     el_client_name,
     node_selectors,
+    tolerations,
     port_publisher,
     additional_service_index,
     docker_cache_params,
@@ -176,6 +184,7 @@ def get_config_backend(
         1,
     )
 
+    # TODO: kubernetes node toleration not passed in all blockscout related services!
     return ServiceConfig(
         image=shared_utils.docker_cache_image_calc(
             docker_cache_params,
@@ -212,6 +221,7 @@ def get_config_backend(
         min_memory=BLOCKSCOUT_MIN_MEMORY,
         max_memory=BLOCKSCOUT_MAX_MEMORY,
         node_selectors=node_selectors,
+        tolerations=tolerations,
     )
 
 
@@ -222,6 +232,7 @@ def get_config_frontend(
     blockscout_params,
     network_params,
     node_selectors,
+    tolerations,
     blockscout_service,
 ):
     return ServiceConfig(
@@ -260,4 +271,5 @@ def get_config_frontend(
         min_memory=BLOCKSCOUT_MIN_MEMORY,
         max_memory=BLOCKSCOUT_MAX_MEMORY,
         node_selectors=node_selectors,
+        tolerations=tolerations,
     )

--- a/src/tx_fuzz/tx_fuzz.star
+++ b/src/tx_fuzz/tx_fuzz.star
@@ -14,12 +14,14 @@ def launch_tx_fuzz(
     el_uri,
     tx_fuzz_params,
     global_node_selectors,
+    global_tolerations,
 ):
     config = get_config(
         prefunded_addresses,
         el_uri,
         tx_fuzz_params,
         global_node_selectors,
+        global_tolerations,
     )
     plan.add_service(SERVICE_NAME, config)
 
@@ -29,6 +31,7 @@ def get_config(
     el_uri,
     tx_fuzz_params,
     node_selectors,
+    tolerations,
 ):
     cmd = [
         "spam",
@@ -47,4 +50,5 @@ def get_config(
         min_memory=MIN_MEMORY,
         max_memory=MAX_MEMORY,
         node_selectors=node_selectors,
+        tolerations=tolerations,
     )


### PR DESCRIPTION
Passes through the `global_tolerations` to all services of blockscout as well as the tx-fuzz service