### PR TITLE
fix: claude skill install command does exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2058,15 +2058,14 @@ The canonical skill lives at `.claude/skills/kurtosis-ethereum/` with a symlink 
 
 **Claude Code:**
 
-```bash
-claude skill install --name kurtosis-ethereum /path/to/ethereum-package/.claude/skills/kurtosis-ethereum
-```
-
-Or reference it directly from GitHub:
+Clone the repo and copy the skill to your personal Claude skills folder:
 
 ```bash
-claude skill install --name kurtosis-ethereum github.com/ethpandaops/ethereum-package/.claude/skills/kurtosis-ethereum
+git clone https://github.com/ethpandaops/ethereum-package.git
+cp -r ethereum-package/.claude/skills/kurtosis-ethereum ~/.claude/skills/
 ```
+
+Claude Code auto-discovers skills in `~/.claude/skills/`. Once copied, invoke with `/kurtosis-ethereum`.
 
 **Codex:** The skill is auto-discovered from `.agents/skills/` when working in this repo. No extra installation needed.
 


### PR DESCRIPTION
The `README.md` tells the user to use a `claude skill install` command to install the kurtosis ethereum skill for claude code but the command doesn't exist. 
This PR fixes up the `README.md` to just copy the `SKILL.md` to `~/.claude/skills` using linux commands.