### PR TITLE
fix: bump kurtosis-assertoor-github-action to fix Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,7 +70,7 @@ jobs:
           username: ethpandaops
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Kurtosis Assertoor GitHub Action
-        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@f64942cbc780df731a731ea9f45765b161d2c8df # v1
         with:
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           ethereum_package_branch: ""

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -71,7 +71,7 @@ jobs:
           username: ethpandaops
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Kurtosis Assertoor GitHub Action
-        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@f64942cbc780df731a731ea9f45765b161d2c8df # v1
         with:
           ethereum_package_url: "."
           ethereum_package_branch: ""

--- a/.github/workflows/run-k8s.yml
+++ b/.github/workflows/run-k8s.yml
@@ -36,7 +36,7 @@ jobs:
       # run kurtosis test and assertoor
       - name: Run kurtosis testnet
         id: testnet
-        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@f64942cbc780df731a731ea9f45765b161d2c8df # v1
         with:
           kurtosis_extra_args: "--image-download always --non-blocking-tasks --verbosity DETAILED"
           kurtosis_backend: "kubernetes"


### PR DESCRIPTION
## Summary

- Bumps `ethpandaops/kurtosis-assertoor-github-action` from `5932604b` to `f64942cb` in all 3 workflow files
- The new commit bundles Node.js 24 compatible internal actions: `actions/upload-artifact` v4.6.2, `tale/kubectl-action` v1.4.0, `JarvusInnovations/background-action` v1.0.7

## Test plan

- [ ] Verify no Node.js 20 deprecation warnings appear in `run_k8s_test` workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)