### PR TITLE
feat(prysm): default --p2p-max-peers to participant count

### DIFF
--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -72,6 +72,7 @@ def launch(
             "launcher": prysm.new_prysm_launcher(
                 el_cl_data,
                 jwt_file,
+                num_participants,
             ),
             "launch_method": prysm.launch,
             "get_beacon_config": prysm.get_beacon_config,

--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -219,6 +219,7 @@ def get_beacon_config(
         "--p2p-udp-port={0}".format(discovery_port_udp),
         "--p2p-quic-port={0}".format(discovery_port_quic),
         "--min-sync-peers={0}".format(constants.MIN_PEERS),
+        "--p2p-max-peers={0}".format(launcher.num_participants),
         "--verbosity=" + log_level,
         "--slots-per-archive-point={0}".format(32 if constants.ARCHIVE_MODE else 8192),
         "--suggested-fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
@@ -455,10 +456,12 @@ def get_cl_context(
 def new_prysm_launcher(
     el_cl_genesis_data,
     jwt_file,
+    num_participants,
 ):
     return struct(
         el_cl_genesis_data=el_cl_genesis_data,
         jwt_file=jwt_file,
+        num_participants=num_participants,
     )
 
 


### PR DESCRIPTION
## Summary
- Set Prysm beacon's `--p2p-max-peers` to the total number of CL participants so the peer cap scales with the kurtosis network size without manual `cl_extra_params` tuning.
- Plumb `num_participants` through `new_prysm_launcher` so it's available inside `get_beacon_config`.

## Test plan
- [ ] Spin up a multi-participant network including a Prysm node and verify `--p2p-max-peers=<num_participants>` appears in its launch cmd.
- [ ] Confirm Prysm starts cleanly and peers up across a small (e.g. 2-3) and larger (e.g. 8+) participant set.
- [ ] Verify other CL clients (lighthouse/teku/nimbus/lodestar/grandine) are unaffected.