### PR TITLE
feat: update `zkboost` usage to `v0.6.0`

### DIFF
--- a/.github/tests/1gpu_zkvm.yaml_norun
+++ b/.github/tests/1gpu_zkvm.yaml_norun
@@ -45,7 +45,7 @@ additional_services:
   - tempo
 
 zkboost_params:
-  image: ghcr.io/eth-act/zkboost/zkboost:0.5.0
+  image: ghcr.io/eth-act/zkboost/zkboost:0.6.0
   env:
     RUST_LOG: info,zkboost=debug
   instances:
@@ -54,15 +54,5 @@ zkboost_params:
   zkvms:
     - kind: ere
       proof_type: reth-zisk
-      image: ghcr.io/eth-act/ere/ere-server-zisk:0.6.1-cuda
-      program_url: https://github.com/eth-act/ere-guests/releases/download/v0.7.0/stateless-validator-reth-zisk
-      port: 3000
       gpu:
         device_ids: ["0"]
-        shm_size: 32768
-        ulimits:
-          memlock: -1
-      env:
-        RUST_LOG: info
-        ERE_ZISK_SETUP_ON_INIT: "1"
-        ERE_ZISK_START_SERVER_TIMEOUT_SEC: "600"

--- a/.github/tests/8gpu_zkvm.yaml_norun
+++ b/.github/tests/8gpu_zkvm.yaml_norun
@@ -53,7 +53,7 @@ additional_services:
   - tempo
 
 zkboost_params:
-  image: ghcr.io/eth-act/zkboost/zkboost:0.5.0
+  image: ghcr.io/eth-act/zkboost/zkboost:0.6.0
   env:
     RUST_LOG: info,zkboost=debug
   instances:
@@ -62,29 +62,9 @@ zkboost_params:
   zkvms:
     - kind: ere
       proof_type: reth-zisk
-      image: ghcr.io/eth-act/ere/ere-server-zisk:0.6.1-cuda
-      program_url: https://github.com/eth-act/ere-guests/releases/download/v0.7.0/stateless-validator-reth-zisk
-      port: 3000
       gpu:
         device_ids: ["0", "1", "2", "3"]
-        shm_size: 32768
-        ulimits:
-          memlock: -1
-      env:
-        RUST_LOG: info
-        ERE_ZISK_SETUP_ON_INIT: "1"
-        ERE_ZISK_START_SERVER_TIMEOUT_SEC: "600"
     - kind: ere
       proof_type: ethrex-zisk
-      image: ghcr.io/eth-act/ere/ere-server-zisk:0.6.1-cuda
-      program_url: https://github.com/eth-act/ere-guests/releases/download/v0.7.0/stateless-validator-ethrex-zisk
-      port: 3000
       gpu:
         device_ids: ["4", "5", "6", "7"]
-        shm_size: 32768
-        ulimits:
-          memlock: -1
-      env:
-        RUST_LOG: info
-        ERE_ZISK_SETUP_ON_INIT: "1"
-        ERE_ZISK_START_SERVER_TIMEOUT_SEC: "600"

--- a/README.md
+++ b/README.md
@@ -1123,10 +1123,11 @@ zkboost_params:
   #   mock_failure: whether to simulate proving failures (default: false)
   #
   # ere-specific fields (only for kind: ere):
-  #   image (required): docker image for the ere-server
-  #   program_url: URL to download the EVM program binary (or use program_path for a path
-  #     already present in the image)
-  #   port: port the ere-server listens on (default 3000)
+  #   image: docker image for the ere-server (default: resolved from zkboost's
+  #     pinned ere version in its Cargo.toml)
+  #   elf_url: HTTPS URL of the guest ELF to prove. ere-server fetches it
+  #     itself at startup. (default: resolved from zkboost's pinned ere-guests
+  #     version).
   #   gpu: GPU configuration (default: no GPU)
   #     count: number of GPUs to allocate (default 0)
   #         NOTE: if more than one ere service uses gpu.count, Docker will assign
@@ -1163,8 +1164,8 @@ zkboost_params:
   #   mock_proving_time: { kind: linear, ms_per_mgas: 150 }
   # - kind: ere
   #   proof_type: reth-zisk
-  #   image: "ghcr.io/eth-act/ere-server-zisk:latest"
-  #   program_url: "https://example.com/reth-zisk.bin"
+  #   image: "ghcr.io/eth-act/ere/ere-server-zisk:latest"
+  #   elf_url: "https://github.com/eth-act/ere-guests/releases/download/v0.8.0/stateless-validator-reth-zisk.elf"
   #   gpu:
   #     count: 1
   #     driver: "nvidia"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -554,20 +554,6 @@ def input_parser(plan, input_args):
                     )
                 )
 
-            if kind == "ere":
-                if "image" not in zkvm:
-                    fail(
-                        "zkboost_params.zkvms[{0}]: ere zkvm requires 'image'".format(
-                            idx
-                        )
-                    )
-                if "program_url" not in zkvm and "program_path" not in zkvm:
-                    fail(
-                        "zkboost_params.zkvms[{0}]: ere zkvm requires 'program_url' or 'program_path'".format(
-                            idx
-                        )
-                    )
-
             if kind == "external":
                 if zkvm.get("endpoint", "") == "":
                     fail(

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -23,10 +23,30 @@ USED_PORTS = {
 }
 
 ERE_SERVER_HTTP_PORT_ID = "http"
-ERE_SERVER_DEFAULT_PORT = 3000
-ERE_SERVER_PROGRAMS_DIRPATH = "/programs"
+ERE_SERVER_PORT = 3000
 ERE_SERVER_READY_TIMEOUT = "600s"
 ERE_SERVER_READY_INTERVAL = "10s"
+
+# Templates for auto-resolving ere-server image and ere-guests ELF URL from the
+# Cargo.toml in zkboost repo, that pins ere and ere-guests version.
+ZKBOOST_CARGO_TOML_FILEPATH = "github.com/eth-act/zkboost/Cargo.toml@{ref}"
+ERE_SERVER_IMAGE_TEMPLATE = (
+    "ghcr.io/eth-act/ere/ere-server-{zkvm_kind}:{version}{suffix}"
+)
+ERE_GUESTS_ELF_URL_TEMPLATE = "https://github.com/eth-act/ere-guests/releases/download/v{version}/stateless-validator-{proof_type}.elf"
+ERE_DEP_NAME = "ere-server-client"
+ERE_GUESTS_DEP_NAME = "ere-guests-stateless-validator-common"
+
+# Default env applied to every `kind: ere` entry.
+ERE_SERVER_DEFAULT_ENV = {"RUST_LOG": "info"}
+
+# ZisK-specific Ere server defaults.
+ZISK_DEFAULT_SHM_SIZE_MIB = 32768
+ZISK_DEFAULT_ULIMITS = {"memlock": -1}
+ZISK_DEFAULT_ENV = {
+    "RUST_LOG": "info,asm_runner=warn,executor=warn,mem_planner_cpp=warn,proofman=warn,rom_setup=warn,sm_rom=warn,zisk=warn",
+    "ERE_ZISK_SETUP_ON_INIT": "1",
+}
 
 
 def launch_zkboost(
@@ -43,20 +63,27 @@ def launch_zkboost(
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
-    # Launch ere-server services once — shared across all zkboost instances.
+    # Launch ere-server services once - shared across all zkboost instances.
     # Each `ere` zkvm entry results in a single long-lived service; all zkboost
     # instances reference it as an endpoint.
+    # `_resolve_image_and_elf_url` fills in `image` and `elf_url` from zkboost's
+    # pinned ere/ere-guests versions when the user didn't provide them.
     ere_server_endpoints = {}
-    for zkvm in zkboost_params.zkvms:
-        if zkvm["kind"] == "ere":
-            proof_type = zkvm["proof_type"]
-            if proof_type not in ere_server_endpoints:
-                endpoint = _launch_ere_server(
-                    plan, zkvm, global_node_selectors, tolerations
-                )
-                ere_server_endpoints[proof_type] = endpoint
-
     metrics_jobs = []
+    for zkvm in _resolve_image_and_elf_url(zkboost_params.zkvms, zkboost_params.image):
+        if zkvm["kind"] != "ere":
+            continue
+
+        proof_type = zkvm["proof_type"]
+        if proof_type in ere_server_endpoints:
+            continue
+
+        endpoint = _launch_ere_server(
+            plan, zkvm, global_node_selectors, tolerations, tempo_otlp_grpc_url
+        )
+        ere_server_endpoints[proof_type] = endpoint
+        metrics_jobs.append(_get_ere_server_metrics_job(proof_type))
+
     for instance_index, instance in enumerate(zkboost_params.instances):
         name = instance["name"]
         el_participant_index = instance["el_participant_index"]
@@ -214,67 +241,60 @@ def get_config(
     )
 
 
-def _launch_ere_server(plan, zkvm, global_node_selectors, tolerations):
-    """Launch an ere-server-zisk GPU prover service and return its HTTP endpoint.
-
-    If 'program_url' is specified, the program binary is downloaded via a
-    preparation task and mounted into the service at ERE_SERVER_PROGRAMS_DIRPATH.
-    """
+def _launch_ere_server(
+    plan, zkvm, global_node_selectors, tolerations, tempo_otlp_grpc_url
+):
+    """Launch an ere-server prover service and return its HTTP endpoint."""
     proof_type = zkvm["proof_type"]
     service_name = "ere-server-{0}".format(proof_type)
-    port = zkvm.get("port", ERE_SERVER_DEFAULT_PORT)
+    zkvm_kind = _zkvm_kind_from_proof_type(proof_type)
 
-    # Download program binary if a URL is provided
-    files = {}
-    if "program_url" in zkvm:
-        program_url = zkvm["program_url"]
-        binary_name = program_url.split("/")[-1]
-        artifact_name = service_name + "-program"
-        plan.run_sh(
-            name="download-" + service_name,
-            description="Downloading {0} program binary".format(proof_type),
-            run="mkdir -p /programs && wget -q -O /programs/{0} {1} && chmod +x /programs/{0}".format(
-                binary_name, program_url
-            ),
-            image="alpine:latest",
-            store=[StoreSpec(src="/programs", name=artifact_name)],
-        )
-        files[ERE_SERVER_PROGRAMS_DIRPATH] = artifact_name
-        program_path = "{0}/{1}".format(ERE_SERVER_PROGRAMS_DIRPATH, binary_name)
-    else:
-        program_path = zkvm.get("program_path", "")
-        if program_path == "":
-            fail(
-                "ere zkvm '{0}' requires either 'program_url' or 'program_path'".format(
-                    proof_type
-                )
-            )
+    gpu = dict(zkvm.get("gpu", {}))
+    has_gpu = _zkvm_has_gpu(zkvm)
+    if zkvm_kind == "zisk":
+        if "shm_size" not in gpu:
+            gpu["shm_size"] = ZISK_DEFAULT_SHM_SIZE_MIB
+        if "ulimits" not in gpu:
+            gpu["ulimits"] = dict(ZISK_DEFAULT_ULIMITS)
 
     used_ports = {
         ERE_SERVER_HTTP_PORT_ID: shared_utils.new_port_spec(
-            port,
+            ERE_SERVER_PORT,
             shared_utils.TCP_PROTOCOL,
             shared_utils.HTTP_APPLICATION_PROTOCOL,
             wait=None,
         )
     }
 
-    env_vars = dict(zkvm.get("env", {}))
+    env_vars = dict(ERE_SERVER_DEFAULT_ENV)
+    if zkvm_kind == "zisk":
+        for key, value in ZISK_DEFAULT_ENV.items():
+            env_vars[key] = value
+    for key, value in zkvm.get("env", {}).items():
+        env_vars[key] = value
+    if tempo_otlp_grpc_url != None:
+        env_vars["OTEL_EXPORTER_OTLP_ENDPOINT"] = tempo_otlp_grpc_url
+        env_vars["OTEL_SERVICE_NAME"] = service_name
 
     plan.add_service(
         name=service_name,
         config=ServiceConfig(
             image=zkvm["image"],
             ports=used_ports,
-            files=files,
-            cmd=["--port", "{0}".format(port), "--program-path", program_path, "gpu"],
+            cmd=[
+                "--port",
+                "{0}".format(ERE_SERVER_PORT),
+                "--elf-url",
+                zkvm["elf_url"],
+                "gpu" if has_gpu else "cpu",
+            ],
             env_vars=env_vars,
             gpu=GpuConfig(
-                count=zkvm.get("gpu", {}).get("count", 0),
-                device_ids=zkvm.get("gpu", {}).get("device_ids", []),
-                shm_size=zkvm.get("gpu", {}).get("shm_size", 0),
-                ulimits=zkvm.get("gpu", {}).get("ulimits", {}),
-                driver=zkvm.get("gpu", {}).get("driver", "nvidia"),
+                count=gpu.get("count", 0),
+                device_ids=gpu.get("device_ids", []),
+                shm_size=gpu.get("shm_size", 0),
+                ulimits=gpu.get("ulimits", {}),
+                driver=gpu.get("driver", "nvidia"),
             ),
             node_selectors=global_node_selectors,
             tolerations=tolerations,
@@ -292,4 +312,209 @@ def _launch_ere_server(plan, zkvm, global_node_selectors, tolerations):
         ),
     )
 
-    return "http://{0}:{1}".format(service_name, port)
+    return "http://{0}:{1}".format(service_name, ERE_SERVER_PORT)
+
+
+def _zkvm_has_gpu(zkvm):
+    gpu = zkvm.get("gpu", {})
+    return len(gpu.get("device_ids", [])) > 0 or gpu.get("count", 0) > 0
+
+
+def _zkvm_kind_from_proof_type(proof_type):
+    """Derive the zkVM backend (e.g. `zisk`, `openvm`) from `proof_type` (e.g.
+    `ethrex-zisk`, `reth-openvm`).
+    """
+    return proof_type.split("-")[-1]
+
+
+def _resolve_image_and_elf_url(zkvms, zkboost_image):
+    """Return a new zkvms list where every `kind: ere` entry is guaranteed to
+    have `image` and `elf_url` set. Missing fields are resolved from zkboost's
+    Cargo.toml pinned ere/ere-guests versions.
+
+    Fails when an auto-resolve is required but the corresponding dep isn't
+    tag-pinned in zkboost (uses branch or rev), in which case the user must set
+    the field explicitly.
+    """
+    if not any(
+        [
+            zkvm["kind"] == "ere" and ("image" not in zkvm or "elf_url" not in zkvm)
+            for zkvm in zkvms
+        ]
+    ):
+        return zkvms
+
+    ere_version, ere_guests_version = _resolve_ere_versions(zkboost_image)
+
+    resolved = []
+    for zkvm in zkvms:
+        if zkvm["kind"] != "ere":
+            resolved.append(zkvm)
+            continue
+        zkvm = dict(zkvm)
+        proof_type = zkvm["proof_type"]
+        zkvm_kind = _zkvm_kind_from_proof_type(proof_type)
+
+        if "image" not in zkvm:
+            zkvm["image"] = ERE_SERVER_IMAGE_TEMPLATE.format(
+                zkvm_kind=zkvm_kind,
+                version=ere_version,
+                suffix="-cuda" if _zkvm_has_gpu(zkvm) else "",
+            )
+        if "elf_url" not in zkvm:
+            zkvm["elf_url"] = ERE_GUESTS_ELF_URL_TEMPLATE.format(
+                version=ere_guests_version,
+                proof_type=proof_type,
+            )
+        resolved.append(zkvm)
+    return resolved
+
+
+def _resolve_ere_versions(zkboost_image):
+    """Resolve ere and ere-guests versions from zkboost's Cargo.toml at the git
+    ref matching the zkboost image tag.
+
+    Auto-resolution is supported for the zkboost image:
+      - `ghcr.io/eth-act/zkboost/zkboost` and
+        `ghcr.io/eth-act/zkboost/zkboost:latest` -> `Cargo.toml@vX.Y.Z`
+          where `X.Y.Z` is resolved from `workspace.package.version` of
+          `Cargo.toml@master`.
+      - `ghcr.io/eth-act/zkboost/zkboost:X.Y.Z` -> `Cargo.toml@vX.Y.Z`
+      - `ghcr.io/eth-act/zkboost/zkboost:<sha:7>` -> `Cargo.toml@<sha:7>`
+          where `<sha:7>` is the 7 characters lowercase hex git commit SHA.
+
+    Any other image (different registry, fork, pre-release tag, etc.) cannot
+    be guaranteed to match a specific Cargo.toml revision, so the user must
+    set `image` and `elf_url` explicitly on each ere zkvm entry.
+    """
+    image_base = constants.DEFAULT_ZKBOOST_IMAGE.split(":")[0]
+    if zkboost_image == image_base:
+        image_tag = "latest"
+    elif zkboost_image.startswith(image_base + ":"):
+        image_tag = zkboost_image[len(image_base) + 1 :]
+    else:
+        _fail_resolve_ere_versions(
+            "zkboost_params.image '{image}' is not the official zkboost image. Auto-resolution is only supported for `{official}` with no tag, `:latest`, `:X.Y.Z`, or `:<sha:7>`".format(
+                image=zkboost_image,
+                official=image_base,
+            )
+        )
+
+    if image_tag == "latest":
+        cargo_toml = read_file(ZKBOOST_CARGO_TOML_FILEPATH.format(ref="master"))
+        version = _parse_cargo_workspace_version(cargo_toml)
+        if version == None:
+            _fail_resolve_ere_versions(
+                "cannot locate `workspace.package.version` in zkboost's master Cargo.toml to resolve `:latest`",
+            )
+        ref = "v" + version
+    elif _is_semver(image_tag):
+        ref = "v" + image_tag
+    elif _is_git_sha(image_tag):
+        ref = image_tag
+    else:
+        _fail_resolve_ere_versions(
+            "zkboost_params.image tag '{image_tag}' is not `latest`, `X.Y.Z`, or a git commit SHA (7 lowercase hex chars)".format(
+                image_tag=image_tag,
+            ),
+        )
+
+    cargo_toml = read_file(ZKBOOST_CARGO_TOML_FILEPATH.format(ref=ref))
+    ere_version = _parse_cargo_dependency_version(cargo_toml, ERE_DEP_NAME)
+    if ere_version == None:
+        _fail_resolve_ere_versions(
+            "`{dep}` is not tag-pinned in zkboost's Cargo.toml@{ref}".format(
+                dep=ERE_DEP_NAME,
+                ref=ref,
+            ),
+        )
+    ere_guests_version = _parse_cargo_dependency_version(
+        cargo_toml, ERE_GUESTS_DEP_NAME
+    )
+    if ere_guests_version == None:
+        _fail_resolve_ere_versions(
+            "`{dep}` is not tag-pinned in zkboost's Cargo.toml@{ref}".format(
+                dep=ERE_GUESTS_DEP_NAME,
+                ref=ref,
+            ),
+        )
+    return ere_version, ere_guests_version
+
+
+def _fail_resolve_ere_versions(reason):
+    fail(
+        reason
+        + ". Set `image` and `elf_url` explicitly on each `kind: ere` zkvm entry to skip auto-resolution."
+    )
+
+
+def _is_semver(image_tag):
+    digits = image_tag.split(".")
+    return len(digits) == 3 and all([digit.isdigit() for digit in digits])
+
+
+def _is_git_sha(image_tag):
+    return len(image_tag) >= 7 and all(
+        [char in "0123456789abcdef" for char in image_tag.elems()]
+    )
+
+
+def _parse_cargo_workspace_version(cargo_toml):
+    """Return the value of `version` under the `[workspace.package]` table, or
+    `None` if not found. Stops at the next `[section]` header so it won't leak
+    into other tables.
+    """
+    tokens = [token.strip(",").strip('"') for token in cargo_toml.split()]
+    for i in range(len(tokens)):
+        if tokens[i] != "[workspace.package]":
+            continue
+        for j in range(i + 1, len(tokens) - 2):
+            if tokens[j].startswith("[") and tokens[j].endswith("]"):
+                return None
+            if tokens[j] == "version" and tokens[j + 1] == "=":
+                return tokens[j + 2]
+        return None
+    return None
+
+
+def _parse_cargo_dependency_version(cargo_toml, dependency):
+    """Return the version pinned by `<dependency> = { ..., tag = "vX.Y.Z", ... }`
+    in cargo_toml, with the leading `v` stripped.
+    """
+    tokens = [token.strip(",").strip('"') for token in cargo_toml.split()]
+    for i in range(len(tokens) - 2):
+        if tokens[i] != dependency or tokens[i + 1] != "=" or tokens[i + 2] != "{":
+            continue
+        depth = 1
+        for j in range(i + 3, len(tokens)):
+            if tokens[j] == "{":
+                depth += 1
+            elif tokens[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            elif (
+                depth == 1
+                and tokens[j] == "tag"
+                and j + 2 < len(tokens)
+                and tokens[j + 1] == "="
+                and tokens[j + 2].startswith("v")
+            ):
+                return tokens[j + 2][1:]
+        return None
+    return None
+
+
+def _get_ere_server_metrics_job(proof_type):
+    service_name = "ere-server-{0}".format(proof_type)
+    return {
+        "Name": service_name,
+        "Endpoint": "{0}:{1}".format(service_name, ERE_SERVER_PORT),
+        "MetricsPath": "/metrics",
+        "Labels": {
+            "service": service_name,
+            "client_type": "ere-server",
+            "proof_type": proof_type,
+        },
+        "ScrapeInterval": "15s",
+    }

--- a/static_files/grafana-config/dashboards/zkboost/zkboost.json
+++ b/static_files/grafana-config/dashboards/zkboost/zkboost.json
@@ -2064,7 +2064,7 @@
           },
           "limit": 500,
           "metricsQueryType": "range",
-          "query": "{resource.service.name=\"zkboost\" && name=~\"request_proof\"} | select(span.block_number, span.gas_used, span.timestamp)",
+          "query": "{resource.service.name=~\"$service\" && name=~\"request_proof\"} | select(span.block_number, span.gas_used, span.timestamp)",
           "queryType": "traceql",
           "refId": "A",
           "serviceMapUseNativeHistograms": false,


### PR DESCRIPTION
- Fix the grafana dashbaord proof trace panel
- Update launcher to adapt to `zkboost@v0.6.0` configuration
  - Update `--program-path` to use `--elf-path`
  - Since `ere-server` supports `--elf-url` now, downloading program `run_sh` is removed
  - Remove `--elf-path` since I don't see a simple approach in `kurtosis` CLI to upload a local ELF file (outside of `ethereum-package`)
- Auto resoluation of `ere` and `ere-guests` versions
  When `zkvm.kind = ere` without the `image` or `elf_url`, it resolves the version by checking the `Cargo.toml` of zkboost repo at the revision of the zkboost image, and fill in the fields by:
  - `image`: `ghcr.io/eth-act/ere/ere-server-{zkvm_kind}:{ere_version}{suffix}` (suffix is `-cuda` if GPU configured)
  - `elf_url`: `https://github.com/eth-act/ere-guests/releases/download/v{ere_guests_version}/stateless-validator-{proof_type}.elf`
- Add default configuration for ZisK proof types (`shm_size`, `ulimits`, and `envs`)
