### PR TITLE
fix(zkboost): fill mock_proving_time defaults from slot duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,8 +1226,8 @@ zkboost_params:
     - name: zkboost
       el_participant_index: 0
   # List of zkVM backend configurations.
-  # If empty or not set, the default shown below (a mock reth-zisk zkvm) is
-  # auto-configured. Each entry must have a unique proof_type.
+  # If empty or not set, a mock reth-zisk zkvm is auto-configured with
+  # random timing scaled to slot duration. Each entry must have a unique proof_type.
   #
   # Common fields for all entries:
   #   kind (required): the zkVM backend type
@@ -1236,13 +1236,13 @@ zkboost_params:
   #     "external" - connects to an already-deployed prover via HTTP
   #   proof_type (required): identifies the EL client + zkVM combination
   #     "ethrex-risc0", "ethrex-sp1", "ethrex-zisk", "reth-openvm", "reth-risc0", "reth-sp1", "reth-zisk"
-  #   proof_timeout_secs: timeout for proof generation in seconds (default: 12, must be > 0)
+  #   proof_timeout_secs: timeout for proof generation in seconds (default: 3/4 of slot duration, must be > 0)
   #
   # Mock-specific fields (only for kind: mock):
-  #   mock_proving_time: controls simulated proving duration (default: { kind: constant, ms: 6000 })
-  #     { kind: constant, ms: <ms> }                   - fixed duration
-  #     { kind: random, min_ms: <min>, max_ms: <max> } - uniformly random, min_ms must be <= max_ms
-  #     { kind: linear, ms_per_mgas: <ms> }            - proportional to block per million gas usage
+  #   mock_proving_time: controls simulated proving duration
+  #     { kind: constant, ms: <ms> }                   - fixed duration (default: 2/3 of slot_duration_ms)
+  #     { kind: random, min_ms: <min>, max_ms: <max> } - uniformly random (defaults: min=1/3, max=4/3 of slot)
+  #     { kind: linear, ms_per_mgas: <ms> }            - proportional to block gas (default: 150 ms/Mgas)
   #   mock_proof_size: simulated proof size in bytes, must be >= 32 (default: 131072 / 128 KiB)
   #   mock_failure: whether to simulate proving failures (default: false)
   #

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -500,14 +500,15 @@ def input_parser(plan, input_args):
 
         # Inject default mock zkvm if none configured globally or per instance.
         if len(result["zkboost_params"]["zkvms"]) == 0 and not has_instance_zkvms:
+            default_ms = result["network_params"]["slot_duration_ms"] * 2 // 3
             result["zkboost_params"]["zkvms"] = [
                 {
                     "kind": "mock",
                     "proof_type": "reth-zisk",
                     "mock_proving_time": {
                         "kind": "random",
-                        "min_ms": 2000,
-                        "max_ms": 8000,
+                        "min_ms": default_ms // 2,
+                        "max_ms": default_ms * 2,
                     },
                     "mock_proof_size": 128 << 10,
                 },
@@ -614,15 +615,36 @@ def input_parser(plan, input_args):
                                 zkvm_path, pt_kind
                             )
                         )
-                    if pt_kind == "random":
-                        min_ms = mock_proving_time.get("min_ms", 0)
-                        max_ms = mock_proving_time.get("max_ms", 0)
-                        if min_ms > max_ms:
+                    # Fill in kind-appropriate defaults so a partial override
+                    # like `mock_proving_time: { kind: constant }` doesn't
+                    # silently become 0ms because of missing dict keys.
+                    # Defaults scale with slot duration (2/3 of slot).
+                    default_ms = result["network_params"]["slot_duration_ms"] * 2 // 3
+                    mock_proving_time["kind"] = pt_kind
+                    if pt_kind == "constant":
+                        mock_proving_time["ms"] = mock_proving_time.get(
+                            "ms", default_ms
+                        )
+                    elif pt_kind == "random":
+                        mock_proving_time["min_ms"] = mock_proving_time.get(
+                            "min_ms", default_ms // 2
+                        )
+                        mock_proving_time["max_ms"] = mock_proving_time.get(
+                            "max_ms", default_ms * 2
+                        )
+                        if mock_proving_time["min_ms"] > mock_proving_time["max_ms"]:
                             fail(
                                 "{0}: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
-                                    zkvm_path, min_ms, max_ms
+                                    zkvm_path,
+                                    mock_proving_time["min_ms"],
+                                    mock_proving_time["max_ms"],
                                 )
                             )
+                    elif pt_kind == "linear":
+                        mock_proving_time["ms_per_mgas"] = mock_proving_time.get(
+                            "ms_per_mgas", default_ms
+                        )
+                    zkvm["mock_proving_time"] = mock_proving_time
 
                 mock_proof_size = zkvm.get("mock_proof_size", 128 << 10)
                 if mock_proof_size < 32:

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -593,11 +593,17 @@ def input_parser(plan, input_args):
             if proof_type not in configured_proof_types:
                 configured_proof_types.append(proof_type)
 
-            proof_timeout = zkvm.get("proof_timeout_secs", 12)
-            if proof_timeout <= 0:
+            # Default proof_timeout_secs to 3/4 of slot duration (minimum 1 second)
+            default_proof_timeout = max(
+                1, result["network_params"]["slot_duration_ms"] * 3 // 4000
+            )
+            zkvm["proof_timeout_secs"] = zkvm.get(
+                "proof_timeout_secs", default_proof_timeout
+            )
+            if zkvm["proof_timeout_secs"] <= 0:
                 fail(
                     "{0}: proof_timeout_secs must be > 0, got {1}".format(
-                        zkvm_path, proof_timeout
+                        zkvm_path, zkvm["proof_timeout_secs"]
                     )
                 )
 
@@ -606,53 +612,55 @@ def input_parser(plan, input_args):
                     fail("{0}: external zkvm requires 'endpoint'".format(zkvm_path))
 
             if kind == "mock":
+                # Normalize mock_proving_time - handle omitted, null, and partial cases
                 mock_proving_time = zkvm.get("mock_proving_time")
-                if mock_proving_time != None:
-                    pt_kind = mock_proving_time.get("kind", "constant")
-                    if pt_kind not in ["constant", "random", "linear"]:
-                        fail(
-                            "{0}: unsupported mock_proving_time kind '{1}', please use 'constant', 'random' or 'linear'".format(
-                                zkvm_path, pt_kind
-                            )
-                        )
-                    # Fill in kind-appropriate defaults so a partial override
-                    # like `mock_proving_time: { kind: constant }` doesn't
-                    # silently become 0ms because of missing dict keys.
-                    # Defaults scale with slot duration (2/3 of slot).
-                    default_ms = result["network_params"]["slot_duration_ms"] * 2 // 3
-                    mock_proving_time["kind"] = pt_kind
-                    if pt_kind == "constant":
-                        mock_proving_time["ms"] = mock_proving_time.get(
-                            "ms", default_ms
-                        )
-                    elif pt_kind == "random":
-                        mock_proving_time["min_ms"] = mock_proving_time.get(
-                            "min_ms", default_ms // 2
-                        )
-                        mock_proving_time["max_ms"] = mock_proving_time.get(
-                            "max_ms", default_ms * 2
-                        )
-                        if mock_proving_time["min_ms"] > mock_proving_time["max_ms"]:
-                            fail(
-                                "{0}: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
-                                    zkvm_path,
-                                    mock_proving_time["min_ms"],
-                                    mock_proving_time["max_ms"],
-                                )
-                            )
-                    elif pt_kind == "linear":
-                        mock_proving_time["ms_per_mgas"] = mock_proving_time.get(
-                            "ms_per_mgas", default_ms
-                        )
-                    zkvm["mock_proving_time"] = mock_proving_time
-
-                mock_proof_size = zkvm.get("mock_proof_size", 128 << 10)
-                if mock_proof_size < 32:
+                if mock_proving_time == None:
+                    mock_proving_time = {}
+                pt_kind = mock_proving_time.get("kind", "constant")
+                if pt_kind not in ["constant", "random", "linear"]:
                     fail(
-                        "{0}: mock_proof_size must be >= 32, got {1}".format(
-                            zkvm_path, mock_proof_size
+                        "{0}: unsupported mock_proving_time kind '{1}', please use 'constant', 'random' or 'linear'".format(
+                            zkvm_path, pt_kind
                         )
                     )
+                # Fill in kind-appropriate defaults so partial or omitted
+                # mock_proving_time doesn't silently become 0ms.
+                # Duration defaults scale with slot duration (2/3 of slot).
+                default_ms = result["network_params"]["slot_duration_ms"] * 2 // 3
+                mock_proving_time["kind"] = pt_kind
+                if pt_kind == "constant":
+                    mock_proving_time["ms"] = mock_proving_time.get("ms", default_ms)
+                elif pt_kind == "random":
+                    mock_proving_time["min_ms"] = mock_proving_time.get(
+                        "min_ms", default_ms // 2
+                    )
+                    mock_proving_time["max_ms"] = mock_proving_time.get(
+                        "max_ms", default_ms * 2
+                    )
+                    if mock_proving_time["min_ms"] > mock_proving_time["max_ms"]:
+                        fail(
+                            "{0}: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
+                                zkvm_path,
+                                mock_proving_time["min_ms"],
+                                mock_proving_time["max_ms"],
+                            )
+                        )
+                elif pt_kind == "linear":
+                    # ms_per_mgas is a rate (ms per mega-gas), not a duration
+                    mock_proving_time["ms_per_mgas"] = mock_proving_time.get(
+                        "ms_per_mgas", 150
+                    )
+                zkvm["mock_proving_time"] = mock_proving_time
+
+                # Set mock_proof_size and mock_failure defaults
+                zkvm["mock_proof_size"] = zkvm.get("mock_proof_size", 128 << 10)
+                if zkvm["mock_proof_size"] < 32:
+                    fail(
+                        "{0}: mock_proof_size must be >= 32, got {1}".format(
+                            zkvm_path, zkvm["mock_proof_size"]
+                        )
+                    )
+                zkvm["mock_failure"] = zkvm.get("mock_failure", False)
 
         _validate_ere_gpu_config(effective_ere_zkvms_by_proof_type.values())
         _validate_requested_proof_types(result["participants"], configured_proof_types)

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -138,7 +138,11 @@ def launch_zkboost(
                 entry["ProgramVkUrl"] = zkvm["program_vk_url"]
             elif zkvm["kind"] == "mock":
                 mock_proving_time = zkvm.get(
-                    "mock_proving_time", {"kind": "constant", "ms": 6000}
+                    "mock_proving_time",
+                    {
+                        "kind": "constant",
+                        "ms": network_params.slot_duration_ms * 2 // 3,
+                    },
                 )
                 entry["MockProvingTimeKind"] = mock_proving_time.get("kind", "constant")
                 entry["MockProvingTimeConstantMs"] = mock_proving_time.get("ms", 6000)

--- a/src/zkboost/zkboost_launcher.star
+++ b/src/zkboost/zkboost_launcher.star
@@ -65,8 +65,6 @@ def launch_zkboost(
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
-    default_proof_timeout_secs = network_params.seconds_per_slot * 3 // 4
-
     # Per-instance zkvms: each instance falls back to the global
     # `zkboost_params.zkvms` if no per-instance list is set. Resolve artifacts
     # (ere image/elf_url, verifier program_vk_url) for each, then collect every
@@ -122,9 +120,7 @@ def launch_zkboost(
             entry = {
                 "Kind": zkvm["kind"],
                 "ProofType": zkvm["proof_type"],
-                "ProofTimeoutSecs": zkvm.get(
-                    "proof_timeout_secs", default_proof_timeout_secs
-                ),
+                "ProofTimeoutSecs": zkvm["proof_timeout_secs"],
             }
             if zkvm["kind"] == "ere":
                 entry["Endpoint"] = ere_server_endpoints[zkvm["proof_type"]]
@@ -137,22 +133,19 @@ def launch_zkboost(
                 # zkboost loads ere-verifier-* in-process; only the .vk URL is needed.
                 entry["ProgramVkUrl"] = zkvm["program_vk_url"]
             elif zkvm["kind"] == "mock":
-                mock_proving_time = zkvm.get(
-                    "mock_proving_time",
-                    {
-                        "kind": "constant",
-                        "ms": network_params.slot_duration_ms * 2 // 3,
-                    },
-                )
-                entry["MockProvingTimeKind"] = mock_proving_time.get("kind", "constant")
-                entry["MockProvingTimeConstantMs"] = mock_proving_time.get("ms", 6000)
-                entry["MockProvingTimeRandomMinMs"] = mock_proving_time.get("min_ms", 0)
-                entry["MockProvingTimeRandomMaxMs"] = mock_proving_time.get("max_ms", 0)
-                entry["MockProvingTimeLinearMsPerMgas"] = mock_proving_time.get(
-                    "ms_per_mgas", 0
-                )
-                entry["MockProofSize"] = zkvm.get("mock_proof_size", 128 << 10)
-                entry["MockFailure"] = zkvm.get("mock_failure", False)
+                mock_proving_time = zkvm["mock_proving_time"]
+                entry["MockProvingTimeKind"] = mock_proving_time["kind"]
+                if mock_proving_time["kind"] == "constant":
+                    entry["MockProvingTimeConstantMs"] = mock_proving_time["ms"]
+                elif mock_proving_time["kind"] == "random":
+                    entry["MockProvingTimeRandomMinMs"] = mock_proving_time["min_ms"]
+                    entry["MockProvingTimeRandomMaxMs"] = mock_proving_time["max_ms"]
+                elif mock_proving_time["kind"] == "linear":
+                    entry["MockProvingTimeLinearMsPerMgas"] = mock_proving_time[
+                        "ms_per_mgas"
+                    ]
+                entry["MockProofSize"] = zkvm["mock_proof_size"]
+                entry["MockFailure"] = zkvm["mock_failure"]
             zkvms.append(entry)
 
         template_data = {


### PR DESCRIPTION
## Summary

- A partial override like `mock_proving_time: { kind: constant }` silently became 0ms because dict.get on the missing `ms` key returned 0, while omitting `mock_proving_time` entirely fell back to the launcher's hardcoded 6000ms — surprising and inconsistent.
- Fill in kind-appropriate defaults during input validation so partial overrides behave like the no-override case. Defaults now scale with `slot_duration_ms` (2/3 of slot): `constant.ms`, `random.min_ms`/`max_ms` (default_ms/2 .. default_ms*2), and `linear.ms_per_mgas`.
- Updated the launcher's defensive fallback and the auto-injected default zkvm to use the same 2/3-of-slot scaling.

## Test plan

- [ ] `kurtosis lint --format .` passes
- [ ] `zkvms: [{ kind: mock, proof_type: reth-zisk }]` → mock proving time defaults to 4000ms on 6s slots (2/3 of 6000)
- [ ] `zkvms: [{ kind: mock, proof_type: reth-zisk, mock_proving_time: { kind: constant } }]` → resolves to 4000ms (no longer 0ms)
- [ ] `zkvms: [{ kind: mock, proof_type: reth-zisk, mock_proving_time: { kind: random } }]` → resolves to 2000–8000ms on 6s slots
- [ ] On a 12s slot, defaults scale to 8000ms / 4000–16000ms