### PR TITLE
chore: bump ethereum-genesis-generator to 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:5.3.6
+  image: ethpandaops/ethereum-genesis-generator:6.0.0
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:5.3.6
+  image: ethpandaops/ethereum-genesis-generator:6.0.0
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:5.3.6"
+    "ethpandaops/ethereum-genesis-generator:6.0.0"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -20,7 +20,7 @@ DEFAULT_EL_IMAGES = {
 
 DEFAULT_CL_IMAGES = {
     "lighthouse": "sigp/lighthouse:latest",
-    "teku": "ethpandaops/teku:master",
+    "teku": "consensys/teku:latest",
     "nimbus": "statusim/nimbus-eth2:multiarch-latest",
     "prysm": "offchainlabs/prysm-beacon-chain:stable",
     "lodestar": "chainsafe/lodestar:latest",
@@ -45,7 +45,7 @@ DEFAULT_VC_IMAGES = {
     "lodestar": "chainsafe/lodestar:latest",
     "nimbus": "statusim/nimbus-validator-client:multiarch-latest",
     "prysm": "offchainlabs/prysm-validator:stable",
-    "teku": "ethpandaops/teku:master",
+    "teku": "consensys/teku:latest",
     "grandine": "sifrai/grandine:stable",
     "vero": "ghcr.io/serenita-org/vero:latest",
     "consensoor": "ethpandaops/consensoor:main",


### PR DESCRIPTION
## Summary
- Bump default `ethpandaops/ethereum-genesis-generator` image from `5.3.6` to `6.0.0` (constants, `network_params.yaml`, README example)
- Revert default teku CL and VC image back to `consensys/teku:latest` (was temporarily pointed at `ethpandaops/teku:master` in #1332)

## Test plan
- [ ] `kurtosis run --enclave egg-bump . --args-file network_params.yaml` comes up on all clients
- [ ] Teku participants pull `consensys/teku:latest` by default