### PR TITLE
feat: add confirmation_byzantine_threshold, bump genesis-generator to 5.3.6, tempo in zkvm tests

### DIFF
--- a/.github/tests/1gpu_zkvm.yaml_norun
+++ b/.github/tests/1gpu_zkvm.yaml_norun
@@ -42,6 +42,7 @@ additional_services:
   - dora
   - prometheus
   - grafana
+  - tempo
 
 zkboost_params:
   image: ghcr.io/eth-act/zkboost/zkboost:0.5.0

--- a/.github/tests/8gpu_zkvm.yaml_norun
+++ b/.github/tests/8gpu_zkvm.yaml_norun
@@ -50,6 +50,7 @@ additional_services:
   - dora
   - prometheus
   - grafana
+  - tempo
 
 zkboost_params:
   image: ghcr.io/eth-act/zkboost/zkboost:0.5.0

--- a/README.md
+++ b/README.md
@@ -1573,7 +1573,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:5.3.6
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/README.md
+++ b/README.md
@@ -740,6 +740,10 @@ network_params:
   # Defaults to 65536
   churn_limit_quotient: 65536
 
+  # Byzantine threshold (in percent) used by the confirmation rule
+  # Defaults to 25
+  confirmation_byzantine_threshold: 25
+
   # Ejection balance
   # Defaults to 16ETH
   # 16000000000 gwei

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.5
+  image: ethpandaops/ethereum-genesis-generator:5.3.6
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -93,6 +93,7 @@ network_params:
   genesis_gaslimit: 60000000
   max_per_epoch_activation_churn_limit: 8
   churn_limit_quotient: 65536
+  confirmation_byzantine_threshold: 25
   ejection_balance: 16000000000
   eth1_follow_distance: 2048
   min_validator_withdrawability_delay: 256

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:master"
+    "ethpandaops/ethereum-genesis-generator:5.3.6"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:5.3.5"
+    "ethpandaops/ethereum-genesis-generator:master"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -736,6 +736,9 @@ def input_parser(plan, input_args):
                 "max_per_epoch_activation_churn_limit"
             ],
             churn_limit_quotient=result["network_params"]["churn_limit_quotient"],
+            confirmation_byzantine_threshold=result["network_params"][
+                "confirmation_byzantine_threshold"
+            ],
             ejection_balance=result["network_params"]["ejection_balance"],
             eth1_follow_distance=result["network_params"]["eth1_follow_distance"],
             altair_fork_epoch=result["network_params"]["altair_fork_epoch"],
@@ -1591,6 +1594,7 @@ def default_network_params():
         "genesis_gaslimit": 60000000,
         "max_per_epoch_activation_churn_limit": 8,
         "churn_limit_quotient": 65536,
+        "confirmation_byzantine_threshold": 25,
         "ejection_balance": 16000000000,
         "eth1_follow_distance": 2048,
         "min_validator_withdrawability_delay": 256,
@@ -1673,6 +1677,7 @@ def default_minimal_network_params():
         "genesis_gaslimit": 60000000,
         "max_per_epoch_activation_churn_limit": 4,
         "churn_limit_quotient": 32,
+        "confirmation_byzantine_threshold": 25,
         "ejection_balance": 16000000000,
         "eth1_follow_distance": 16,
         "min_validator_withdrawability_delay": 256,

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -228,6 +228,7 @@ SUBCATEGORY_PARAMS = {
         "genesis_gaslimit",
         "max_per_epoch_activation_churn_limit",
         "churn_limit_quotient",
+        "confirmation_byzantine_threshold",
         "ejection_balance",
         "eth1_follow_distance",
         "min_validator_withdrawability_delay",

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -152,6 +152,7 @@ def new_env_file_for_el_cl_genesis_data(
         "GenesisGasLimit": network_params.genesis_gaslimit,
         "MaxPerEpochActivationChurnLimit": network_params.max_per_epoch_activation_churn_limit,
         "ChurnLimitQuotient": network_params.churn_limit_quotient,
+        "ConfirmationByzantineThreshold": network_params.confirmation_byzantine_threshold,
         "EjectionBalance": network_params.ejection_balance,
         "Eth1FollowDistance": network_params.eth1_follow_distance,
         "AltairForkEpoch": "{0}".format(network_params.altair_fork_epoch),

--- a/static_files/genesis-generation-config/el-cl/values.env.tmpl
+++ b/static_files/genesis-generation-config/el-cl/values.env.tmpl
@@ -32,6 +32,7 @@ export GENESIS_DELAY={{ .GenesisDelay }}
 export GENESIS_GASLIMIT={{ .GenesisGasLimit }}
 export MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT={{ .MaxPerEpochActivationChurnLimit }}
 export CHURN_LIMIT_QUOTIENT={{ .ChurnLimitQuotient }}
+export CONFIRMATION_BYZANTINE_THRESHOLD={{ .ConfirmationByzantineThreshold }}
 export EJECTION_BALANCE={{ .EjectionBalance }}
 export ETH1_FOLLOW_DISTANCE={{ .Eth1FollowDistance }}
 export SHADOW_FORK_FILE={{ .ShadowForkFile }}


### PR DESCRIPTION
## Summary
- Add new CL `network_params.confirmation_byzantine_threshold` (default `25` for both mainnet and minimal presets); threaded through `input_parser`, `sanity_check`, `el_cl_genesis_generator`, and `values.env.tmpl`; documented in `README.md` and `network_params.yaml`
- Bump `DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE` from `5.3.5` to `5.3.6`
- Add `tempo` to `additional_services` in `.github/tests/1gpu_zkvm.yaml_norun` and `.github/tests/8gpu_zkvm.yaml_norun`

## Test plan
- [ ] CI passes
- [ ] Confirm `CONFIRMATION_BYZANTINE_THRESHOLD=25` ends up in the rendered `values.env` for a default run
- [ ] Override `confirmation_byzantine_threshold` via `network_params.yaml` and confirm it propagates to the genesis generator
- [ ] Run `kurtosis run --enclave eip8025-zkboost-1gpu . --args-file .github/tests/1gpu_zkvm.yaml_norun` and confirm tempo is up
- [ ] Run `kurtosis run --enclave eip8025-zkboost-8gpu . --args-file .github/tests/8gpu_zkvm.yaml_norun` and confirm tempo is up