### PR TITLE
feat: Extra Files for `*_extra_mounts` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1374,60 +1374,16 @@ extra_files:
       "enable_doppelganger": true,
       "suggested_fee_recipient": "0x1234..."
     }
-  custom_genesis.json: |
-    {
-      "config": {
-        "chainId": 12345
-      }
-    }
-  startup_script.sh: |
-    #!/bin/bash
-    echo "Custom initialization"
-    # Your custom logic here
 
 participants:
   - el_type: geth
     cl_type: lighthouse
     
-    # Mount files into the execution layer client
-    el_extra_mounts:
-      "/genesis": "custom_genesis.json"  # File available at: /genesis/custom_genesis.json
-      "/scripts": "startup_script.sh"    # File available at: /scripts/startup_script.sh
-    
     # Mount files into the consensus layer client  
     cl_extra_mounts:
       "/configs": "validator_config.json" # File available at: /configs/validator_config.json
-    
-    # Mount files into the validator client
-    vc_extra_mounts:
-      "/validator/config": "validator_config.json" # File available at: /validator/config/validator_config.json
 ```
 
-### Accessing Your Files
-
-Once mounted, you can access your files inside the containers:
-
-```bash
-# Example: Access validator config in the VC container
-docker exec -it <vc-container> cat /validator/config/validator_config.json
-
-# Example: Run the startup script in the EL container
-docker exec -it <el-container> bash /scripts/startup_script.sh
-```
-
-### Use Cases
-
-- **Custom Configuration Files**: Mount client-specific configuration files
-- **Modified Genesis Files**: Override genesis parameters for testing
-- **Scripts and Tools**: Add debugging or monitoring scripts
-- **Key Files**: Mount validator keys or JWT secrets (for testing only!)
-- **Network Configs**: Custom bootnodes, static peers, or network topology files
-
-### Restrictions
-
-- **No Package Files**: You cannot mount files from the ethereum-package repository directly
-- **Content Only**: All files must be defined as content strings in `extra_files`
-- **Name References**: Mount values MUST reference keys defined in `extra_files`
 
 ## Beacon Node <> Validator Client compatibility
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ participants:
     el_extra_params: []
 
     # A list of optional extra mount points that will be passed to the EL client container
-    # Key is the path in the container, value is the local path to the file
-    # Example: el_extra_mounts: {"/tmp/custom.yaml": "local_directory/custom.yaml"}
+    # Key is the path in the container, value MUST be a reference to network_params.extra_files
+    # Example: el_extra_mounts: {"/tmp/custom.yaml": "my_config"}  # where "my_config" is defined in network_params.extra_files
     el_extra_mounts: {}
 
     # A list of tolerations that will be passed to the EL client container
@@ -259,8 +259,8 @@ participants:
     cl_extra_params: []
 
     # A list of optional extra mount points that will be passed to the CL client container
-    # Key is the path in the container, value is the local path to the file
-    # Example: cl_extra_mounts: {"/tmp/custom.yaml": "local_directory/custom.yaml"}
+    # Key is the path in the container, value MUST be a reference to network_params.extra_files
+    # Example: cl_extra_mounts: {"/tmp/custom.yaml": "my_config"}  # where "my_config" is defined in network_params.extra_files
     cl_extra_mounts: {}
 
     # A list of tolerations that will be passed to the CL client container
@@ -334,8 +334,8 @@ participants:
     vc_extra_params: []
 
     # A list of optional extra mount points that will be passed to the validator client container
-    # Key is the path in the container, value is the local path to the file
-    # Example: vc_extra_mounts: {"/tmp/custom.yaml": "local_directory/custom.yaml"}
+    # Key is the path in the container, value MUST be a reference to network_params.extra_files
+    # Example: vc_extra_mounts: {"/tmp/custom.yaml": "my_config"}  # where "my_config" is defined in network_params.extra_files
     vc_extra_mounts: {}
 
     # A list of tolerations that will be passed to the validator container
@@ -1335,35 +1335,27 @@ ethereum_metrics_exporter_enabled: true
 
 ## Extra Files and Mounts
 
-### Mounting Files into Containers
-
-Use `el_extra_mounts`, `cl_extra_mounts`, and `vc_extra_mounts` to mount files into containers:
-
-```yaml
-participants:
-  - el_type: geth
-    cl_type: lighthouse
-    el_extra_mounts:
-      "/config/custom.toml": "my_config"  # Reference pre-uploaded file by name
-    cl_extra_mounts:
-      "/data/genesis.json": "genesis_data"  # Reference another pre-uploaded file
-```
-
-### Uploading External Files
-
-Use `network_params.extra_files` to upload files that can be referenced in mounts:
+Use `network_params.extra_files` to define file contents, then mount them using `el_extra_mounts`, `cl_extra_mounts`, and `vc_extra_mounts`:
 
 ```yaml
 network_params:
   extra_files:
-    my_config: "/path/to/config.toml"
-    genesis_data: "/home/user/genesis.json"
+    my_config: |
+      # Custom configuration file content
+      setting1: value1
+      setting2: value2
+    genesis_override: |
+      {"custom": "genesis data"}
 
 participants:
   - el_type: geth
+    cl_type: lighthouse
     el_extra_mounts:
-      "/config/custom.toml": "my_config"  # Reference by name
+      "/config/custom.toml": "my_config"  # References my_config from extra_files
+      "/data/override.json": "genesis_override"  # References genesis_override from extra_files
 ```
+
+**Note:** All extra_mounts MUST reference files defined in `network_params.extra_files`. Direct package file mounting is not supported.
 
 ## Beacon Node <> Validator Client compatibility
 

--- a/README.md
+++ b/README.md
@@ -1333,42 +1333,37 @@ ethereum_metrics_exporter_enabled: true
 
 </details>
 
-## Using Extra Mounts
+## Extra Files and Mounts
 
-The `el_extra_mounts`, `cl_extra_mounts`, and `vc_extra_mounts` parameters allow you to mount additional files or directories into the EL, CL, and VC containers respectively. This is useful for providing custom configuration files, certificates, or other data that your clients need.
+### Mounting Files into Containers
 
-### How it works
-
-The extra mounts feature automatically handles file uploads for you:
-- **Relative paths** within the package (e.g., `static_files/config.toml`) are automatically uploaded as artifacts
-- **Existing artifact names** (e.g., `jwt_file`) are used directly
-- Files are mounted at the specified container paths
-
-### Example: Using Built-in Artifacts
+Use `el_extra_mounts`, `cl_extra_mounts`, and `vc_extra_mounts` to mount files into containers:
 
 ```yaml
 participants:
   - el_type: geth
     cl_type: lighthouse
     el_extra_mounts:
-      "/custom/jwt/path": "jwt_file"  # jwt_file is a built-in artifact
+      "/config/custom.toml": "my_config"  # Reference pre-uploaded file by name
+    cl_extra_mounts:
+      "/data/genesis.json": "genesis_data"  # Reference another pre-uploaded file
 ```
 
-### Example: Mounting Files from local directory
+### Uploading External Files
+
+Use `network_params.extra_files` to upload files that can be referenced in mounts:
 
 ```yaml
+network_params:
+  extra_files:
+    my_config: "/path/to/config.toml"
+    genesis_data: "/home/user/genesis.json"
+
 participants:
   - el_type: geth
-    cl_type: lighthouse
-    cl_extra_mounts:
-      "/lighthouse/custom.yaml": "local_directory/lighthouse/custom.yaml"
+    el_extra_mounts:
+      "/config/custom.toml": "my_config"  # Reference by name
 ```
-
-### Notes
-
-- All file paths must be relative to the package root directory
-- Files outside the package directory cannot be mounted directly
-- The entire directory structure is preserved when mounting directories
 
 ## Beacon Node <> Validator Client compatibility
 

--- a/main.star
+++ b/main.star
@@ -128,7 +128,7 @@ def run(plan, args={}):
     )
 
     # Upload extra files specified in network_params
-    uploaded_files = {}
+    extra_files_artifacts = {}
     if hasattr(network_params, "extra_files") and network_params.extra_files:
         plan.print("Uploading extra files specified in network_params")
         for file_name, file_path in network_params.extra_files.items():
@@ -140,7 +140,7 @@ def run(plan, args={}):
                 src=file_path,
                 name=file_name,
             )
-            uploaded_files[file_name] = uploaded_file
+            extra_files_artifacts[file_name] = uploaded_file
 
     if network_params.perfect_peerdas_enabled:
         plan.print("Uploading peerdas node keys")
@@ -229,7 +229,7 @@ def run(plan, args={}):
         global_node_selectors,
         keymanager_enabled,
         parallel_keystore_generation,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     plan.print(

--- a/main.star
+++ b/main.star
@@ -127,6 +127,21 @@ def run(plan, args={}):
         name="keymanager_file",
     )
 
+    # Upload extra files specified in network_params
+    uploaded_files = {}
+    if hasattr(network_params, "extra_files") and network_params.extra_files:
+        plan.print("Uploading extra files specified in network_params")
+        for file_name, file_path in network_params.extra_files.items():
+            plan.print("  Uploading {0} from {1}".format(file_name, file_path))
+            # Ensure path is relative to package root
+            if not file_path.startswith("./"):
+                file_path = "./" + file_path
+            uploaded_file = plan.upload_files(
+                src=file_path,
+                name=file_name,
+            )
+            uploaded_files[file_name] = uploaded_file
+
     if network_params.perfect_peerdas_enabled:
         plan.print("Uploading peerdas node keys")
         for index, participant in enumerate(args_with_right_defaults.participants[:16]):
@@ -214,6 +229,7 @@ def run(plan, args={}):
         global_node_selectors,
         keymanager_enabled,
         parallel_keystore_generation,
+        uploaded_files,
     )
 
     plan.print(

--- a/main.star
+++ b/main.star
@@ -79,7 +79,7 @@ def run(plan, args={}):
 
     num_participants = len(args_with_right_defaults.participants)
     network_params = args_with_right_defaults.network_params
-    
+
     # Process extra_files - create artifacts from provided content
     extra_files_artifacts = {}
     extra_files = getattr(args_with_right_defaults, "extra_files", {})
@@ -87,15 +87,10 @@ def run(plan, args={}):
         for name, content in extra_files.items():
             # Use render_templates to create a file with the content
             # The file inside the artifact will be named after the extra_files key
-            template_data = {
-                name: struct(
-                    template = content,
-                    data = {}
-                )
-            }
+            template_data = {name: struct(template=content, data={})}
             artifact = plan.render_templates(template_data, name + "_artifact")
             extra_files_artifacts[name] = artifact
-    
+
     mev_params = args_with_right_defaults.mev_params
     parallel_keystore_generation = args_with_right_defaults.parallel_keystore_generation
     persistent = args_with_right_defaults.persistent

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -233,3 +233,14 @@ port_publisher:
   other:
     enabled: false
     public_port_start: 38000
+
+# Define custom file contents to be mounted into containers
+# Files defined here can be referenced in el_extra_mounts, cl_extra_mounts, and vc_extra_mounts
+# Example:
+# extra_files:
+#   my_config.json: |
+#     {"setting": "value"}
+#   my_script.sh: |
+#     #!/bin/bash
+#     echo "Hello"
+extra_files: {}

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -6,6 +6,7 @@ participants:
     el_extra_env_vars: {}
     el_extra_labels: {}
     el_extra_params: []
+    el_extra_mounts: {}
     el_tolerations: []
     el_volume_size: 0
     el_min_cpu: 0

--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -32,6 +32,7 @@ def launch(
     prysm_password_relative_filepath,
     prysm_password_artifact_uuid,
     global_other_index,
+    uploaded_files = {},
 ):
     plan.print("Launching CL network")
 
@@ -218,6 +219,7 @@ def launch(
                 args_with_right_defaults.port_publisher,
                 index,
                 network_params,
+                uploaded_files,
             )
 
             blobber_config = get_blobber_config(
@@ -265,6 +267,7 @@ def launch(
                 args_with_right_defaults.port_publisher,
                 index,
                 network_params,
+                uploaded_files,
             )
 
             cl_participant_info[cl_service_name] = {

--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -32,7 +32,7 @@ def launch(
     prysm_password_relative_filepath,
     prysm_password_artifact_uuid,
     global_other_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     plan.print("Launching CL network")
 
@@ -219,7 +219,7 @@ def launch(
                 args_with_right_defaults.port_publisher,
                 index,
                 network_params,
-                uploaded_files,
+                extra_files_artifacts,
             )
 
             blobber_config = get_blobber_config(
@@ -267,7 +267,7 @@ def launch(
                 args_with_right_defaults.port_publisher,
                 index,
                 network_params,
-                uploaded_files,
+                extra_files_artifacts,
             )
 
             cl_participant_info[cl_service_name] = {

--- a/src/cl/grandine/grandine_launcher.star
+++ b/src/cl/grandine/grandine_launcher.star
@@ -52,6 +52,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     config = get_beacon_config(
         plan,
@@ -72,6 +73,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, config)
@@ -108,6 +110,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -315,7 +318,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -57,7 +57,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     # Launch Beacon node
     beacon_config = get_beacon_config(
@@ -79,6 +79,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, beacon_config)
@@ -115,7 +116,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -287,7 +288,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts, uploaded_files
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -57,6 +57,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     # Launch Beacon node
     beacon_config = get_beacon_config(
@@ -114,6 +115,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -285,7 +287,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/lodestar/lodestar_launcher.star
+++ b/src/cl/lodestar/lodestar_launcher.star
@@ -44,6 +44,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     # Launch Beacon node
     beacon_config = get_beacon_config(
@@ -65,6 +66,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, beacon_config)
@@ -101,6 +103,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -263,7 +266,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/nimbus/nimbus_launcher.star
+++ b/src/cl/nimbus/nimbus_launcher.star
@@ -65,6 +65,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     beacon_config = get_beacon_config(
         plan,
@@ -85,6 +86,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, beacon_config)
@@ -121,6 +123,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -314,7 +317,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -48,6 +48,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     beacon_config = get_beacon_config(
         plan,
@@ -68,6 +69,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, beacon_config)
@@ -104,6 +106,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -294,7 +297,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -52,6 +52,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     config = get_beacon_config(
         plan,
@@ -72,6 +73,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        extra_files_artifacts,
     )
 
     beacon_service = plan.add_service(beacon_service_name, config)
@@ -108,6 +110,7 @@ def get_beacon_config(
     port_publisher,
     participant_index,
     network_params,
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
@@ -331,7 +334,7 @@ def get_beacon_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.cl_extra_mounts
+        plan, participant.cl_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -43,7 +43,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -61,7 +61,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -88,7 +88,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -230,7 +230,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -43,6 +43,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -60,6 +61,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -86,6 +88,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -227,7 +230,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -30,7 +30,7 @@ def launch(
     port_publisher,
     mev_builder_type,
     mev_params,
-    uploaded_files = {},
+    extra_files_artifacts = {},
 ):
     el_launchers = {
         constants.EL_TYPE.geth: {
@@ -168,7 +168,7 @@ def launch(
                 port_publisher,
                 index,
                 network_params,
-                uploaded_files,
+                extra_files_artifacts,
             )
 
             # Add participant el additional prometheus metrics
@@ -192,7 +192,7 @@ def launch(
                 port_publisher,
                 index,
                 network_params,
-                uploaded_files,
+                extra_files_artifacts,
             )
 
             el_participant_info[el_service_name] = {

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -30,7 +30,7 @@ def launch(
     port_publisher,
     mev_builder_type,
     mev_params,
-    extra_files_artifacts = {},
+    extra_files_artifacts={},
 ):
     el_launchers = {
         constants.EL_TYPE.geth: {

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -30,6 +30,7 @@ def launch(
     port_publisher,
     mev_builder_type,
     mev_params,
+    uploaded_files = {},
 ):
     el_launchers = {
         constants.EL_TYPE.geth: {
@@ -167,6 +168,7 @@ def launch(
                 port_publisher,
                 index,
                 network_params,
+                uploaded_files,
             )
 
             # Add participant el additional prometheus metrics
@@ -190,6 +192,7 @@ def launch(
                 port_publisher,
                 index,
                 network_params,
+                uploaded_files,
             )
 
             el_participant_info[el_service_name] = {

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -41,7 +41,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -59,7 +59,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -86,7 +86,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -202,7 +202,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -41,6 +41,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -58,6 +59,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -84,6 +86,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -199,7 +202,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/ethereumjs/ethereumjs_launcher.star
+++ b/src/el/ethereumjs/ethereumjs_launcher.star
@@ -43,7 +43,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -61,7 +61,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -88,7 +88,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -226,7 +226,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/ethereumjs/ethereumjs_launcher.star
+++ b/src/el/ethereumjs/ethereumjs_launcher.star
@@ -43,6 +43,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -60,6 +61,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -86,6 +88,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -223,7 +226,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -58,7 +58,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -76,7 +76,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -103,7 +103,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     public_ports = {}
     public_ports_for_component = None
@@ -215,7 +215,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -58,6 +58,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -75,6 +76,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -101,6 +103,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     public_ports = {}
     public_ports_for_component = None
@@ -212,7 +215,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -50,6 +50,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -67,6 +68,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -93,6 +95,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -291,7 +294,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -50,7 +50,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -68,7 +68,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -95,7 +95,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -294,7 +294,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -39,7 +39,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -57,7 +57,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -84,7 +84,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -218,7 +218,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -39,6 +39,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -56,6 +57,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -82,6 +84,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -215,7 +218,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -39,6 +39,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -56,6 +57,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -82,6 +84,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -206,7 +209,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -39,7 +39,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -57,7 +57,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -84,7 +84,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -209,7 +209,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -48,6 +48,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -65,6 +66,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
+        uploaded_files,
     )
 
     service = plan.add_service(service_name, config)
@@ -91,6 +93,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -246,7 +249,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts
+        plan, participant.el_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -48,7 +48,7 @@ def launch(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -66,7 +66,7 @@ def launch(
         port_publisher,
         participant_index,
         network_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     service = plan.add_service(service_name, config)
@@ -93,7 +93,7 @@ def get_config(
     port_publisher,
     participant_index,
     network_params,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -249,7 +249,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.el_extra_mounts, uploaded_files
+        plan, participant.el_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1120,6 +1120,7 @@ def default_network_params():
         "withdrawal_address": "0x8943545177806ED17B9F23F0a21ee5948eCaa776",
         "validator_balance": 32,
         "min_epochs_for_data_column_sidecars_requests": 4096,
+        "extra_files": {},
     }
 
 
@@ -1188,6 +1189,7 @@ def default_minimal_network_params():
         "withdrawal_address": "0x8943545177806ED17B9F23F0a21ee5948eCaa776",
         "validator_balance": 32,
         "min_epochs_for_data_column_sidecars_requests": 4096,
+        "extra_files": {},
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -596,6 +596,7 @@ def input_parser(plan, input_args):
         global_tolerations=result["global_tolerations"],
         global_node_selectors=result["global_node_selectors"],
         keymanager_enabled=result["keymanager_enabled"],
+        extra_files=result.get("extra_files", {}),
         checkpoint_sync_enabled=result["checkpoint_sync_enabled"],
         checkpoint_sync_url=result["checkpoint_sync_url"],
         ethereum_genesis_generator_params=struct(
@@ -1029,6 +1030,7 @@ def default_input_args(input_args):
         "participants": participants,
         "participants_matrix": participants_matrix,
         "network_params": network_params,
+        "extra_files": {},
         "wait_for_finalization": False,
         "global_log_level": "info",
         "snooper_enabled": False,
@@ -1120,7 +1122,6 @@ def default_network_params():
         "withdrawal_address": "0x8943545177806ED17B9F23F0a21ee5948eCaa776",
         "validator_balance": 32,
         "min_epochs_for_data_column_sidecars_requests": 4096,
-        "extra_files": {},
     }
 
 
@@ -1189,7 +1190,6 @@ def default_minimal_network_params():
         "withdrawal_address": "0x8943545177806ED17B9F23F0a21ee5948eCaa776",
         "validator_balance": 32,
         "min_epochs_for_data_column_sidecars_requests": 4096,
-        "extra_files": {},
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -250,7 +250,6 @@ SUBCATEGORY_PARAMS = {
         "withdrawal_address",
         "validator_balance",
         "min_epochs_for_data_column_sidecars_requests",
-        "extra_files",
     ],
     "blockscout_params": [
         "image",
@@ -495,6 +494,7 @@ def sanity_check(plan, input_args):
             + ADDITIONAL_CATEGORY_PARAMS.keys()
         )
         combined_root_params.append("additional_services")
+        combined_root_params.append("extra_files")
 
         if param not in combined_root_params:
             fail(

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -250,6 +250,7 @@ SUBCATEGORY_PARAMS = {
         "withdrawal_address",
         "validator_balance",
         "min_epochs_for_data_column_sidecars_requests",
+        "extra_files",
     ],
     "blockscout_params": [
         "image",

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -46,6 +46,7 @@ def launch_participant_network(
     global_node_selectors,
     keymanager_enabled,
     parallel_keystore_generation,
+    uploaded_files = {},
 ):
     network_id = network_params.network_id
     num_participants = len(args_with_right_defaults.participants)
@@ -149,6 +150,7 @@ def launch_participant_network(
         args_with_right_defaults.port_publisher,
         args_with_right_defaults.mev_type,
         args_with_right_defaults.mev_params,
+        uploaded_files,
     )
 
     # Launch all consensus layer clients
@@ -185,6 +187,7 @@ def launch_participant_network(
         prysm_password_relative_filepath,
         prysm_password_artifact_uuid,
         global_other_index,
+        uploaded_files,
     )
 
     # Launch all blobbers after all CLs are up
@@ -476,6 +479,7 @@ def launch_participant_network(
             network_params=network_params,
             port_publisher=args_with_right_defaults.port_publisher,
             vc_index=current_vc_index,
+            uploaded_files=uploaded_files,
         )
         if vc_service_config == None:
             continue

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -46,7 +46,7 @@ def launch_participant_network(
     global_node_selectors,
     keymanager_enabled,
     parallel_keystore_generation,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     network_id = network_params.network_id
     num_participants = len(args_with_right_defaults.participants)
@@ -150,7 +150,7 @@ def launch_participant_network(
         args_with_right_defaults.port_publisher,
         args_with_right_defaults.mev_type,
         args_with_right_defaults.mev_params,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     # Launch all consensus layer clients
@@ -187,7 +187,7 @@ def launch_participant_network(
         prysm_password_relative_filepath,
         prysm_password_artifact_uuid,
         global_other_index,
-        uploaded_files,
+        extra_files_artifacts,
     )
 
     # Launch all blobbers after all CLs are up
@@ -479,7 +479,7 @@ def launch_participant_network(
             network_params=network_params,
             port_publisher=args_with_right_defaults.port_publisher,
             vc_index=current_vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
         if vc_service_config == None:
             continue

--- a/src/shared_utils/shared_utils.star
+++ b/src/shared_utils/shared_utils.star
@@ -419,7 +419,7 @@ def ensure_alphanumeric_bounds(s):
     return s[start:end]
 
 
-def process_extra_mounts(plan, extra_mounts, extra_files_artifacts = {}):
+def process_extra_mounts(plan, extra_mounts, extra_files_artifacts={}):
     """
     Process extra mounts by resolving extra_files references ONLY.
 
@@ -440,11 +440,15 @@ def process_extra_mounts(plan, extra_mounts, extra_files_artifacts = {}):
         if type(source) != "string":
             processed_mounts[mount_path] = source
             continue
-        
+
         # Source MUST be an extra_files reference
         if source not in extra_files_artifacts:
-            fail("Mount source '" + source + "' not found in extra_files. All extra_mounts must reference files defined in extra_files.")
-        
+            fail(
+                "Mount source '"
+                + source
+                + "' not found in extra_files. All extra_mounts must reference files defined in extra_files."
+            )
+
         processed_mounts[mount_path] = extra_files_artifacts[source]
 
     return processed_mounts

--- a/src/shared_utils/shared_utils.star
+++ b/src/shared_utils/shared_utils.star
@@ -426,7 +426,7 @@ def process_extra_mounts(plan, extra_mounts, extra_files_artifacts = {}):
     Args:
         plan: The Kurtosis plan object
         extra_mounts: Dictionary where keys are mount paths and values are extra_file names
-        extra_files_artifacts: Dictionary of extra files artifacts from network_params.extra_files
+        extra_files_artifacts: Dictionary of extra files artifacts from extra_files
 
     Returns:
         Dictionary where keys are mount paths and values are artifact names/objects
@@ -443,7 +443,7 @@ def process_extra_mounts(plan, extra_mounts, extra_files_artifacts = {}):
         
         # Source MUST be an extra_files reference
         if source not in extra_files_artifacts:
-            fail("Mount source '" + source + "' not found in network_params.extra_files. All extra_mounts must reference files defined in network_params.extra_files.")
+            fail("Mount source '" + source + "' not found in extra_files. All extra_mounts must reference files defined in extra_files.")
         
         processed_mounts[mount_path] = extra_files_artifacts[source]
 

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -32,7 +32,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -117,7 +117,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -32,6 +32,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -116,7 +117,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/lodestar.star
+++ b/src/vc/lodestar.star
@@ -31,6 +31,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -126,7 +127,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/lodestar.star
+++ b/src/vc/lodestar.star
@@ -31,7 +31,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -127,7 +127,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/nimbus.star
+++ b/src/vc/nimbus.star
@@ -21,6 +21,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     validator_keys_dirpath = ""
     validator_secrets_dirpath = ""
@@ -103,7 +104,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/nimbus.star
+++ b/src/vc/nimbus.star
@@ -21,7 +21,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     validator_keys_dirpath = ""
     validator_secrets_dirpath = ""
@@ -104,7 +104,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -26,7 +26,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     validator_keys_dirpath = shared_utils.path_join(
         constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
@@ -129,7 +129,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -26,6 +26,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     validator_keys_dirpath = shared_utils.path_join(
         constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
@@ -128,7 +129,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/teku.star
+++ b/src/vc/teku.star
@@ -21,7 +21,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     validator_keys_dirpath = ""
     validator_secrets_dirpath = ""
@@ -122,7 +122,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/teku.star
+++ b/src/vc/teku.star
@@ -21,6 +21,7 @@ def get_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     validator_keys_dirpath = ""
     validator_secrets_dirpath = ""
@@ -121,7 +122,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -36,7 +36,7 @@ def get_vc_config(
     network_params,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     if node_keystore_files == None:
         return None
@@ -76,7 +76,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.lodestar:
         config = lodestar.get_config(
@@ -98,7 +98,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.teku:
         config = teku.get_config(
@@ -119,7 +119,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.nimbus:
         config = nimbus.get_config(
@@ -140,7 +140,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.prysm:
         config = prysm.get_config(
@@ -163,7 +163,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.vero:
         if remote_signer_context == None:
@@ -184,7 +184,7 @@ def get_vc_config(
             node_selectors=node_selectors,
             port_publisher=port_publisher,
             vc_index=vc_index,
-            uploaded_files=uploaded_files,
+            extra_files_artifacts=extra_files_artifacts,
         )
     elif vc_type == constants.VC_TYPE.grandine:
         fail("Grandine VC is not yet supported")

--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -36,6 +36,7 @@ def get_vc_config(
     network_params,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     if node_keystore_files == None:
         return None
@@ -75,6 +76,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.lodestar:
         config = lodestar.get_config(
@@ -96,6 +98,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.teku:
         config = teku.get_config(
@@ -116,6 +119,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.nimbus:
         config = nimbus.get_config(
@@ -136,6 +140,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.prysm:
         config = prysm.get_config(
@@ -158,6 +163,7 @@ def get_vc_config(
             network_params=network_params,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.vero:
         if remote_signer_context == None:
@@ -178,6 +184,7 @@ def get_vc_config(
             node_selectors=node_selectors,
             port_publisher=port_publisher,
             vc_index=vc_index,
+            uploaded_files=uploaded_files,
         )
     elif vc_type == constants.VC_TYPE.grandine:
         fail("Grandine VC is not yet supported")

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -26,6 +26,7 @@ def get_config(
     node_selectors,
     port_publisher,
     vc_index,
+    uploaded_files = {},
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -67,7 +68,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts
+        plan, participant.vc_extra_mounts, uploaded_files
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -26,7 +26,7 @@ def get_config(
     node_selectors,
     port_publisher,
     vc_index,
-    uploaded_files = {},
+    extra_files_artifacts,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -68,7 +68,7 @@ def get_config(
 
     # Add extra mounts - automatically handle file uploads
     processed_mounts = shared_utils.process_extra_mounts(
-        plan, participant.vc_extra_mounts, uploaded_files
+        plan, participant.vc_extra_mounts, extra_files_artifacts
     )
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact


### PR DESCRIPTION
Adds `extra_files` to the config, which provides a solution to the path of `*_extra_mounts` files not working if the path is outside of the package (Kurtosis limitation)

### Example
```
extra_files:
  example.json: |
    {
      "test": "data",
      "foo": "bar"
    }

participants:
  - el_type: geth
    cl_type: lighthouse
    vc_extra_mounts:
      "/configs": "example.json"
```

This will create a file in the vc at `/configs/example.json` with the conte