### PR TITLE
feat(mev): add commit_boost_config param for custom CB config templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,6 +1353,24 @@ mev_params:
   run_multiple_relays: false
   # The image to use for helix relay (used when run_multiple_relays is true or mev_type is helix)
   helix_relay_image: ghcr.io/gattaca-com/helix-relay:main
+  # Inline Commit-Boost config template. When set, replaces the default auto-generated
+  # config. Template variables {{ .Timestamp }}, {{ .Network }}, {{ .Port }}, {{ .Relays }}
+  # are rendered at enclave creation. Only used when mev_type is "commit-boost".
+  # Example:
+  #   commit_boost_config: |
+  #     chain = { genesis_time_secs = {{ .Timestamp }}, path = "{{ .Network }}" }
+  #     [pbs]
+  #     host = "0.0.0.0"
+  #     port = {{ .Port }}
+  #     skip_sigverify = true
+  #     {{ range $index, $relay := .Relays }}
+  #     [[relays]]
+  #     id = "mev_relay_{{$index}}"
+  #     url = "{{ $relay }}"
+  #     {{- end }}
+  #     [logs.stdout]
+  #     level = "debug"
+  commit_boost_config: ""
 
 # Parameters for the buildoor builder+relay service (used when mev_type is "buildoor")
 buildoor_params:

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -214,6 +214,10 @@ mev_params:
     labels: {}
   run_multiple_relays: false
   helix_relay_image: ghcr.io/gattaca-com/helix-relay:main
+  # Inline Commit-Boost config template. When set, replaces the default template.
+  # Template variables {{ .Timestamp }}, {{ .Network }}, {{ .Port }}, {{ .Relays }}
+  # are rendered at enclave creation. Only used when mev_type is "commit-boost".
+  commit_boost_config: ""
   custom_flood_params:
     interval_between_transactions: 1
 buildoor_params:

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -214,9 +214,6 @@ mev_params:
     labels: {}
   run_multiple_relays: false
   helix_relay_image: ghcr.io/gattaca-com/helix-relay:main
-  # Inline Commit-Boost config template. When set, replaces the default template.
-  # Template variables {{ .Timestamp }}, {{ .Network }}, {{ .Port }}, {{ .Relays }}
-  # are rendered at enclave creation. Only used when mev_type is "commit-boost".
   commit_boost_config: ""
   custom_flood_params:
     interval_between_transactions: 1

--- a/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
+++ b/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
@@ -57,12 +57,12 @@ def launch(
     )
 
     if mev_params.commit_boost_config:
-        config_template = mev_params.commit_boost_config
+        commit_boost_config_template = mev_params.commit_boost_config
     else:
-        config_template = read_file(static_files.COMMIT_BOOST_CONFIG_FILEPATH)
+        commit_boost_config_template = read_file(static_files.COMMIT_BOOST_CONFIG_FILEPATH)
 
     template_and_data = shared_utils.new_template_and_data(
-        config_template, template_data
+        commit_boost_config_template, template_data
     )
 
     template_and_data_by_rel_dest_filepath = {}

--- a/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
+++ b/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
@@ -51,14 +51,18 @@ def launch(
     )
 
     image = mev_params.mev_boost_image
+
     template_data = new_config_template_data(
         network, constants.MEV_BOOST_PORT, relays, final_genesis_timestamp
     )
 
-    commit_boost_config_template = read_file(static_files.COMMIT_BOOST_CONFIG_FILEPATH)
+    if mev_params.commit_boost_config:
+        config_template = mev_params.commit_boost_config
+    else:
+        config_template = read_file(static_files.COMMIT_BOOST_CONFIG_FILEPATH)
 
     template_and_data = shared_utils.new_template_and_data(
-        commit_boost_config_template, template_data
+        config_template, template_data
     )
 
     template_and_data_by_rel_dest_filepath = {}

--- a/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
+++ b/src/mev/commit-boost/mev_boost/mev_boost_launcher.star
@@ -59,7 +59,9 @@ def launch(
     if mev_params.commit_boost_config:
         commit_boost_config_template = mev_params.commit_boost_config
     else:
-        commit_boost_config_template = read_file(static_files.COMMIT_BOOST_CONFIG_FILEPATH)
+        commit_boost_config_template = read_file(
+            static_files.COMMIT_BOOST_CONFIG_FILEPATH
+        )
 
     template_and_data = shared_utils.new_template_and_data(
         commit_boost_config_template, template_data

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -756,6 +756,7 @@ def input_parser(plan, input_args):
             launch_adminer=result["mev_params"]["launch_adminer"],
             run_multiple_relays=result["mev_params"]["run_multiple_relays"],
             helix_relay_image=result["mev_params"]["helix_relay_image"],
+            commit_boost_config=result["mev_params"].get("commit_boost_config", ""),
         )
         if result["mev_params"]
         else None,
@@ -1806,6 +1807,7 @@ def get_default_mev_params(mev_type, preset):
         "launch_adminer": launch_adminer,
         "run_multiple_relays": False,
         "helix_relay_image": constants.DEFAULT_HELIX_RELAY_IMAGE,
+        "commit_boost_config": "",
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -382,6 +382,7 @@ SUBCATEGORY_PARAMS = {
         "launch_adminer",
         "run_multiple_relays",
         "helix_relay_image",
+        "commit_boost_config",
     ],
     "xatu_sentry_params": [
         "xatu_sentry_image",


### PR DESCRIPTION
## Summary

Adds a `commit_boost_config` parameter to `mev_params` that allows users to provide
a custom Commit-Boost configuration template as inline TOML content when using
`mev_type: commit-boost`.

## Motivation

The current Commit-Boost integration uses a hardcoded PBS-only config template
(`cb-config.toml.tmpl`) that only supports `[pbs]` + `[[relays]]` + `[logs]`.
This means users cannot test Commit-Boost features that require additional
configuration sections:

- `[signer]` (local keystores, Dirk, Web3Signer)
- `[[modules]]` (custom commit modules)
- `[[mux]]` (per-validator relay routing)
- `[metrics]`
- PBS tuning (`header_validation_mode`, `extra_validation_enabled`, timing games)

This change lets users pass a full CB config while still benefiting from
automatic relay URL and genesis timestamp injection via template variables.

## Changes

- **`sanity_check.star`**: added `commit_boost_config` to the `mev_params` allowlist
- **`input_parser.star`**: added `commit_boost_config` with default `""` to
  `get_default_mev_params()`
- **`network_params.yaml`**: documented the new parameter with usage example
- **`mev_boost_launcher.star`**: if `mev_params.commit_boost_config` is set, use it
  as the config template instead of reading from `static_files`. Template variables
  (`{{ .Network }}`, `{{ .Port }}`, `{{ .Relays }}`, `{{ .Timestamp }}`) work in
  both paths.

When the field is empty (default), behavior is identical to before.

## Example

```yaml
# Test config: mux routing with single relay backing both entries
# Tests that CB parses [[mux]] correctly
# Both relay entries point at the same flashbots relay with different IDs.

participants:
  - el_type: geth
    cl_type: lighthouse
    count: 2

mev_type: commit-boost

mev_params:
  mev_boost_image: commit-boost/pbs:kurtosis
  mev_relay_image: ethpandaops/mev-boost-relay:main
  mev_builder_cl_image: sigp/lighthouse:latest
  mev_builder_image: ethpandaops/reth-rbuilder:develop
  commit_boost_config: |
    chain = { genesis_time_secs = {{ .Timestamp }}, path = "{{ .Network }}" }

    [pbs]
    host = "0.0.0.0"
    port = {{ .Port }}
    skip_sigverify = true
    timeout_get_header_ms = 950

    {{ range $index, $relay := .Relays }}
    [[relays]]
    id = "relay_{{$index}}"
    url = "{{ $relay }}"
    {{- end }}

    [[mux]]
    id = "fast_path"
    validator_pubkeys = [
        "0x8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000deadbeef",
    ]
    timeout_get_header_ms = 500
    late_in_slot_time_ms = 1000
    [[mux.relays]]
    id = "mux_relay"
    url = "{{ index .Relays 0 }}"

    [logs.stdout]
    level = "debug"

    [logs.file]
    enabled = false

additional_services:
  - dora
```