### PR TITLE
fix(consensoor): drop hardcoded --graffiti=consensoor

### DIFF
--- a/src/cl/consensoor/consensoor_launcher.star
+++ b/src/cl/consensoor/consensoor_launcher.star
@@ -194,7 +194,6 @@ def get_beacon_config(
         "--beacon-api-port={0}".format(BEACON_HTTP_PORT_NUM),
         "--metrics-port={0}".format(BEACON_METRICS_PORT_NUM),
         "--fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
-        "--graffiti=consensoor",
     ]
 
     if el_context != None:


### PR DESCRIPTION
## Summary
- Removes the hardcoded `--graffiti=consensoor` arg from the consensoor CL launcher so blocks render with just the standard EL+CL version prefix (e.g. `EX2123COadce`), matching the style of every other client (`EX2123PRd664`, `NMd654LH98ed`, etc.).

## Why
consensoor's own CLI defaults `--graffiti` to empty, expecting `build_graffiti` to emit only the prefix. The hardcoded arg here overrode that and wasted 11 of 32 graffiti bytes on every block, producing the noisy `EX2123COadce consensoor` rows visible in dora today.

No other CL launcher in `src/cl/*/` injects a `--graffiti` default; consensoor shouldn't either. Operators can still set a custom graffiti via the participant config when they want one.

## Test plan
- [x] Restart kurtosis with consensoor; dora shows `EX2123COxxxx` (no trailing ` consensoor`).