### PR TITLE
fix: update tempo config for 3.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,16 +1179,6 @@ zkboost_params:
 
 # Configuration place for tempo tracing backend
 tempo_params:
-  # How long to retain traces
-  retention_duration: "12h"
-  # Rate limiting for trace ingestion (bytes per second)
-  ingestion_rate_limit: 20971520  # 20MB
-  # Burst limit for trace ingestion (bytes)
-  ingestion_burst_limit: 52428800  # 50MB
-  # Maximum duration for trace searches
-  max_search_duration: "30s"
-  # Maximum bytes per individual trace
-  max_bytes_per_trace: 52428800  # 50MB
   # Resource management for tempo container
   # CPU is milicores
   # RAM is in MB

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2023,7 +2023,7 @@ def get_default_tempo_params():
         "max_cpu": 1000,
         "min_mem": 128,
         "max_mem": 2048,
-        "image": "grafana/tempo:latest",
+        "image": "grafana/tempo:2.10.4",
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2023,7 +2023,7 @@ def get_default_tempo_params():
         "max_cpu": 1000,
         "min_mem": 128,
         "max_mem": 2048,
-        "image": "grafana/tempo:2.10.4",
+        "image": "grafana/tempo:latest",
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -938,11 +938,6 @@ def input_parser(plan, input_args):
             image=result["grafana_params"]["image"],
         ),
         tempo_params=struct(
-            retention_duration=result["tempo_params"]["retention_duration"],
-            ingestion_rate_limit=result["tempo_params"]["ingestion_rate_limit"],
-            ingestion_burst_limit=result["tempo_params"]["ingestion_burst_limit"],
-            max_search_duration=result["tempo_params"]["max_search_duration"],
-            max_bytes_per_trace=result["tempo_params"]["max_bytes_per_trace"],
             min_cpu=result["tempo_params"]["min_cpu"],
             max_cpu=result["tempo_params"]["max_cpu"],
             min_mem=result["tempo_params"]["min_mem"],
@@ -2014,11 +2009,6 @@ def get_default_grafana_params():
 
 def get_default_tempo_params():
     return {
-        "retention_duration": "12h",
-        "ingestion_rate_limit": 20971520,  # 20MB
-        "ingestion_burst_limit": 52428800,  # 50MB
-        "max_search_duration": "30s",
-        "max_bytes_per_trace": 52428800,  # 50MB
         "min_cpu": 10,
         "max_cpu": 1000,
         "min_mem": 128,

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -341,11 +341,6 @@ SUBCATEGORY_PARAMS = {
         "image",
     ],
     "tempo_params": [
-        "retention_duration",
-        "ingestion_rate_limit",
-        "ingestion_burst_limit",
-        "max_search_duration",
-        "max_bytes_per_trace",
         "min_cpu",
         "max_cpu",
         "min_mem",

--- a/src/tempo/tempo_launcher.star
+++ b/src/tempo/tempo_launcher.star
@@ -146,9 +146,4 @@ def new_config_template_data(tempo_params):
         "GRPCPort": GRPC_PORT_NUMBER,
         "OTLPGRPCPort": OTLP_GRPC_PORT_NUMBER,
         "OTLPHTTPPort": OTLP_HTTP_PORT_NUMBER,
-        "RetentionDuration": tempo_params.retention_duration,
-        "IngestionRateLimit": tempo_params.ingestion_rate_limit,
-        "IngestionBurstLimit": tempo_params.ingestion_burst_limit,
-        "MaxSearchDuration": tempo_params.max_search_duration,
-        "MaxBytesPerTrace": tempo_params.max_bytes_per_trace,
     }

--- a/static_files/tempo-config/tempo.yaml.tmpl
+++ b/static_files/tempo-config/tempo.yaml.tmpl
@@ -1,3 +1,5 @@
+stream_over_http_enabled: true
+
 server:
   http_listen_port: {{ .HTTPPort }}
 
@@ -10,14 +12,6 @@ distributor:
         http:
           endpoint: 0.0.0.0:{{ .OTLPHTTPPort }}
 
-ingester:
-  trace_idle_period: 10s
-  max_block_duration: 5m
-
-compactor:
-  compaction:
-    block_retention: {{ .RetentionDuration }}
-
 storage:
   trace:
     backend: local
@@ -25,5 +19,3 @@ storage:
       path: /tmp/tempo/wal
     local:
       path: /tmp/tempo/traces
-
-stream_over_http_enabled: true


### PR DESCRIPTION
## Summary
- Remove `ingester` and `compactor` blocks from `tempo.yaml.tmpl` — these were removed in Tempo 3.0
- Clean up unused template variables from `tempo_launcher.star`
- Keep image as `grafana/tempo:latest` since config is now 3.0-compatible

## Context
`grafana/tempo:latest` now tracks the `main` branch which includes Tempo 3.0 breaking changes. The new architecture handles ingestion and compaction internally in single-binary mode without needing top-level config sections.

See: https://github.com/grafana/tempo/issues/6384

## Test plan
- [ ] Run a devnet with `tempo` in `additional_services` and verify traces are collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)