### PR TITLE
fix: ensure proper bpo scheduling

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -337,36 +337,61 @@ def input_parser(plan, input_args):
             "Mock mev is only supported if the first participant is lighthouse client, please use a different client or set mev_type to 'flashbots', 'mev-rs' or 'commit-boost' or make the first participant lighthouse"
         )
 
-    if result["network_params"]["bpo_1_epoch"] < result["network_params"]["fulu_fork_epoch"]:
-        result["network_params"]["bpo_1_epoch"] = result["network_params"]["fulu_fork_epoch"]
+    if (
+        result["network_params"]["bpo_1_epoch"]
+        < result["network_params"]["fulu_fork_epoch"]
+    ):
+        result["network_params"]["bpo_1_epoch"] = result["network_params"][
+            "fulu_fork_epoch"
+        ]
         plan.print(
             "BPO 1 epoch adjusted to Fulu epoch {0}".format(
                 result["network_params"]["fulu_fork_epoch"]
             )
         )
-    if result["network_params"]["bpo_2_epoch"] < result["network_params"]["bpo_1_epoch"]:
-        result["network_params"]["bpo_2_epoch"] = result["network_params"]["bpo_1_epoch"]
+    if (
+        result["network_params"]["bpo_2_epoch"]
+        < result["network_params"]["bpo_1_epoch"]
+    ):
+        result["network_params"]["bpo_2_epoch"] = result["network_params"][
+            "bpo_1_epoch"
+        ]
         plan.print(
             "BPO 2 epoch adjusted to BPO 1 epoch {0}".format(
                 result["network_params"]["bpo_1_epoch"]
             )
         )
-    if result["network_params"]["bpo_3_epoch"] < result["network_params"]["bpo_2_epoch"]:
-        result["network_params"]["bpo_3_epoch"] = result["network_params"]["bpo_2_epoch"]
+    if (
+        result["network_params"]["bpo_3_epoch"]
+        < result["network_params"]["bpo_2_epoch"]
+    ):
+        result["network_params"]["bpo_3_epoch"] = result["network_params"][
+            "bpo_2_epoch"
+        ]
         plan.print(
             "BPO 3 epoch adjusted to BPO 2 epoch {0}".format(
                 result["network_params"]["bpo_2_epoch"]
             )
         )
-    if result["network_params"]["bpo_4_epoch"] < result["network_params"]["bpo_3_epoch"]:
-        result["network_params"]["bpo_4_epoch"] = result["network_params"]["bpo_3_epoch"]
+    if (
+        result["network_params"]["bpo_4_epoch"]
+        < result["network_params"]["bpo_3_epoch"]
+    ):
+        result["network_params"]["bpo_4_epoch"] = result["network_params"][
+            "bpo_3_epoch"
+        ]
         plan.print(
             "BPO 4 epoch adjusted to BPO 3 epoch {0}".format(
                 result["network_params"]["bpo_3_epoch"]
             )
         )
-    if result["network_params"]["bpo_5_epoch"] < result["network_params"]["bpo_4_epoch"]:
-        result["network_params"]["bpo_5_epoch"] = result["network_params"]["bpo_4_epoch"]
+    if (
+        result["network_params"]["bpo_5_epoch"]
+        < result["network_params"]["bpo_4_epoch"]
+    ):
+        result["network_params"]["bpo_5_epoch"] = result["network_params"][
+            "bpo_4_epoch"
+        ]
         plan.print(
             "BPO 5 epoch adjusted to BPO 4 epoch {0}".format(
                 result["network_params"]["bpo_4_epoch"]


### PR DESCRIPTION
This PR adds logic to ensure proper BPO scheduling:
```
BPO1 >= FULU
BPO2 >= BPO1
BPO3 >= BPO2
BPO4 >= BPO3
BPO5 >= BPO4
```