### PR TITLE
chore: bump ethereum-genesis-generator to 6.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,7 +1566,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.0.4
+  image: ethpandaops/ethereum-genesis-generator:6.0.5
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.0.4
+  image: ethpandaops/ethereum-genesis-generator:6.0.5
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.0.4"
+    "ethpandaops/ethereum-genesis-generator:6.0.5"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
## Summary

Bumps the default `ethpandaops/ethereum-genesis-generator` image from `6.0.4` to `6.0.5` in `src/package_io/constants.star`, `network_params.yaml`, and the README example.

6.0.5 picks up the consensus-specs `v1.7.0-alpha.7` config sync (see ethpandaops/ethereum-genesis-generator#289).

## Test plan
- [ ] `kurtosis run --enclave egg-bump .` with default network params boots successfully on the new image