### PR TITLE
feat: besu: remove sync-mode config logic

### DIFF
--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -151,11 +151,6 @@ def get_config(
         "--engine-jwt-secret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--engine-host-allowlist=*",
         "--engine-rpc-port={0}".format(ENGINE_HTTP_RPC_PORT_NUM),
-        "{0}".format(
-            "--sync-mode=FULL"
-            if network_params.network in constants.NETWORK_NAME.kurtosis
-            else "--sync-mode=SNAP"
-        ),
         "--metrics-enabled=true",
         "--metrics-host=0.0.0.0",
         "--metrics-port={0}".format(METRICS_PORT_NUM),


### PR DESCRIPTION
Removing this setting from here enables us to override sync-mode via kurtosis config, if required for testing.

Also this exact same logic now exists in besu itself - 

default: SNAP if a --network is supplied. FULL otherwise.