### PR TITLE
feat(spamoor): expose full participant name as a client_group

### DIFF
--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -208,12 +208,11 @@ def new_hosts_template_data(
             index + 1, len(str(len(participant_contexts)))
         )
         rpchost = (
-            "group({0},{1},{2},{1}-{2}-{4})name({3})".format(
+            "group({0},{1},{2},{1}-{2}-{0})name({3})".format(
                 index_str,
                 cl_client.client_name,
                 el_client.client_name,
                 full_name,
-                index + 1,
             )
             + rpchost
         )

--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -208,11 +208,12 @@ def new_hosts_template_data(
             index + 1, len(str(len(participant_contexts)))
         )
         rpchost = (
-            "group({0},{1},{2})name({3})".format(
+            "group({0},{1},{2},{1}-{2}-{4})name({3})".format(
                 index_str,
                 cl_client.client_name,
                 el_client.client_name,
                 full_name,
+                index + 1,
             )
             + rpchost
         )

--- a/src/spamoor/spamoor.star
+++ b/src/spamoor/spamoor.star
@@ -208,7 +208,7 @@ def new_hosts_template_data(
             index + 1, len(str(len(participant_contexts)))
         )
         rpchost = (
-            "group({0},{1},{2},{1}-{2}-{0})name({3})".format(
+            "group({0},{1},{2},{1}-{2}-{0},{3})name({3})".format(
                 index_str,
                 cl_client.client_name,
                 el_client.client_name,


### PR DESCRIPTION
## Summary
- Add the participant identifier `<cl>-<el>-<index>` (e.g. `prysm-geth-1`) as an additional `group(...)` entry in the spamoor `rpc-hosts.txt`, so spammer configs can target a single node via `client_group` rather than only the broader `<index>`, `<cl>`, or `<el>` groups.
- Index padding is shared with the existing `name(full_name)` via `zfill_custom` — unpadded for <10 participants (`prysm-geth-1`), padded once we cross that threshold (`prysm-geth-01`).

Example:
```yaml
spamoor_params:
  image: ethpandaops/spamoor:master
  spammers:
    - scenario: eoatx
      config:
        throughput: 100
        client_group: prysm-geth-1
```

## Test plan
- [ ] Spin up a 2-participant devnet (prysm-geth, lighthouse-geth) and confirm `rpc-hosts.txt` contains `group(...,prysm-geth-1)` / `group(...,lighthouse-geth-2)`.
- [ ] Run a spammer with `client_group: prysm-geth-1` and verify it only hits that node's RPC.
- [ ] Run a 10+ participant setup and confirm padded form (`prysm-geth-01`).