### PR TITLE
fix: corrected prysm supernode flag

### DIFF
--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -211,7 +211,7 @@ def get_beacon_config(
     ]
 
     supernode_cmd = [
-        "--subscribe-all-data-subnets=true",
+        "--subscribe-all-subnets=true",
     ]
 
     if network_params.perfect_peerdas_enabled and participant_index < 16:


### PR DESCRIPTION
The previous flag was incorrect, and prevented prysm from starting. The correct flag is `--subscribe-all-subnets`. Source: [prysm flags documentation](https://prysm.offchainlabs.com/docs/configure-prysm/parameters/).