### PR TITLE
Fix Geth bootnode setup

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/ethpandaops/ethereum-package"
+name: "github.com/cskiraly/ethereum-package"

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -36,6 +36,7 @@ VERBOSITY_LEVELS = {
 BUILDER_IMAGE_STR = "builder"
 SUAVE_ENABLED_GETH_IMAGE_STR = "suave"
 
+FORCE_BOOTNODE_OVERRIDE = True
 
 def launch(
     plan,
@@ -234,7 +235,10 @@ def get_config(
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network
     ):
-        if len(existing_el_clients) > 0:
+        if (
+            len(existing_el_clients) > 0
+            or FORCE_BOOTNODE_OVERRIDE
+        ):
             cmd.append(
                 "--bootnodes="
                 + ",".join(


### PR DESCRIPTION
override public bootnodes in first node as well

Bootnodes were changes in all but one node. In the node that was
started first, the "--bootnodes" parameter was not used, leaving
public bootnodes in effect. This can create issues in testnets.

This is just a quick workaround. A better solution would be to use separate parameters for
- using or not using the public bootnodes
- adding new bootnodes