### PR TITLE
feat: add telemetry service name flag to Lighthouse

### DIFF
--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -262,6 +262,7 @@ def get_beacon_config(
     # Add tempo telemetry integration if tempo is enabled
     if tempo_otlp_grpc_url != None:
         cmd.append("--telemetry-collector-url={}".format(tempo_otlp_grpc_url))
+        cmd.append("--telemetry-service-name={}".format(beacon_service_name))
 
     if len(participant.cl_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark


### PR DESCRIPTION
Add service name to traces exported by Lighthouse.

Please do not merge until the new lighthouse flag PR is merged: https://github.com/sigp/lighthouse/pull/7903

<img width="2296" height="1254" alt="image" src="https://github.com/user-attachments/assets/9fb655f2-255b-475c-bf7a-fbd70f74d33d" />


