### PR TITLE
fix: drop gloas-support and heze-support image overrides

### DIFF
--- a/src/assertoor/assertoor_launcher.star
+++ b/src/assertoor/assertoor_launcher.star
@@ -140,22 +140,6 @@ def get_config(
     )
 
     IMAGE_NAME = assertoor_params.image
-    default_assertoor_image = (
-        docker_cache_params.url
-        + (docker_cache_params.dockerhub_prefix if docker_cache_params.enabled else "")
-        + constants.DEFAULT_ASSERTOOR_IMAGE
-    )
-    if assertoor_params.image == default_assertoor_image:
-        if network_params.gloas_fork_epoch < constants.FAR_FUTURE_EPOCH:
-            IMAGE_NAME = (
-                docker_cache_params.url
-                + (
-                    docker_cache_params.dockerhub_prefix
-                    if docker_cache_params.enabled
-                    else ""
-                )
-                + "ethpandaops/assertoor:gloas-support"
-            )
 
     return ServiceConfig(
         image=IMAGE_NAME,

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -151,32 +151,6 @@ def get_config(
 
     IMAGE_NAME = dora_params.image
     env_vars = dora_params.env
-    default_dora_image = (
-        docker_cache_params.url
-        + (docker_cache_params.dockerhub_prefix if docker_cache_params.enabled else "")
-        + constants.DEFAULT_DORA_IMAGE
-    )
-    if dora_params.image == default_dora_image:
-        if network_params.gloas_fork_epoch < constants.FAR_FUTURE_EPOCH:
-            IMAGE_NAME = (
-                docker_cache_params.url
-                + (
-                    docker_cache_params.dockerhub_prefix
-                    if docker_cache_params.enabled
-                    else ""
-                )
-                + "ethpandaops/dora:gloas-support"
-            )
-        if network_params.heze_fork_epoch < constants.FAR_FUTURE_EPOCH:
-            IMAGE_NAME = (
-                docker_cache_params.url
-                + (
-                    docker_cache_params.dockerhub_prefix
-                    if docker_cache_params.enabled
-                    else ""
-                )
-                + "ethpandaops/dora:heze-support"
-            )
 
     return ServiceConfig(
         image=IMAGE_NAME,


### PR DESCRIPTION
## Summary
- Remove the conditional override that swapped the default dora image for `ethpandaops/dora:gloas-support` / `ethpandaops/dora:heze-support` when those forks were scheduled.
- Remove the equivalent override that pointed assertoor at `ethpandaops/assertoor:gloas-support`.
- The `:latest` images now cover gloas/heze scenarios, so the per-fork overrides are no longer needed.

## Test plan
- [ ] Spin up a devnet with `gloas_fork_epoch` scheduled and confirm dora + assertoor still come up healthy on `:latest`.
- [ ] Spin up a devnet with `heze_fork_epoch` scheduled and confirm dora still comes up healthy on `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)