### PR TITLE
fix: enable private discovery for Grandine for both built-in and external vc

### DIFF
--- a/src/cl/grandine/grandine_launcher.star
+++ b/src/cl/grandine/grandine_launcher.star
@@ -233,12 +233,12 @@ def get_beacon_config(
         "--metrics-address=0.0.0.0",
         "--metrics-port={0}".format(BEACON_METRICS_PORT_NUM),
         "--features=DisableFinalizedRootCheck",  # enables peering with prysm
+        "--enable-private-discovery",
     ]
     validator_default_cmd = [
         "--keystore-dir=" + validator_keys_dirpath,
         "--keystore-password-file=" + validator_secrets_dirpath,
         "--suggested-fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
-        "--enable-private-discovery",
     ]
 
     keymanager_api_cmd = [


### PR DESCRIPTION
Fix missing `--enable-private-discovery` flag propagation to the Grandine beacon node when using a separate VC, which caused node connectivity issues.