### PR TITLE
feat: enable `custom_preset` in checkpointz config

### DIFF
--- a/static_files/checkpointz-config/config.yaml.tmpl
+++ b/static_files/checkpointz-config/config.yaml.tmpl
@@ -5,6 +5,7 @@ global:
 
 checkpointz:
   mode: "light"
+  custom_preset: true
   caches:
     blocks:
       max_items: 200


### PR DESCRIPTION
The setting enables support for custom presets in checkpointz (https://github.com/ethpandaops/checkpointz/pull/226#issuecomment-3613972590),
it works for mainnet presets as well, and the performance impact is negligible for testing setups