### PR TITLE
fix: mev rbuilder remove unused config param

### DIFF
--- a/static_files/mev/flashbots/mev_builder/config.toml.tmpl
+++ b/static_files/mev/flashbots/mev_builder/config.toml.tmpl
@@ -10,7 +10,6 @@ reth_datadir = "{{ .DataDir }}"
 
 coinbase_secret_key = "{{ .SecretKey }}"
 relay_secret_key = "{{ .SecretKey }}"
-optimistic_relay_secret_key = "{{ .SecretKey }}"
 
 # cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
 cl_node_url = ["{{ .CLEndpoint }}"]


### PR DESCRIPTION
fixing:
```sh
2025-11-26T11:08:50.529308Z ERROR Fatal rbuilder error: Config file parsing: TOML parse error at line 1, column 1
  |
1 | log_json = true
  | ^^^^^^^^^^^^^^^
unknown field `optimistic_relay_secret_key`
```