### PR TITLE
fix: enforce spammer names to avoid deduplication on spammor side

### DIFF
--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -170,6 +170,8 @@ def new_config_template_data(
 ):
     startup_spammer_json = []
     for index, spammer in enumerate(startup_spammer):
+        if "name" not in spammer:
+            spammer["name"] = "kurtosis-{0}".format(index)
         startup_spammer_json.append(json.encode(spammer))
 
     return {


### PR DESCRIPTION
enforce auto generated spammer names ("kurtosis-<index>") if no spammer name is specified.
this is needed to threat these spammers as their own instances, otherwise spammers with equal name & scenario get merged during import

supersedes https://github.com/ethpandaops/spamoor/pull/169