### PR TITLE
feat(ethrex): set default --http.api namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ participants:
     # - reth: ghcr.io/paradigmxyz/reth
     # - ethereumjs: ethpandaops/ethereumjs:master
     # - nimbus-eth1: statusim/nimbus-eth1:master
-    # - ethrex: ghcr.io/lambdaclass/ethrex:latest
+    # - ethrex: ethpandaops/ethrex:main
     el_image: ""
 
     # Path to a local EL binary to inject into the container (Docker only)

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -162,6 +162,7 @@ def get_config(
         "--log.level={0}".format(VERBOSITY_LEVELS[global_log_level]),
         "--http.port={0}".format(RPC_PORT_NUM),
         "--http.addr=0.0.0.0",
+        "--http.api=eth,net,web3,debug,admin,txpool",
         "--authrpc.port={0}".format(ENGINE_RPC_PORT_NUM),
         "--authrpc.jwtsecret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--authrpc.addr=0.0.0.0",

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -14,7 +14,7 @@ DEFAULT_EL_IMAGES = {
     "reth": "ghcr.io/paradigmxyz/reth",
     "ethereumjs": "ethpandaops/ethereumjs:master",
     "nimbus": "statusim/nimbus-eth1:master",
-    "ethrex": "ghcr.io/lambdaclass/ethrex:latest",
+    "ethrex": "ethpandaops/ethrex:main",
 }
 
 DEFAULT_CL_IMAGES = {


### PR DESCRIPTION
Waiting on ethrex team's approval when to merge this. 

## Summary
- Add `--http.api=eth,net,web3,debug,admin,txpool` to the ethrex launcher's default cmd so HTTP RPC exposes the same namespace set we already enable for the other EL clients (geth/reth/besu/erigon/nethermind).

## Test plan
- [x] Spin up a devnet with `el_type: ethrex` and confirm `eth_*`, `net_*`, `web3_*`, `debug_*`, `admin_*`, and `txpool_*` JSON-RPC methods respond over HTTP.