### PR TITLE
Fix: use correct port key for blobber validator proxy in launcher

### DIFF
--- a/src/blobber/blobber_launcher.star
+++ b/src/blobber/blobber_launcher.star
@@ -55,7 +55,7 @@ def launch(
     blobber_service = plan.add_service(blobber_service_name, blobber_config)
     return blobber_context.new_blobber_context(
         blobber_service.ip_address,
-        blobber_service.ports[BLOBBER_VALIDATOR_PROXY_PORT_NUM],
+        blobber_service.ports[BLOBBER_VALIDATOR_PROXY_PORT_ID],
     )
 
 


### PR DESCRIPTION
Replaced the numeric port key (BLOBBER_VALIDATOR_PROXY_PORT_NUM) with the string identifier (BLOBBER_VALIDATOR_PROXY_PORT_ID) when accessing the validator proxy port in the blobber service context. This ensures the correct port value is retrieved from the service's ports dictionary, preventing potential runtime errors due to key mismatch.