### PR TITLE
feat: sync CL config with consensus-specs v1.7.0-alpha.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,10 @@ network_params:
   # Defaults to 5000 basis points (50% of slot duration)
   contribution_due_bps_gloas: 5000
 
+  # Payload availability deadline for Gloas fork
+  # Defaults to 7500 basis points (75% of slot duration)
+  payload_due_bps: 7500
+
   # Payload attestation due timing for Gloas fork
   # Defaults to 7500 basis points (75% of slot duration)
   payload_attestation_due_bps: 7500
@@ -823,8 +827,8 @@ network_params:
   min_validator_withdrawability_delay: 256
 
   # The minimum number of epochs for builder withdrawability delay
-  # Defaults to 4096, 8 for minimal preset
-  min_builder_withdrawability_delay: 4096
+  # Defaults to 8192, 2 for minimal preset
+  min_builder_withdrawability_delay: 8192
 
   # The period of the shard committee
   # Defaults to 256 epoch ~27 hours

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -102,6 +102,7 @@ network_params:
   aggregate_due_bps_gloas: 5000
   sync_message_due_bps_gloas: 2500
   contribution_due_bps_gloas: 5000
+  payload_due_bps: 7500
   payload_attestation_due_bps: 7500
   view_freeze_cutoff_bps: 7500
   inclusion_list_submission_due_bps: 6667
@@ -255,7 +256,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.0.6
+  image: ethpandaops/ethereum-genesis-generator:6.0.7
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -108,7 +108,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.0.6"
+    "ethpandaops/ethereum-genesis-generator:6.0.7"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -772,6 +772,7 @@ def input_parser(plan, input_args):
             contribution_due_bps_gloas=result["network_params"][
                 "contribution_due_bps_gloas"
             ],
+            payload_due_bps=result["network_params"]["payload_due_bps"],
             payload_attestation_due_bps=result["network_params"][
                 "payload_attestation_due_bps"
             ],
@@ -1608,12 +1609,13 @@ def default_network_params():
         "ejection_balance": 16000000000,
         "eth1_follow_distance": 2048,
         "min_validator_withdrawability_delay": 256,
-        "min_builder_withdrawability_delay": 64,
+        "min_builder_withdrawability_delay": 8192,
         "shard_committee_period": 256,
         "attestation_due_bps_gloas": 2500,
         "aggregate_due_bps_gloas": 5000,
         "sync_message_due_bps_gloas": 2500,
         "contribution_due_bps_gloas": 5000,
+        "payload_due_bps": 7500,
         "payload_attestation_due_bps": 7500,
         "view_freeze_cutoff_bps": 7500,
         "inclusion_list_submission_due_bps": 6667,
@@ -1697,6 +1699,7 @@ def default_minimal_network_params():
         "aggregate_due_bps_gloas": 5000,
         "sync_message_due_bps_gloas": 2500,
         "contribution_due_bps_gloas": 5000,
+        "payload_due_bps": 7500,
         "payload_attestation_due_bps": 7500,
         "view_freeze_cutoff_bps": 7500,
         "inclusion_list_submission_due_bps": 6667,

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -238,6 +238,7 @@ SUBCATEGORY_PARAMS = {
         "aggregate_due_bps_gloas",
         "sync_message_due_bps_gloas",
         "contribution_due_bps_gloas",
+        "payload_due_bps",
         "payload_attestation_due_bps",
         "view_freeze_cutoff_bps",
         "inclusion_list_submission_due_bps",

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -181,6 +181,7 @@ def new_env_file_for_el_cl_genesis_data(
         "AggregateDueBpsGloas": network_params.aggregate_due_bps_gloas,
         "SyncMessageDueBpsGloas": network_params.sync_message_due_bps_gloas,
         "ContributionDueBpsGloas": network_params.contribution_due_bps_gloas,
+        "PayloadDueBps": network_params.payload_due_bps,
         "PayloadAttestationDueBps": network_params.payload_attestation_due_bps,
         "ViewFreezeCutoffBps": network_params.view_freeze_cutoff_bps,
         "InclusionListSubmissionDueBps": network_params.inclusion_list_submission_due_bps,

--- a/static_files/genesis-generation-config/el-cl/values.env.tmpl
+++ b/static_files/genesis-generation-config/el-cl/values.env.tmpl
@@ -43,6 +43,7 @@ export ATTESTATION_DUE_BPS_GLOAS={{ .AttestationDueBpsGloas }}
 export AGGREGATE_DUE_BPS_GLOAS={{ .AggregateDueBpsGloas }}
 export SYNC_MESSAGE_DUE_BPS_GLOAS={{ .SyncMessageDueBpsGloas }}
 export CONTRIBUTION_DUE_BPS_GLOAS={{ .ContributionDueBpsGloas }}
+export PAYLOAD_DUE_BPS={{ .PayloadDueBps }}
 export PAYLOAD_ATTESTATION_DUE_BPS={{ .PayloadAttestationDueBps }}
 export VIEW_FREEZE_CUTOFF_BPS={{ .ViewFreezeCutoffBps }}
 export INCLUSION_LIST_SUBMISSION_DUE_BPS={{ .InclusionListSubmissionDueBps }}


### PR DESCRIPTION
## Summary

Mirrors [ethpandaops/ethereum-genesis-generator#293](https://github.com/ethpandaops/ethereum-genesis-generator/pull/293) and brings the package in line with consensus-specs `v1.7.0-alpha.8` ([release notes](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.8)).

Only two upstream changes touch the YAML configs:

- **`MIN_BUILDER_WITHDRAWABILITY_DELAY`** — mainnet default raised from `64` to `8192` epochs ([consensus-specs#5223](https://github.com/ethereum/consensus-specs/pull/5223)). Minimal preset stays at `2`. The README docs were already drifted (said `4096`), so they're corrected here too.
- **`PAYLOAD_DUE_BPS`** — new field, `7500` bps in both presets ([consensus-specs#5212](https://github.com/ethereum/consensus-specs/pull/5212), _Introduce separate payload availability deadline_). Added as a configurable `network_params` entry (default `7500`) so devnets can override it.

Also bumps the default ethereum-genesis-generator image from `6.0.6` to `6.0.7` (the patch release that carries the upstream changes).

## Test plan
- [x] `kurtosis run --enclave alpha8 . --args-file gloas_genesis.yaml` — confirm the rendered CL config contains the new `PAYLOAD_DUE_BPS: 7500` and `MIN_BUILDER_WITHDRAWABILITY_DELAY: 8192`
- [x] Validate that omitting `payload_due_bps` from a user-provided network_params still works (default fallback)
- [x] Validate that overriding `payload_due_bps` in network_params propagates into the rendered config