### PR TITLE
fix: failed to start network: ethereum-package execution error: Evaluation error: key osaka_time not in dict

### DIFF
--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -603,5 +603,5 @@ def launch_participant_network(
         el_cl_data.genesis_validators_root,
         el_cl_data.files_artifact_uuid,
         network_id,
-        el_cl_data.shadowfork_times["osaka_time"],
+        el_cl_data.shadowfork_times.get("osaka_time", ""),
     )


### PR DESCRIPTION
The code was trying to access osaka_time using dictionary bracket notation ["osaka_time"], which fails if the key doesn't exist. I changed it to use .get("osaka_time", "") which returns an empty string if the key is not present, preventing the error.