### PR TITLE
feat: add OTLP collector URL to Lighthouse validator client

### DIFF
--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -490,6 +490,7 @@ def launch_participant_network(
             port_publisher=args_with_right_defaults.port_publisher,
             vc_index=current_vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            tempo_otlp_grpc_url=tempo_otlp_grpc_url,
         )
         if vc_service_config == None:
             continue

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -20,6 +20,7 @@ def get_config(
     participant,
     el_cl_genesis_data,
     image,
+    service_name,
     global_log_level,
     beacon_http_urls,
     cl_context,
@@ -33,6 +34,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    tempo_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.vc_log_level, global_log_level, VERBOSITY_LEVELS
@@ -80,6 +82,11 @@ def get_config(
     if network_params.gas_limit > 0:
         cmd.append("--gas-limit={0}".format(network_params.gas_limit))
         cmd.append("--builder-proposals")
+
+    # Add tempo telemetry integration if tempo is enabled
+    if tempo_otlp_grpc_url != None:
+        cmd.append("--telemetry-collector-url={}".format(tempo_otlp_grpc_url))
+        cmd.append("--telemetry-service-name={}".format(service_name))
 
     if len(participant.vc_extra_params):
         cmd.extend([param for param in participant.vc_extra_params])

--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -38,6 +38,7 @@ def get_vc_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    tempo_otlp_grpc_url=None,
 ):
     if node_keystore_files == None:
         return None
@@ -78,6 +79,7 @@ def get_vc_config(
             participant=participant,
             el_cl_genesis_data=launcher.el_cl_genesis_data,
             image=image,
+            service_name=service_name,
             global_log_level=global_log_level,
             beacon_http_urls=beacon_http_urls,
             cl_context=cl_context,
@@ -91,6 +93,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            tempo_otlp_grpc_url=tempo_otlp_grpc_url,
         )
     elif vc_type == constants.VC_TYPE.lodestar:
         config = lodestar.get_config(


### PR DESCRIPTION
## Summary
Adds Tempo OTLP telemetry integration to the Lighthouse validator client, matching the existing
implementation for the Lighthouse beacon node.

## Changes
- Thread `tempo_otlp_grpc_url` parameter through validator client configuration layers
- Add `--telemetry-collector-url` and `--telemetry-service-name` flags to Lighthouse VC command
- Use proper service name with "vc-" prefix for telemetry identification (e.g.,
"vc-1-lighthouse-geth")
