### PR TITLE
fix(zkboost): lazy-import launcher to restore compat with older Kurtosis

### DIFF
--- a/main.star
+++ b/main.star
@@ -64,7 +64,6 @@ get_prefunded_accounts = import_module(
 )
 spamoor = import_module("./src/spamoor/spamoor.star")
 slashoor = import_module("./src/slashoor/slashoor_launcher.star")
-zkboost = import_module("./src/zkboost/zkboost_launcher.star")
 
 GRAFANA_USER = "admin"
 GRAFANA_PASSWORD = "admin"
@@ -1048,6 +1047,8 @@ def run(plan, args={}):
             plan.print("Successfully launched slashoor")
         elif additional_service == "zkboost":
             plan.print("Launching zkboost")
+            # Lazy import: zkboost_launcher.star references GpuConfig, which requires Kurtosis >= 1.18.1.
+            zkboost = import_module("./src/zkboost/zkboost_launcher.star")
             zkboost_config_template = read_file(
                 static_files.ZKBOOST_CONFIG_TEMPLATE_FILEPATH
             )


### PR DESCRIPTION
## Summary

- Move `zkboost = import_module("./src/zkboost/zkboost_launcher.star")` from the top of `main.star` into the `elif additional_service == "zkboost":` branch so the file is only loaded when zkboost is enabled.
- Fixes a hard failure on Kurtosis < 1.18.1 for **all** users, regardless of whether they use zkboost.

## Problem

Commit 835dd9b (#1353) introduced `GpuConfig` usage in `src/zkboost/zkboost_launcher.star:272`. `GpuConfig` is a Kurtosis predeclared global added in Kurtosis [1.18.1](https://github.com/kurtosis-tech/kurtosis/releases/tag/1.18.1).

Kurtosis's Starlark resolver checks predeclared names at module load time (per-file, eagerly). Because `main.star` top-level-imports `zkboost_launcher.star` unconditionally, any user on Kurtosis < 1.18.1 now hits:

```
at [src/zkboost/zkboost_launcher.star:272:17]: undefined: GpuConfig (did you mean get_config?)
at [main.star:67:24]: <toplevel>
```

…even when `additional_services` does not contain `zkboost`. This surfaced in [`ethpandaops/syncoor`](https://github.com/ethpandaops/syncoor/blob/master/action.yaml#L242), which still defaults `kurtosis-version: 1.16.6`, breaking all `bal-devnets` syncoor runs.

## Fix

Defer the `import_module()` call for `zkboost_launcher.star` to the only branch that uses it. The module is a function-call-based import in Kurtosis, not a language-level `load`, and is valid inside a function body.

zkboost users still need Kurtosis >= 1.18.1 — that requirement is unchanged. Everyone else is unblocked on older Kurtosis.