### PR TITLE
chore: bump ethereum-genesis-generator to 6.0.2

### DIFF
--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.0.1
+  image: ethpandaops/ethereum-genesis-generator:6.0.2
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.0.1"
+    "ethpandaops/ethereum-genesis-generator:6.0.2"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
## Summary

Bump `ethpandaops/ethereum-genesis-generator` from `6.0.1` → `6.0.2`.

Release: https://github.com/ethpandaops/ethereum-genesis-generator/releases/tag/v6.0.2

Picks up the Nethermind chainspec transition timestamps for two bal-devnet-4 EIPs at the Gloas/Amsterdam fork:

- EIP-7976 — Increase Calldata Floor Cost (64/64)
- EIP-7981 — Increase Access List Cost

Without these fields in the generated chainspec, Nethermind runs Amsterdam without the new calldata-floor and access-list gas rules and diverges from clients (e.g. geth) that activate both EIPs at the Amsterdam fork timestamp.

Upstream PR: ethpandaops/ethereum-genesis-generator#286

## Test plan

- [ ] Boot a Kurtosis devnet-4 (lighthouse + nethermind) with the bumped image and confirm no consensus divergence against geth across the Amsterdam fork boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)