### PR TITLE
chore: bump ethereum-genesis-generator to 6.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,7 +1566,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.0.2
+  image: ethpandaops/ethereum-genesis-generator:6.0.4
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.0.2
+  image: ethpandaops/ethereum-genesis-generator:6.0.4
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.0.2"
+    "ethpandaops/ethereum-genesis-generator:6.0.4"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
## Summary
Bumps the default \`ethereum-genesis-generator\` image from \`6.0.2\` → \`6.0.4\` everywhere it's pinned:

- \`src/package_io/constants.star\` — runtime default
- \`network_params.yaml\` — example user config
- \`README.md\` — documented default

## What's in 6.0.4
- Pins \`eth-beacon-genesis\` to v0.0.2 ([egg #288](https://github.com/ethpandaops/ethereum-genesis-generator/pull/288)).
- v0.0.2 brings minimal-preset \`PTC_SIZE: 2 → 16\` (matching consensus-specs alpha 6 [#5177](https://github.com/ethereum/consensus-specs/pull/5177)) and a \`go-eth2-client\` v0.1.0 → v0.1.1 bump.

## Test plan
- [ ] Wait for \`ethpandaops/ethereum-genesis-generator:6.0.4\` to be published before merging.
- [ ] Spin up a minimal-preset Gloas devnet via this branch and confirm the genesis state encodes \`PTC_SIZE = 16\`.