### PR TITLE
fix: request both(reth-zisk and ethrex-zisk) configured proof types

### DIFF
--- a/.github/tests/8gpu_zkvm.yaml_norun
+++ b/.github/tests/8gpu_zkvm.yaml_norun
@@ -19,10 +19,10 @@ participants:
     cl_extra_params:
       - --target-peers=3
       - --proof-engine-endpoint=http://zkboost-1:3000
-      - --proof-types=6
+      - --proof-types=2,6
     vc_extra_params:
       - --proof-engine-endpoint=http://zkboost-1:3000
-      - --proof-types=6
+      - --proof-types=2,6
     count: 2
   - cl_type: lighthouse
     cl_image: ethpandaops/lighthouse:eth-act-optional-proofs


### PR DESCRIPTION
## Description

- Fix 8-GPU zkboost config to request both configured proof types (ethrex-zisk and reth-zisk)
- Previously only proof-type 6 (reth-zisk) was requested, leaving GPUs 4-7 (ethrex-zisk) unused

## Testing
  - [x] Run with `kurtosis run --enclave eip8025-8gpu . --args-file .github/tests/8gpu_zkvm.yaml_norun`
  - [x] Verify both ere-server instances receive prove requests
  - [x] Confirm proofs from both proof types appear in zkboost logs