### PR TITLE
chore: bump ethereum-genesis-generator to 6.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1566,7 +1566,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.0.5
+  image: ethpandaops/ethereum-genesis-generator:6.0.6
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -256,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.0.5
+  image: ethpandaops/ethereum-genesis-generator:6.0.6
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.0.5"
+    "ethpandaops/ethereum-genesis-generator:6.0.6"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2059,19 +2059,19 @@ def get_default_spamoor_params():
                     "base_fee": 20,
                 },
             },
-            # {
-            #     "name": "Blob Spammer (Kurtosis Package)",
-            #     "description": "3 type-4 blob transactions per slot with 1-2 sidecars each, gas/blobgas limit 20 gwei",
-            #     "scenario": "blob-combined",
-            #     "config": {
-            #         "throughput": 3,
-            #         "sidecars": 2,
-            #         "max_pending": 6,
-            #         "max_wallets": 20,
-            #         "base_fee": 20,
-            #         "blob_fee": 20,
-            #     },
-            # },
+            {
+                "name": "Blob Spammer (Kurtosis Package)",
+                "description": "3 type-4 blob transactions per slot with 1-2 sidecars each, gas/blobgas limit 20 gwei",
+                "scenario": "blob-combined",
+                "config": {
+                    "throughput": 6,
+                    "sidecars": 2,
+                    "max_pending": 6,
+                    "max_wallets": 20,
+                    "base_fee": 20,
+                    "blob_fee": 20,
+                },
+            },
         ],
     }
 


### PR DESCRIPTION
## Summary
- Bump `ethpandaops/ethereum-genesis-generator` from `6.0.5` to `6.0.6` in `src/package_io/constants.star`, `network_params.yaml`, and `README.md`.

## Test plan
- [x] CI green