### PR TITLE
feat: allow passing custom env vars to the genesis generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,8 @@ spamoor_params:
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
   image: ethpandaops/ethereum-genesis-generator:5.1.0
+  # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
+  extra_env: {}
 
 # Configuration for public ports and NAT exit IP addresses
 port_publisher:

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -227,6 +227,7 @@ checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
   image: ethpandaops/ethereum-genesis-generator:5.1.0
+  extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER
   el:

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -685,6 +685,7 @@ def input_parser(plan, input_args):
         checkpoint_sync_url=result["checkpoint_sync_url"],
         ethereum_genesis_generator_params=struct(
             image=result["ethereum_genesis_generator_params"]["image"],
+            extra_env=result["ethereum_genesis_generator_params"]["extra_env"],
         ),
         port_publisher=struct(
             nat_exit_ip=result["port_publisher"]["nat_exit_ip"],
@@ -1950,6 +1951,7 @@ def docker_cache_image_override(plan, result):
 def get_default_ethereum_genesis_generator_params():
     return {
         "image": constants.DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE,
+        "extra_env": {},
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -363,6 +363,7 @@ SUBCATEGORY_PARAMS = {
     ],
     "ethereum_genesis_generator_params": [
         "image",
+        "extra_env",
     ],
 }
 

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -91,6 +91,7 @@ def launch_participant_network(
         el_cl_data = el_cl_genesis_data_generator.generate_el_cl_genesis_data(
             plan,
             ethereum_genesis_generator_image,
+            args_with_right_defaults.ethereum_genesis_generator_params,
             el_cl_genesis_config_template,
             el_cl_genesis_additional_contracts_template,
             final_genesis_timestamp,

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -14,6 +14,7 @@ SHADOWFORK_FILEPATH = "/shadowfork"
 def generate_el_cl_genesis_data(
     plan,
     image,
+    genesis_generator_params,
     genesis_generation_config_yml_template,
     genesis_additional_contracts_yml_template,
     genesis_unix_timestamp,
@@ -35,6 +36,7 @@ def generate_el_cl_genesis_data(
         total_num_validator_keys_to_preregister,
         shadowfork_file,
         network_params,
+        genesis_generator_params.extra_env,
     )
     genesis_generation_template = shared_utils.new_template_and_data(
         genesis_generation_config_yml_template, template_data
@@ -157,7 +159,12 @@ def new_env_file_for_el_cl_genesis_data(
     total_num_validator_keys_to_preregister,
     shadowfork_file,
     network_params,
+    extra_env,
 ):
+    extra_env_safe = {}
+    for k, v in extra_env.items():
+        extra_env_safe[k] = json.encode(v)
+
     return {
         "UnixTimestamp": genesis_unix_timestamp,
         "NetworkId": constants.NETWORK_ID[network_params.network.split("-")[0]]
@@ -243,6 +250,7 @@ def new_env_file_for_el_cl_genesis_data(
         "ValidatorBalance": int(network_params.validator_balance * 1000000000),
         "MinEpochsForDataColumnSidecarsRequests": network_params.min_epochs_for_data_column_sidecars_requests,
         "MinEpochsForBlockRequests": network_params.min_epochs_for_block_requests,
+        "ExtraEnvVars": extra_env_safe,
     }
 
 

--- a/static_files/genesis-generation-config/el-cl/values.env.tmpl
+++ b/static_files/genesis-generation-config/el-cl/values.env.tmpl
@@ -80,3 +80,6 @@ export BPO_5_TARGET_BLOBS={{ .Bpo5TargetBlobs }}
 export BPO_5_BASE_FEE_UPDATE_FRACTION={{ .Bpo5BaseFeeUpdateFraction }}
 export MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS={{ .MinEpochsForDataColumnSidecarsRequests }}
 export MIN_EPOCHS_FOR_BLOCK_REQUESTS={{ .MinEpochsForBlockRequests }}
+{{ range $key, $value := .ExtraEnvVars }}
+export {{ $key }}={{ $value }}
+{{ end }}


### PR DESCRIPTION
this PR adds a new setting to the config that allows passing arbitrary custom env vars to the genesis generator:
```yaml
ethereum_genesis_generator_params:
  extra_env:
    CUSTOM_ENV_VAR: "value"
```