### PR TITLE
feat(launcher): add publish_udp to participant configurations

### DIFF
--- a/src/cl/grandine/grandine_launcher.star
+++ b/src/cl/grandine/grandine_launcher.star
@@ -361,6 +361,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,

--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -338,6 +338,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,

--- a/src/cl/lodestar/lodestar_launcher.star
+++ b/src/cl/lodestar/lodestar_launcher.star
@@ -314,6 +314,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,

--- a/src/cl/nimbus/nimbus_launcher.star
+++ b/src/cl/nimbus/nimbus_launcher.star
@@ -367,6 +367,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [command_str],
         "files": files,

--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -348,6 +348,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,

--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -372,6 +372,7 @@ def get_beacon_config(
         "image": participant.cl_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.cl_enabled,
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -266,6 +266,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": [final_cmd_str],
         "files": files,
         "entrypoint": ENTRYPOINT_ARGS,

--- a/src/el/dummy/dummy_launcher.star
+++ b/src/el/dummy/dummy_launcher.star
@@ -168,6 +168,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -282,6 +282,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": [command_arg_str],
         "files": files,
         "entrypoint": ENTRYPOINT_ARGS,

--- a/src/el/ethereumjs/ethereumjs_launcher.star
+++ b/src/el/ethereumjs/ethereumjs_launcher.star
@@ -251,6 +251,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "entrypoint": ENTRYPOINT_ARGS,

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -243,6 +243,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -302,6 +302,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": [cmd_str],
         "files": files,
         "entrypoint": ENTRYPOINT_ARGS,

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -253,6 +253,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -234,6 +234,7 @@ def get_config(
         "image": participant.el_image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -314,6 +314,7 @@ def get_config(
         "image": image,
         "ports": used_ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.el_enabled,
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,

--- a/src/remote_signer/remote_signer_launcher.star
+++ b/src/remote_signer/remote_signer_launcher.star
@@ -156,6 +156,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.remote_signer_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": participant.remote_signer_extra_env_vars,

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -138,6 +138,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": env,

--- a/src/vc/lodestar.star
+++ b/src/vc/lodestar.star
@@ -145,6 +145,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": env_vars,

--- a/src/vc/nimbus.star
+++ b/src/vc/nimbus.star
@@ -124,6 +124,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": participant.vc_extra_env_vars,

--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -143,6 +143,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": participant.vc_extra_env_vars,

--- a/src/vc/teku.star
+++ b/src/vc/teku.star
@@ -136,6 +136,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": participant.vc_extra_env_vars,

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -82,6 +82,7 @@ def get_config(
         "image": image,
         "ports": ports,
         "public_ports": public_ports,
+        "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
         "env_vars": participant.vc_extra_env_vars,

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,3 @@
+port_publisher:
+  el: 
+    enabled: true


### PR DESCRIPTION
Requires kurtosis [1.15.2](https://github.com/kurtosis-tech/kurtosis/releases/tag/1.15.2).

Adds the `publish_udp` key to the configuration dictionaries generated by various client and service launchers (CL, EL, VC, remote signer). This allows clients to signal whether UDP port forwarding should be enabled via the port publisher, preparing for future network configuration capabilities. Also adds a basic test file.