### PR TITLE
feat: update `zkboost` to `v0.5.0` config and image

### DIFF
--- a/.github/tests/zkboost.yaml
+++ b/.github/tests/zkboost.yaml
@@ -10,12 +10,12 @@ additional_services:
   - grafana
 
 zkboost_params:
+  dashboard_enabled: true
   zkvms:
     - kind: mock
       proof_type: reth-zisk
-      mock_proving_time_ms: 5000
+      mock_proving_time: { kind: constant, ms: 5000 }
       mock_proof_size: 1024
     - kind: mock
       proof_type: ethrex-zisk
-      mock_proving_time_ms: 5000
-      mock_proof_size: 1024
+      mock_proving_time: { kind: random, min_ms: 2000, max_ms: 8000 }

--- a/.github/tests/zkboost.yaml
+++ b/.github/tests/zkboost.yaml
@@ -11,14 +11,9 @@ additional_services:
   - tempo
 
 zkboost_params:
-  dashboard_enabled: true
-  env:
-    RUST_LOG: info
   zkvms:
     - kind: mock
       proof_type: reth-zisk
-      mock_proving_time: { kind: constant, ms: 5000 }
-      mock_proof_size: 1024
     - kind: mock
       proof_type: ethrex-zisk
       mock_proving_time: { kind: random, min_ms: 2000, max_ms: 8000 }

--- a/.github/tests/zkboost.yaml
+++ b/.github/tests/zkboost.yaml
@@ -8,9 +8,12 @@ additional_services:
   - dora
   - prometheus
   - grafana
+  - tempo
 
 zkboost_params:
   dashboard_enabled: true
+  env:
+    RUST_LOG: info
   zkvms:
     - kind: mock
       proof_type: reth-zisk

--- a/README.md
+++ b/README.md
@@ -1085,46 +1085,53 @@ bootnodoor_params:
   extra_args: []
 
 # Configuration place for zkboost - https://github.com/eth-act/zkboost
+# The dashboard is automatically enabled when grafana is in additional_services.
 zkboost_params:
   # zkboost docker image to use
   # Defaults to the latest image
   image: "ghcr.io/eth-act/zkboost/zkboost:latest"
-  # Timeout in seconds for witness fetching
-  # Defaults to 12
-  witness_timeout_secs: 12
-  # Timeout in seconds for proof generation
-  # Defaults to 12
-  proof_timeout_secs: 12
-  # Number of witnesses to cache
-  # Defaults to 128
-  witness_cache_size: 128
-  # Number of proofs to cache
-  # Defaults to 128
-  proof_cache_size: 128
-  # Whether the live dashboard UI is enabled
-  # Defaults to false
-  dashboard_enabled: false
-  # Maximum number of recent block records to keep in the dashboard
-  # Defaults to 256
-  dashboard_retention: 256
-  # List of zkVM configurations
-  # Each entry has: kind (mock/ere), proof_type, and kind-specific options
+  # List of zkboost instances, each running a separate zkboost container.
+  # Each instance watches one EL participant for new blocks.
+  #   name (required): Kurtosis service name, must be unique across instances
+  #   el_participant_index (required): index of the EL participant to connect to (must not be dummy)
+  # Defaults to a single instance named "zkboost" connected to the first EL participant.
+  instances:
+    - name: zkboost
+      el_participant_index: 0
+  # List of zkVM backend configurations.
+  # If empty or not set, a default mock zkvm is auto-configured:
+  #   { kind: mock, proof_type: ethrex-zisk, mock_proving_time: { kind: constant, ms: 6000 }, mock_proof_size: 131072 }
+  # Each entry must have a unique proof_type.
+  #
+  # Common fields for all entries:
+  #   kind (required): the zkVM backend type
+  #     "mock" - in-process mock backend for testing, no real proving
+  #     "ere"  - remote ere-server backend (not yet supported)
+  #   proof_type (required): identifies the EL client + zkVM combination
+  #     "ethrex-risc0", "ethrex-sp1", "ethrex-zisk", "reth-openvm", "reth-risc0", "reth-sp1", "reth-zisk"
+  #   proof_timeout_secs: timeout for proof generation in seconds (default: 12, must be > 0)
+  #
+  # Mock-specific fields (only for kind: mock):
+  #   mock_proving_time: controls simulated proving duration (default: { kind: constant, ms: 6000 })
+  #     { kind: constant, ms: <ms> }                   - fixed duration
+  #     { kind: random, min_ms: <min>, max_ms: <max> } - uniformly random, min_ms must be <= max_ms
+  #     { kind: linear, ms_per_mgas: <ms> }            - proportional to block per million gas usage
+  #   mock_proof_size: simulated proof size in bytes, must be >= 32 (default: 131072 / 128 KiB)
+  #   mock_failure: whether to simulate proving failures (default: false)
+  #
   # example:
   # - kind: mock
   #   proof_type: ethrex-zisk
   #   mock_proving_time: { kind: constant, ms: 5000 }
   #   mock_proof_size: 1024
-  #   mock_failure: false
   # - kind: mock
   #   proof_type: reth-zisk
   #   mock_proving_time: { kind: random, min_ms: 2000, max_ms: 8000 }
   # - kind: mock
   #   proof_type: reth-sp1
   #   mock_proving_time: { kind: linear, ms_per_mgas: 150 }
-  # - kind: ere  # not yet supported
-  #   proof_type: ethrex-risc0
   zkvms: []
-  # A list of optional extra env_vars the zkboost container should spin up with
+  # Defaults RUST_LOG to "info" if not set.
   env: {}
 
 # Configuration place for tempo tracing backend

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ bootnodoor_params:
 zkboost_params:
   # zkboost docker image to use
   # Defaults to the latest image
-  image: "ghcr.io/eth-act/zkboost/zkboost-server:latest"
+  image: "ghcr.io/eth-act/zkboost/zkboost:latest"
   # Timeout in seconds for witness fetching
   # Defaults to 12
   witness_timeout_secs: 12
@@ -1101,14 +1101,28 @@ zkboost_params:
   # Number of proofs to cache
   # Defaults to 128
   proof_cache_size: 128
+  # Whether the live dashboard UI is enabled
+  # Defaults to false
+  dashboard_enabled: false
+  # Maximum number of recent block records to keep in the dashboard
+  # Defaults to 256
+  dashboard_retention: 256
   # List of zkVM configurations
-  # Each entry has: kind (mock/external), proof_type, and kind-specific options
-  # Example:
-  # zkvms:
-  #   - kind: mock
-  #     proof_type: reth-zisk
-  #     mock_proving_time_ms: 5000
-  #     mock_proof_size: 1024
+  # Each entry has: kind (mock/ere), proof_type, and kind-specific options
+  # example:
+  # - kind: mock
+  #   proof_type: ethrex-zisk
+  #   mock_proving_time: { kind: constant, ms: 5000 }
+  #   mock_proof_size: 1024
+  #   mock_failure: false
+  # - kind: mock
+  #   proof_type: reth-zisk
+  #   mock_proving_time: { kind: random, min_ms: 2000, max_ms: 8000 }
+  # - kind: mock
+  #   proof_type: reth-sp1
+  #   mock_proving_time: { kind: linear, ms_per_mgas: 150 }
+  # - kind: ere  # not yet supported
+  #   proof_type: ethrex-risc0
   zkvms: []
   # A list of optional extra env_vars the zkboost container should spin up with
   env: {}

--- a/main.star
+++ b/main.star
@@ -1061,6 +1061,7 @@ def run(plan, args={}):
                 args_with_right_defaults.port_publisher,
                 index,
                 args_with_right_defaults.docker_cache_params,
+                tempo_otlp_grpc_url,
             )
             prometheus_additional_metrics_jobs.extend(zkboost_metrics_jobs)
             plan.print("Successfully launched zkboost")

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -120,7 +120,7 @@ DEFAULT_COMMIT_BOOST_MEV_BOOST_IMAGE = "ghcr.io/commit-boost/pbs:latest"
 DEFAULT_MOCK_MEV_IMAGE = "ethpandaops/rustic-builder:main"
 DEFAULT_BUILDOOR_IMAGE = "ethpandaops/buildoor:main"
 DEFAULT_HELIX_RELAY_IMAGE = "ghcr.io/gattaca-com/helix-relay:main"
-DEFAULT_ZKBOOST_IMAGE = "ghcr.io/eth-act/zkboost/zkboost-server:latest"
+DEFAULT_ZKBOOST_IMAGE = "ghcr.io/eth-act/zkboost/zkboost:latest"
 DEFAULT_MEV_PUBKEY = "0xa55c1285d84ba83a5ad26420cd5ad3091e49c55a813eee651cd467db38a8c8e63192f47955e9376f6b42f6d190571cb5"
 DEFAULT_MEV_SECRET_KEY = (
     "0x607a11b45a7219cc61a3d9c5fd08c7eebd602a6a19a977f8d3771d5711a550f2"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -965,11 +965,12 @@ def input_parser(plan, input_args):
         ),
         zkboost_params=struct(
             image=result["zkboost_params"]["image"],
-            port=result["zkboost_params"]["port"],
             witness_timeout_secs=result["zkboost_params"]["witness_timeout_secs"],
             proof_timeout_secs=result["zkboost_params"]["proof_timeout_secs"],
             witness_cache_size=result["zkboost_params"]["witness_cache_size"],
             proof_cache_size=result["zkboost_params"]["proof_cache_size"],
+            dashboard_enabled=result["zkboost_params"]["dashboard_enabled"],
+            dashboard_retention=result["zkboost_params"]["dashboard_retention"],
             instances=result["zkboost_params"]["instances"],
             zkvms=result["zkboost_params"]["zkvms"],
             env=result["zkboost_params"]["env"],
@@ -2002,11 +2003,12 @@ def get_default_bootnodoor_params():
 def get_default_zkboost_params():
     return {
         "image": constants.DEFAULT_ZKBOOST_IMAGE,
-        "port": 3000,
         "witness_timeout_secs": 12,
         "proof_timeout_secs": 12,
         "witness_cache_size": 128,
         "proof_cache_size": 128,
+        "dashboard_enabled": False,
+        "dashboard_retention": 256,
         "instances": [{"name": "zkboost", "el_participant_index": 0}],
         "zkvms": [],
         "env": {},

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -478,6 +478,19 @@ def input_parser(plan, input_args):
             )
 
     if "zkboost" in result["additional_services"]:
+        # Inject default mock zkvm if none configured
+        if len(result["zkboost_params"]["zkvms"]) == 0:
+            result["zkboost_params"]["zkvms"] = [
+                {
+                    "kind": "mock",
+                    "proof_type": "ethrex-zisk",
+                    "mock_proving_time": {"kind": "constant", "ms": 6000},
+                    "mock_proof_size": 128 << 10,
+                },
+            ]
+        if "RUST_LOG" not in result["zkboost_params"]["env"]:
+            result["zkboost_params"]["env"]["RUST_LOG"] = "info"
+
         has_non_dummy_el = False
         for participant in result["participants"]:
             if participant["el_type"] != "dummy":
@@ -486,6 +499,95 @@ def input_parser(plan, input_args):
             fail(
                 "zkboost is enabled but all participants are using dummy EL. At least one participant must use a real EL client (geth, reth, nethermind, etc.) to produce blocks."
             )
+
+        for idx, instance in enumerate(result["zkboost_params"]["instances"]):
+            el_idx = instance.get("el_participant_index", 0)
+            if el_idx >= len(result["participants"]):
+                fail(
+                    "zkboost_params.instances[{0}]: el_participant_index {1} is out of range, only {2} participants exist".format(
+                        idx, el_idx, len(result["participants"])
+                    )
+                )
+
+        # Validate zkvm configurations
+        valid_proof_types = [
+            "ethrex-risc0",
+            "ethrex-sp1",
+            "ethrex-zisk",
+            "reth-openvm",
+            "reth-risc0",
+            "reth-sp1",
+            "reth-zisk",
+        ]
+        configured_proof_types = []
+        for idx, zkvm in enumerate(result["zkboost_params"]["zkvms"]):
+            kind = zkvm.get("kind")
+            proof_type = zkvm.get("proof_type")
+
+            if kind not in ["mock", "ere"]:
+                fail(
+                    "zkboost_params.zkvms[{0}]: unsupported kind '{1}', please use 'mock' or 'ere'".format(
+                        idx, kind
+                    )
+                )
+
+            if proof_type not in valid_proof_types:
+                fail(
+                    "zkboost_params.zkvms[{0}]: unsupported proof_type '{1}', please use one of: {2}".format(
+                        idx, proof_type, ", ".join(valid_proof_types)
+                    )
+                )
+
+            if proof_type in configured_proof_types:
+                fail(
+                    "zkboost_params.zkvms[{0}]: duplicate proof_type '{1}'".format(
+                        idx, proof_type
+                    )
+                )
+            configured_proof_types.append(proof_type)
+
+            proof_timeout = zkvm.get("proof_timeout_secs", 12)
+            if proof_timeout <= 0:
+                fail(
+                    "zkboost_params.zkvms[{0}]: proof_timeout_secs must be > 0, got {1}".format(
+                        idx, proof_timeout
+                    )
+                )
+
+            if kind == "ere":
+                fail(
+                    "zkboost_params.zkvms[{0}]: ere zkvm kind is not yet supported".format(
+                        idx
+                    )
+                )
+
+            if kind == "mock":
+                mock_proving_time = zkvm.get("mock_proving_time")
+                if mock_proving_time != None:
+                    pt_kind = mock_proving_time.get("kind", "constant")
+                    if pt_kind not in ["constant", "random", "linear"]:
+                        fail(
+                            "zkboost_params.zkvms[{0}]: unsupported mock_proving_time kind '{1}', please use 'constant', 'random' or 'linear'".format(
+                                idx, pt_kind
+                            )
+                        )
+                    if pt_kind == "random":
+                        min_ms = mock_proving_time.get("min_ms", 0)
+                        max_ms = mock_proving_time.get("max_ms", 0)
+                        if min_ms > max_ms:
+                            fail(
+                                "zkboost_params.zkvms[{0}]: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
+                                    idx, min_ms, max_ms
+                                )
+                            )
+
+                mock_proof_size = zkvm.get("mock_proof_size", 128 << 10)
+                if mock_proof_size < 32:
+                    fail(
+                        "zkboost_params.zkvms[{0}]: mock_proof_size must be >= 32, got {1}".format(
+                            idx, mock_proof_size
+                        )
+                    )
 
     if (
         "bootnodoor" not in result["additional_services"]
@@ -965,12 +1067,8 @@ def input_parser(plan, input_args):
         ),
         zkboost_params=struct(
             image=result["zkboost_params"]["image"],
-            witness_timeout_secs=result["zkboost_params"]["witness_timeout_secs"],
-            proof_timeout_secs=result["zkboost_params"]["proof_timeout_secs"],
-            witness_cache_size=result["zkboost_params"]["witness_cache_size"],
-            proof_cache_size=result["zkboost_params"]["proof_cache_size"],
-            dashboard_enabled=result["zkboost_params"]["dashboard_enabled"],
-            dashboard_retention=result["zkboost_params"]["dashboard_retention"],
+            dashboard_enabled="grafana" in result["additional_services"]
+            or "prometheus_grafana" in result["additional_services"],
             instances=result["zkboost_params"]["instances"],
             zkvms=result["zkboost_params"]["zkvms"],
             env=result["zkboost_params"]["env"],
@@ -2003,12 +2101,6 @@ def get_default_bootnodoor_params():
 def get_default_zkboost_params():
     return {
         "image": constants.DEFAULT_ZKBOOST_IMAGE,
-        "witness_timeout_secs": 12,
-        "proof_timeout_secs": 12,
-        "witness_cache_size": 128,
-        "proof_cache_size": 128,
-        "dashboard_enabled": False,
-        "dashboard_retention": 256,
         "instances": [{"name": "zkboost", "el_participant_index": 0}],
         "zkvms": [],
         "env": {},

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -447,12 +447,6 @@ SUBCATEGORY_PARAMS = {
     ],
     "zkboost_params": [
         "image",
-        "witness_timeout_secs",
-        "proof_timeout_secs",
-        "witness_cache_size",
-        "proof_cache_size",
-        "dashboard_enabled",
-        "dashboard_retention",
         "instances",
         "zkvms",
         "env",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -447,11 +447,12 @@ SUBCATEGORY_PARAMS = {
     ],
     "zkboost_params": [
         "image",
-        "port",
         "witness_timeout_secs",
         "proof_timeout_secs",
         "witness_cache_size",
         "proof_cache_size",
+        "dashboard_enabled",
+        "dashboard_retention",
         "instances",
         "zkvms",
         "env",

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -59,12 +59,13 @@ def launch_zkboost(
             entry = {
                 "Kind": zkvm["kind"],
                 "ProofType": zkvm["proof_type"],
+                "ProofTimeoutSecs": zkvm.get("proof_timeout_secs", 12),
             }
             if zkvm["kind"] == "ere":
                 fail("TODO: Ere zkvm kind is not yet supported")
             elif zkvm["kind"] == "mock":
                 mock_proving_time = zkvm.get(
-                    "mock_proving_time", {"kind": "constant", "ms": 3000}
+                    "mock_proving_time", {"kind": "constant", "ms": 6000}
                 )
                 entry["MockProvingTimeKind"] = mock_proving_time.get("kind", "constant")
                 entry["MockProvingTimeConstantMs"] = mock_proving_time.get("ms", 0)
@@ -73,19 +74,18 @@ def launch_zkboost(
                 entry["MockProvingTimeLinearMsPerMgas"] = mock_proving_time.get(
                     "ms_per_mgas", 0
                 )
-                entry["MockProofSize"] = zkvm.get("mock_proof_size", 1024)
+                entry["MockProofSize"] = zkvm.get("mock_proof_size", 128 << 10)
                 entry["MockFailure"] = zkvm.get("mock_failure", False)
             zkvms.append(entry)
 
         template_data = {
             "Port": HTTP_PORT_NUMBER,
             "ELEndpoint": el_endpoint,
-            "WitnessTimeoutSecs": zkboost_params.witness_timeout_secs,
-            "ProofTimeoutSecs": zkboost_params.proof_timeout_secs,
-            "WitnessCacheSize": zkboost_params.witness_cache_size,
-            "ProofCacheSize": zkboost_params.proof_cache_size,
+            "WitnessTimeoutSecs": 12,
+            "WitnessCacheSize": 128,
+            "ProofCacheSize": 128,
             "DashboardEnabled": zkboost_params.dashboard_enabled,
-            "DashboardRetention": zkboost_params.dashboard_retention,
+            "DashboardRetention": 256,
             "Zkvms": zkvms,
         }
 

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -33,6 +33,7 @@ def launch_zkboost(
     port_publisher,
     additional_service_index,
     docker_cache_params,
+    tempo_otlp_grpc_url=None,
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
@@ -108,6 +109,7 @@ def launch_zkboost(
             port_publisher,
             additional_service_index + instance_index,
             docker_cache_params,
+            tempo_otlp_grpc_url,
         )
 
         plan.add_service(name, config)
@@ -138,6 +140,7 @@ def get_config(
     port_publisher,
     additional_service_index,
     docker_cache_params,
+    tempo_otlp_grpc_url,
 ):
     config_file_path = shared_utils.path_join(
         ZKBOOST_CONFIG_MOUNT_DIRPATH_ON_SERVICE,
@@ -151,6 +154,11 @@ def get_config(
         0,
     )
 
+    env_vars = dict(zkboost_params.env)
+    if tempo_otlp_grpc_url != None:
+        env_vars["OTEL_EXPORTER_OTLP_ENDPOINT"] = tempo_otlp_grpc_url
+        env_vars["OTEL_SERVICE_NAME"] = service_name
+
     return ServiceConfig(
         image=shared_utils.docker_cache_image_calc(
             docker_cache_params,
@@ -163,7 +171,7 @@ def get_config(
         },
         entrypoint=["/usr/local/bin/zkboost"],
         cmd=["--config", config_file_path],
-        env_vars=zkboost_params.env,
+        env_vars=env_vars,
         min_cpu=MIN_CPU,
         max_cpu=MAX_CPU,
         min_memory=MIN_MEMORY,

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -3,6 +3,8 @@ constants = import_module("../package_io/constants.star")
 
 SERVICE_NAME_PREFIX = "zkboost"
 
+HTTP_PORT_NUMBER = 3000
+
 ZKBOOST_CONFIG_FILENAME = "config.toml"
 
 ZKBOOST_CONFIG_MOUNT_DIRPATH_ON_SERVICE = "/config"
@@ -11,6 +13,14 @@ MIN_CPU = 100
 MAX_CPU = 1000
 MIN_MEMORY = 256
 MAX_MEMORY = 2048
+
+USED_PORTS = {
+    constants.HTTP_PORT_ID: shared_utils.new_port_spec(
+        HTTP_PORT_NUMBER,
+        shared_utils.TCP_PROTOCOL,
+        shared_utils.HTTP_APPLICATION_PROTOCOL,
+    ),
+}
 
 
 def launch_zkboost(
@@ -49,20 +59,32 @@ def launch_zkboost(
                 "Kind": zkvm["kind"],
                 "ProofType": zkvm["proof_type"],
             }
-            if zkvm["kind"] == "external":
-                fail("TODO: external zkvm kind is not yet supported")
+            if zkvm["kind"] == "ere":
+                fail("TODO: Ere zkvm kind is not yet supported")
             elif zkvm["kind"] == "mock":
-                entry["MockProvingTimeMs"] = zkvm.get("mock_proving_time_ms", 5000)
+                mock_proving_time = zkvm.get(
+                    "mock_proving_time", {"kind": "constant", "ms": 3000}
+                )
+                entry["MockProvingTimeKind"] = mock_proving_time.get("kind", "constant")
+                entry["MockProvingTimeConstantMs"] = mock_proving_time.get("ms", 0)
+                entry["MockProvingTimeRandomMinMs"] = mock_proving_time.get("min_ms", 0)
+                entry["MockProvingTimeRandomMaxMs"] = mock_proving_time.get("max_ms", 0)
+                entry["MockProvingTimeLinearMsPerMgas"] = mock_proving_time.get(
+                    "ms_per_mgas", 0
+                )
                 entry["MockProofSize"] = zkvm.get("mock_proof_size", 1024)
+                entry["MockFailure"] = zkvm.get("mock_failure", False)
             zkvms.append(entry)
 
         template_data = {
-            "Port": zkboost_params.port,
+            "Port": HTTP_PORT_NUMBER,
             "ELEndpoint": el_endpoint,
             "WitnessTimeoutSecs": zkboost_params.witness_timeout_secs,
             "ProofTimeoutSecs": zkboost_params.proof_timeout_secs,
             "WitnessCacheSize": zkboost_params.witness_cache_size,
             "ProofCacheSize": zkboost_params.proof_cache_size,
+            "DashboardEnabled": zkboost_params.dashboard_enabled,
+            "DashboardRetention": zkboost_params.dashboard_retention,
             "Zkvms": zkvms,
         }
 
@@ -89,15 +111,15 @@ def launch_zkboost(
         )
 
         plan.add_service(name, config)
-        metrics_jobs.append(get_metrics_job(name, zkboost_params.port))
+        metrics_jobs.append(get_metrics_job(name))
 
     return metrics_jobs
 
 
-def get_metrics_job(service_name, port):
+def get_metrics_job(service_name):
     return {
         "Name": service_name,
-        "Endpoint": "{0}:{1}".format(service_name, port),
+        "Endpoint": "{0}:{1}".format(service_name, HTTP_PORT_NUMBER),
         "MetricsPath": "/metrics",
         "Labels": {
             "service": service_name,
@@ -122,15 +144,6 @@ def get_config(
         ZKBOOST_CONFIG_FILENAME,
     )
 
-    used_ports = {
-        constants.HTTP_PORT_ID: shared_utils.new_port_spec(
-            zkboost_params.port,
-            shared_utils.TCP_PROTOCOL,
-            shared_utils.HTTP_APPLICATION_PROTOCOL,
-            wait=None,
-        )
-    }
-
     public_ports = shared_utils.get_additional_service_standard_public_port(
         port_publisher,
         constants.HTTP_PORT_ID,
@@ -138,19 +151,17 @@ def get_config(
         0,
     )
 
-    IMAGE_NAME = shared_utils.docker_cache_image_calc(
-        docker_cache_params,
-        zkboost_params.image,
-    )
-
     return ServiceConfig(
-        image=IMAGE_NAME,
-        ports=used_ports,
+        image=shared_utils.docker_cache_image_calc(
+            docker_cache_params,
+            zkboost_params.image,
+        ),
+        ports=USED_PORTS,
         public_ports=public_ports,
         files={
             ZKBOOST_CONFIG_MOUNT_DIRPATH_ON_SERVICE: config_files_artifact_name,
         },
-        entrypoint=["/usr/local/bin/zkboost-server"],
+        entrypoint=["/usr/local/bin/zkboost"],
         cmd=["--config", config_file_path],
         env_vars=zkboost_params.env,
         min_cpu=MIN_CPU,

--- a/static_files/grafana-config/dashboards/zkboost/zkboost.json
+++ b/static_files/grafana-config/dashboards/zkboost/zkboost.json
@@ -982,6 +982,408 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "proofs",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 0,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 27,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 1,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"0.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"1.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"0.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"1.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"1.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"2.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"1.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"2.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"2.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"3.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"2.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"3.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"3.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"4.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"3.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"4.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"4.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"5.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"4.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "J"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"5.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"5.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "K"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"6.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"5.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "L"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"6.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"6.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "M"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"7.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"6.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "N"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"7.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"7.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "O"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"8.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"7.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "P"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"8.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"8.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "Q"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"9.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"8.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "R"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"9.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"9.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "S"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"10.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"9.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "T"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"10.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"10.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "U"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"11.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"10.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "V"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"11.5\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"11.0\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "W"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"12.0\"}[$__range])) - sum by (proof_type) (increase(zkboost_prove_duration_seconds_bucket{le=\"11.5\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "X"
+        }
+      ],
+      "title": "Prove Duration Distribution",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "le": true,
+              "status": true
+            },
+            "indexByName": {
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5,
+              "Value #F": 6,
+              "Value #G": 7,
+              "Value #H": 8,
+              "Value #I": 9,
+              "Value #J": 10,
+              "Value #K": 11,
+              "Value #L": 12,
+              "Value #M": 13,
+              "Value #N": 14,
+              "Value #O": 15,
+              "Value #P": 16,
+              "Value #Q": 17,
+              "Value #R": 18,
+              "Value #S": 19,
+              "Value #T": 20,
+              "Value #U": 21,
+              "Value #V": 22,
+              "Value #W": 23,
+              "Value #X": 24,
+              "proof_type": 0
+            },
+            "renameByName": {
+              "Value #A": "0.5s",
+              "Value #B": "1.0s",
+              "Value #C": "1.5s",
+              "Value #D": "2.0s",
+              "Value #E": "2.5s",
+              "Value #F": "3.0s",
+              "Value #G": "3.5s",
+              "Value #H": "4.0s",
+              "Value #I": "4.5s",
+              "Value #J": "5.0s",
+              "Value #K": "5.5s",
+              "Value #L": "6.0s",
+              "Value #M": "6.5s",
+              "Value #N": "7.0s",
+              "Value #O": "7.5s",
+              "Value #P": "8.0s",
+              "Value #Q": "8.5s",
+              "Value #R": "9.0s",
+              "Value #S": "9.5s",
+              "Value #T": "10.0s",
+              "Value #U": "10.5s",
+              "Value #V": "11.0s",
+              "Value #W": "11.5s",
+              "Value #X": "12.0s",
+              "proof_type": "Proof Type"
+            }
+          }
+        },
+        {
+          "id": "transpose",
+          "options": {}
+        }
+      ],
+      "type": "barchart"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1180,6 +1582,363 @@
       ],
       "title": "Verify Duration",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Proof Traces",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${tempo_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "show below",
+                    "url": "/d/zkboost-dashboard/zkboost?var-traceId=${__value.raw}&${__url_time_range}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 326
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ns"
+              },
+              {
+                "id": "custom.width",
+                "value": 74
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Block"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Gas Used"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 80
+              },
+              {
+                "id": "unit",
+                "value": "si:"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Start time"
+            },
+            "properties": [
+              {
+                "id": "custom.width"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Request latency"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "suffix: s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "custom.width",
+                "value": 124
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 25,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Start time"
+          }
+        ]
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${tempo_datasource}"
+          },
+          "limit": 500,
+          "metricsQueryType": "range",
+          "query": "{resource.service.name=\"zkboost\" && name=~\"request_proof\"} | select(span.block_number, span.gas_used, span.timestamp)",
+          "queryType": "traceql",
+          "refId": "A",
+          "serviceMapUseNativeHistograms": false,
+          "tableType": "spans"
+        }
+      ],
+      "title": "Recent Proof Traces",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Trace ID",
+            "mode": "reduceRow",
+            "reduce": {
+              "include": [
+                "traceIdHidden"
+              ],
+              "reducer": "first"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "timestamp_ms",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "timestamp"
+                }
+              },
+              "operator": "*",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "latency_ms",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Start time"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "timestamp_ms"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Request latency",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "latency_ms"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "1000"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "block_number",
+                "gas_used",
+                "Duration",
+                "Trace ID",
+                "Start time",
+                "Request latency"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "Duration": 4,
+              "Request latency": 3,
+              "Start time": 5,
+              "Trace ID": 0,
+              "block_number": 1,
+              "gas_used": 2
+            },
+            "renameByName": {
+              "block_number": "Block",
+              "duration": "Duration",
+              "gas_used": "Gas Used",
+              "time": "Start time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "${tempo_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 23,
+      "options": {
+        "spanFilters": {
+          "adhocFilters": [],
+          "criticalPathOnly": false,
+          "matchesOnly": false
+        }
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "${tempo_datasource}"
+          },
+          "limit": 20,
+          "query": "${traceId}",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "Proof Trace",
+      "type": "traces"
     }
   ],
   "refresh": "10s",
@@ -1231,6 +1990,35 @@
         "regex": "",
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "Tempo",
+          "value": "Tempo"
+        },
+        "label": "Tempo",
+        "name": "tempo_datasource",
+        "options": [],
+        "query": "tempo",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "label": "Trace ID",
+        "name": "traceId",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
       }
     ]
   },

--- a/static_files/grafana-config/dashboards/zkboost/zkboost.json
+++ b/static_files/grafana-config/dashboards/zkboost/zkboost.json
@@ -695,6 +695,300 @@
         "x": 0,
         "y": 22
       },
+      "id": 105,
+      "panels": [],
+      "title": "Witness Fetch",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(zkboost_witness_fetch_total{service=~\"$service\"}[$__rate_interval])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Witness Fetch Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(zkboost_witness_fetch_duration_seconds_bucket{service=~\"$service\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(zkboost_witness_fetch_duration_seconds_bucket{service=~\"$service\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(zkboost_witness_fetch_duration_seconds_bucket{service=~\"$service\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Witness Fetch Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(zkboost_witness_bytes_bucket{service=~\"$service\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(zkboost_witness_bytes_bucket{service=~\"$service\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Witness Size",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
       "id": 102,
       "panels": [],
       "title": "Prove Operations",
@@ -760,7 +1054,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 23
+        "y": 32
       },
       "id": 10,
       "options": {
@@ -848,7 +1142,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 23
+        "y": 32
       },
       "id": 11,
       "options": {
@@ -947,7 +1241,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 23
+        "y": 32
       },
       "id": 12,
       "options": {
@@ -1035,7 +1329,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "id": 27,
       "options": {
@@ -1389,7 +1683,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "id": 104,
       "panels": [],
@@ -1456,7 +1750,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 41
       },
       "id": 16,
       "options": {
@@ -1544,7 +1838,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 41
       },
       "id": 17,
       "options": {
@@ -1589,7 +1883,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 57
       },
       "id": 103,
       "panels": [],
@@ -1748,7 +2042,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 58
       },
       "id": 25,
       "options": {
@@ -1913,7 +2207,7 @@
         "h": 16,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 66
       },
       "id": 23,
       "options": {

--- a/static_files/zkboost-config/config.toml.tmpl
+++ b/static_files/zkboost-config/config.toml.tmpl
@@ -1,7 +1,6 @@
 port = {{ .Port }}
 el_endpoint = "{{ .ELEndpoint }}"
 witness_timeout_secs = {{ .WitnessTimeoutSecs }}
-proof_timeout_secs = {{ .ProofTimeoutSecs }}
 proof_cache_size = {{ .ProofCacheSize }}
 witness_cache_size = {{ .WitnessCacheSize }}
 
@@ -12,6 +11,7 @@ retention = {{ .DashboardRetention }}
 [[zkvm]]
 kind = "{{ $zkvm.Kind }}"
 proof_type = "{{ $zkvm.ProofType }}"
+proof_timeout_secs = {{ $zkvm.ProofTimeoutSecs }}
 {{- if eq $zkvm.Kind "ere" }}
 endpoint = "{{ $zkvm.Endpoint }}"
 {{- end }}

--- a/static_files/zkboost-config/config.toml.tmpl
+++ b/static_files/zkboost-config/config.toml.tmpl
@@ -4,15 +4,26 @@ witness_timeout_secs = {{ .WitnessTimeoutSecs }}
 proof_timeout_secs = {{ .ProofTimeoutSecs }}
 proof_cache_size = {{ .ProofCacheSize }}
 witness_cache_size = {{ .WitnessCacheSize }}
+
+[dashboard]
+enabled = {{ .DashboardEnabled }}
+retention = {{ .DashboardRetention }}
 {{ range $zkvm := .Zkvms }}
 [[zkvm]]
 kind = "{{ $zkvm.Kind }}"
 proof_type = "{{ $zkvm.ProofType }}"
-{{- if eq $zkvm.Kind "external" }}
+{{- if eq $zkvm.Kind "ere" }}
 endpoint = "{{ $zkvm.Endpoint }}"
 {{- end }}
 {{- if eq $zkvm.Kind "mock" }}
-mock_proving_time_ms = {{ $zkvm.MockProvingTimeMs }}
+{{- if eq $zkvm.MockProvingTimeKind "constant" }}
+mock_proving_time = { kind = "constant", ms = {{ $zkvm.MockProvingTimeConstantMs }} }
+{{- else if eq $zkvm.MockProvingTimeKind "random" }}
+mock_proving_time = { kind = "random", min_ms = {{ $zkvm.MockProvingTimeRandomMinMs }}, max_ms = {{ $zkvm.MockProvingTimeRandomMaxMs }} }
+{{- else if eq $zkvm.MockProvingTimeKind "linear" }}
+mock_proving_time = { kind = "linear", ms_per_mgas = {{ $zkvm.MockProvingTimeLinearMsPerMgas }} }
+{{- end }}
 mock_proof_size = {{ $zkvm.MockProofSize }}
+mock_failure = {{ $zkvm.MockFailure }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Update `zkboost` launcher to `v0.5.0` that has some breaking changes on config and image

- Image name is published as `ghcr.io/eth-act/zkboost/zkboost` now (breaking change)
- Config updates
  - `mock_proving_time_ms` is renamed to `mock_proving_time` and takes a enum object (breaking change):
    - `mock_proving_time: { kind: constant, ms: 5000 }`
    - `mock_proving_time: { kind: random, min_ms: 2000, max_ms: 8000 }`
    - `mock_proving_time: { kind: linear, ms_per_mgas: 150 }` - Linear to block gas used
  - zkVM kind variant `external` is renamed to `ere`
  - Added dashboard config `dashboard_enabled` and `dashboard_retention`
- Wire tempo otel with zkboost
- Update grafana dashboard, add extra `Prove Duration Distribution` panel and `Proof Traces` row

<details>

<summary>Updated dashboard preview</summary>

- `Prove Duration Distribution` panel
  <img width="1241" height="261" alt="image" src="https://github.com/user-attachments/assets/323e6e0c-70d6-4f9f-b9de-2510330b5772" />

- `Proof Traces` row
  <img width="1241" height="754" alt="image" src="https://github.com/user-attachments/assets/51e6c8c4-5f7b-4b25-8f87-414eff0bb4ff" />

</details>