### PR TITLE
fix: change nimbus supernode flag

### DIFF
--- a/src/cl/nimbus/nimbus_launcher.star
+++ b/src/cl/nimbus/nimbus_launcher.star
@@ -260,7 +260,7 @@ def get_beacon_config(
     ]
 
     supernode_cmd = [
-        "--debug-peerdas-supernode=true",
+        "--peerdas-supernode=true",
     ]
 
     if network_params.perfect_peerdas_enabled and participant_index < 16:


### PR DESCRIPTION
`--debug-peerdas-supernode` flag is now deprecatred