### PR TITLE
feat: support amsterdam time

### DIFF
--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -316,4 +316,6 @@ def new_erigon_launcher(el_cl_genesis_data, jwt_file, networkid):
         networkid=networkid,
         osaka_time=el_cl_genesis_data.osaka_time,
         osaka_enabled=el_cl_genesis_data.osaka_enabled,
+        amsterdam_time=el_cl_genesis_data.amsterdam_time,
+        amsterdam_enabled=el_cl_genesis_data.amsterdam_enabled,
     )

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -366,4 +366,6 @@ def new_geth_launcher(
         networkid=networkid,
         osaka_time=el_cl_genesis_data.osaka_time,
         osaka_enabled=el_cl_genesis_data.osaka_enabled,
+        amsterdam_time=el_cl_genesis_data.amsterdam_time,
+        amsterdam_enabled=el_cl_genesis_data.amsterdam_enabled,
     )

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_data.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_data.star
@@ -3,10 +3,14 @@ def new_el_cl_genesis_data(
     genesis_validators_root,
     osaka_time=0,
     osaka_enabled=False,
+    amsterdam_time=0,
+    amsterdam_enabled=False,
 ):
     return struct(
         files_artifact_uuid=files_artifact_uuid,
         genesis_validators_root=genesis_validators_root,
         osaka_time=osaka_time,
         osaka_enabled=osaka_enabled,
+        amsterdam_time=amsterdam_time,
+        amsterdam_enabled=amsterdam_enabled,
     )

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -100,11 +100,26 @@ def generate_el_cl_genesis_data(
         tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
         node_selectors=global_node_selectors,
     )
-
     osaka_enabled_check = plan.run_sh(
         name="check-osaka-enabled",
         description="Check if osaka time is enabled (not false)",
         run="test \"$(jq '.config.osakaTime // false' /data/genesis.json | tr -d '\n')\" != \"false\" && echo true || echo false",
+        files={"/data": genesis.files_artifacts[0]},
+        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
+        node_selectors=global_node_selectors,
+    )
+    amsterdam_time = plan.run_sh(
+        name="read-amsterdam-time",
+        description="Reading amsterdam time from genesis",
+        run="jq '.config.amsterdamTime' /data/genesis.json | tr -d '\n'",
+        files={"/data": genesis.files_artifacts[0]},
+        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
+        node_selectors=global_node_selectors,
+    )
+    amsterdam_enabled_check = plan.run_sh(
+        name="check-amsterdam-enabled",
+        description="Check if amsterdam time is enabled (not false)",
+        run="test \"$(jq '.config.amsterdamTime // false' /data/genesis.json | tr -d '\n')\" != \"false\" && echo true || echo false",
         files={"/data": genesis.files_artifacts[0]},
         tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
         node_selectors=global_node_selectors,
@@ -115,6 +130,8 @@ def generate_el_cl_genesis_data(
         genesis_validators_root.output,
         osaka_time.output,
         osaka_enabled_check.output == "true",
+        amsterdam_time.output,
+        amsterdam_enabled_check.output == "true",
     )
 
     return result


### PR DESCRIPTION
This PR supports Amsterdam time. Features for Glamsterdam such as [BALs](https://github.com/ethereum/go-ethereum/pull/32263) could use this.