### PR TITLE
fix: set deploy_client_group for mev related uniswap spammer

### DIFF
--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -70,6 +70,7 @@ def launch_spamoor(
                         "max_pending": 200,
                         "max_wallets": 200,
                         "client_group": "mevbuilder",
+                        "deploy_client_group": "default",
                     },
                 }
             )


### PR DESCRIPTION
set default client group for deployments to avoid getting stuck
rel. https://github.com/ethpandaops/spamoor/pull/136