### PR TITLE
fix: update kurtosis apt source to sdk.kurtosis.com

### DIFF
--- a/.github/actions/kurtosis-install/action.yaml
+++ b/.github/actions/kurtosis-install/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Install
       shell: bash
       run: |
-        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
         if [ "${{ inputs.version }}" = "latest" ]; then
           sudo apt install kurtosis-cli

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ image:
 tasks:
   - name: Setup Kurtosis
     command: |
-      echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+      echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
       sudo apt update
       sudo apt install kurtosis-cli
       echo -ne '\n' | kurtosis run github.com/fake-package/fake-package-purely-for-analytics || kurtosis clean -a


### PR DESCRIPTION
The old Gemfury-hosted kurtosis apt repository (apt.fury.io/kurtosis-tech) is no longer supported. This updates the apt source to the new official repository at sdk.kurtosis.com/kurtosis-cli-release-artifacts.