### PR TITLE
fix: only add --target-peers=0 only when the network is kurtosis

### DIFF
--- a/main.star
+++ b/main.star
@@ -95,7 +95,10 @@ def run(plan, args={}):
             num_participants == 1
             and participant.cl_type == constants.CL_TYPE.lighthouse
         ):
-            if "--target-peers=0" not in participant.cl_extra_params:
+            if (
+                "--target-peers=0" not in participant.cl_extra_params
+                and network_params.network == constants.NETWORK_NAME.kurtosis
+            ):
                 participant.cl_extra_params.append("--target-peers=0")
 
     prefunded_accounts = genesis_constants.PRE_FUNDED_ACCOUNTS


### PR DESCRIPTION
Current logic adds `--target-peers=0` when there is only one client in the kurtosis params. However, this is also applied when we use single client with a running devnet/testnet where nodes can connect to the bootnodes from the network config. 
This PR fixes this by only adding that flag when the network is `kurtosis`. 