### PR TITLE
fix: update docker/login-action to v4.0.0 for Node.js 24

### DIFF
--- a/.github/actions/docker-login/action.yaml
+++ b/.github/actions/docker-login/action.yaml
@@ -24,7 +24,7 @@ runs:
 
     - name: Login to Docker Hub
       if: env.AUTH_EXISTS == 'true'
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}


### PR DESCRIPTION
## Summary
- Updates `docker/login-action` from v3.4.0 to v4.0.0
- Resolves Node.js 20 deprecation warning: actions will be forced to run with Node.js 24 starting June 2nd, 2026
- v4.0.0 uses Node.js 24 as the default runtime

## Test plan
- [ ] CI workflows using Docker login continue to work
- [ ] No Node.js 20 deprecation warnings in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)