### PR TITLE
feat(otel): opt-in tracing to the engine OTel stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,7 +1402,9 @@ disable_peer_scoring: false
 
 # Enables tracing to the external Kurtosis OTel stack started with `kurtosis otel start`
 # Defaults to false
-otel_tracing: false
+otel:
+  tracing:
+    enabled: false
 
 # Whether the environment should be persistent; this is WIP and is slowly being rolled out across services
 # Note this requires Kurtosis greater than 0.85.49 to work

--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,10 @@ parallel_keystore_generation: false
 # Default to false
 disable_peer_scoring: false
 
+# Enables tracing to the external Kurtosis OTel stack started with `kurtosis otel start`
+# Defaults to false
+otel_tracing: false
+
 # Whether the environment should be persistent; this is WIP and is slowly being rolled out across services
 # Note this requires Kurtosis greater than 0.85.49 to work
 # Note Erigon, Besu, Teku persistence is not currently supported with docker.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Optional features (enabled via flags or parameter files at runtime):
 - Specify the required parameters for the nodes to reach an external block building network
 - Generate keystores for each node in parallel
 - Spin up [TrueBlocks](https://github.com/TrueBlocks/trueblocks-core) (`chifra daemon`) to serve the chifra REST API on port 8080 (`/status`, `/blocks`, `/list`, `/chunks`, etc.). The scraper isn't started automatically; POST `/scrape` (or run `chifra scrape` against the same data dir) when you want to build the local [Unchained Index](https://trueblocks.io/docs/install/get-the-index/). Auto-tunes scrape parameters for devnets vs public networks.
+- Ship traces from every EL/CL/VC to the engine-level Kurtosis OTel stack started with `kurtosis otel start` by adding `otel` to `additional_services`. Traces land in the shared ClickHouse tenanted by enclave; requires the Docker backend.
 
 ## Quickstart
 
@@ -1068,6 +1069,7 @@ additional_services:
   - grafana
   - mempool_bridge
   - nginx
+  - otel
   - prometheus
   - rakoon
   - slashoor
@@ -1426,12 +1428,6 @@ parallel_keystore_generation: false
 # Disable peer scoring to prevent nodes impacted by faults from being permanently ejected from the network
 # Default to false
 disable_peer_scoring: false
-
-# Enables tracing to the external Kurtosis OTel stack started with `kurtosis otel start`
-# Defaults to false
-otel:
-  tracing:
-    enabled: false
 
 # Whether the environment should be persistent; this is WIP and is slowly being rolled out across services
 # Note this requires Kurtosis greater than 0.85.49 to work

--- a/main.star
+++ b/main.star
@@ -76,9 +76,11 @@ HTTP_PORT_ID_FOR_FACT = "http"
 MEV_BOOST_SHOULD_CHECK_RELAY = True
 PATH_TO_PARSED_BEACON_STATE = "/genesis/output/parsedBeaconState.json"
 
-ENGINE_OTEL_OTLP_GRPC_PORT = 4317
-ENGINE_OTEL_OTLP_HTTP_PORT = 4318
-ENGINE_OTEL_CLICKHOUSE_HTTP_PORT = 8123
+# Non-default ports so the engine OTel stack does not collide with a host-level
+# OTLP collector (4317/4318) or ClickHouse (8123). Must match `kurtosis otel start`.
+ENGINE_OTEL_OTLP_GRPC_PORT = 14317
+ENGINE_OTEL_OTLP_HTTP_PORT = 14318
+ENGINE_OTEL_CLICKHOUSE_HTTP_PORT = 18123
 ENGINE_OTEL_DISCOVERY_OUTPUT_FILE = "/tmp/engine-otel-discovery.json"
 ENGINE_OTEL_DISCOVERY_ARTIFACT_NAME = "engine-otel-discovery"
 ENGINE_OTEL_DISCOVERY_MOUNT_DIR = "/engine-otel-discovery"
@@ -120,7 +122,7 @@ if [ -z "$own_ip" ]; then
     exit 1
 fi
 
-clickhouse_ping_url="http://${gateway}:8123/ping"
+clickhouse_ping_url="http://${gateway}:{{ .ClickHousePort }}/ping"
 if ! curl -fsS "$clickhouse_ping_url" >/dev/null; then
     echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before enabling otel.tracing.enabled" >&2
     exit 1
@@ -206,7 +208,7 @@ def detect_engine_otel_endpoints(plan, global_tolerations, global_node_selectors
         {
             ENGINE_OTEL_DISCOVERY_SCRIPT_FILENAME: shared_utils.new_template_and_data(
                 ENGINE_OTEL_DISCOVERY_SCRIPT,
-                {},
+                {"ClickHousePort": ENGINE_OTEL_CLICKHOUSE_HTTP_PORT},
             ),
         },
         name=ENGINE_OTEL_DISCOVERY_SCRIPT_ARTIFACT_NAME,

--- a/main.star
+++ b/main.star
@@ -122,7 +122,7 @@ fi
 
 clickhouse_ping_url="http://${gateway}:8123/ping"
 if ! curl -fsS "$clickhouse_ping_url" >/dev/null; then
-    echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before enabling otel_tracing" >&2
+    echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before enabling otel.tracing.enabled" >&2
     exit 1
 fi
 
@@ -327,9 +327,9 @@ def run(plan, args={}):
     network_params = args_with_right_defaults.network_params
 
     detected_backend = plan.get_cluster_type()
-    if args_with_right_defaults.otel_tracing and detected_backend != "docker":
+    if args_with_right_defaults.otel.tracing.enabled and detected_backend != "docker":
         fail(
-            "otel_tracing requires the Docker backend because it uses the engine OTel stack published on the Docker host; detected backend: {}. Run with the Docker backend or disable otel_tracing.".format(
+            "otel.tracing.enabled requires the Docker backend because it uses the engine OTel stack published on the Docker host; detected backend: {}. Run with the Docker backend or disable otel.tracing.enabled.".format(
                 detected_backend
             )
         )
@@ -379,7 +379,7 @@ def run(plan, args={}):
     docker_cache_params = args_with_right_defaults.docker_cache_params
 
     engine_otel_endpoints = new_engine_otel_endpoints()
-    if args_with_right_defaults.otel_tracing:
+    if args_with_right_defaults.otel.tracing.enabled:
         engine_otel_endpoints = detect_engine_otel_endpoints(
             plan,
             global_tolerations,

--- a/main.star
+++ b/main.star
@@ -125,7 +125,7 @@ fi
 
 clickhouse_ping_url="http://${gateway}:{{ .ClickHousePort }}/ping"
 if ! curl -fsS "$clickhouse_ping_url" >/dev/null; then
-    echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before enabling otel.tracing.enabled" >&2
+    echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before adding 'otel' to additional_services" >&2
     exit 1
 fi
 
@@ -330,9 +330,10 @@ def run(plan, args={}):
     network_params = args_with_right_defaults.network_params
 
     detected_backend = plan.get_cluster_type()
-    if args_with_right_defaults.otel.tracing.enabled and detected_backend != "docker":
+    otel_enabled = "otel" in args_with_right_defaults.additional_services
+    if otel_enabled and detected_backend != "docker":
         fail(
-            "otel.tracing.enabled requires the Docker backend because it uses the engine OTel stack published on the Docker host; detected backend: {}. Run with the Docker backend or disable otel.tracing.enabled.".format(
+            "The 'otel' additional_service requires the Docker backend because it uses the engine OTel stack published on the Docker host; detected backend: {}. Run with the Docker backend or remove 'otel' from additional_services.".format(
                 detected_backend
             )
         )
@@ -382,7 +383,7 @@ def run(plan, args={}):
     docker_cache_params = args_with_right_defaults.docker_cache_params
 
     engine_otel_endpoints = new_engine_otel_endpoints()
-    if args_with_right_defaults.otel.tracing.enabled:
+    if otel_enabled:
         engine_otel_endpoints = detect_engine_otel_endpoints(
             plan,
             global_tolerations,
@@ -1360,6 +1361,10 @@ def run(plan, args={}):
                 args_with_right_defaults.docker_cache_params,
             )
             plan.print("Successfully launched trueblocks")
+        elif additional_service == "otel":
+            # Engine OTel reachability is enforced earlier via detect_engine_otel_endpoints();
+            # if discovery succeeded, the per-client OTLP env vars are already wired.
+            plan.print("OTel tracing wired to engine collector")
         else:
             fail("Invalid additional service %s" % (additional_service))
     if launch_prometheus_grafana:

--- a/main.star
+++ b/main.star
@@ -76,6 +76,243 @@ HTTP_PORT_ID_FOR_FACT = "http"
 MEV_BOOST_SHOULD_CHECK_RELAY = True
 PATH_TO_PARSED_BEACON_STATE = "/genesis/output/parsedBeaconState.json"
 
+ENGINE_OTEL_OTLP_GRPC_PORT = 4317
+ENGINE_OTEL_OTLP_HTTP_PORT = 4318
+ENGINE_OTEL_CLICKHOUSE_HTTP_PORT = 8123
+ENGINE_OTEL_DISCOVERY_OUTPUT_FILE = "/tmp/engine-otel-discovery.json"
+ENGINE_OTEL_DISCOVERY_ARTIFACT_NAME = "engine-otel-discovery"
+ENGINE_OTEL_DISCOVERY_MOUNT_DIR = "/engine-otel-discovery"
+ENGINE_OTEL_DISCOVERY_SCRIPT_FILENAME = "engine-otel-discovery.sh"
+ENGINE_OTEL_DISCOVERY_SCRIPT_ARTIFACT_NAME = "engine-otel-discovery-script"
+ENGINE_OTEL_DISCOVERY_SCRIPT_MOUNT_DIR = "/engine-otel-discovery-script"
+
+ENGINE_OTEL_DISCOVERY_SCRIPT = r"""#!/bin/sh
+set -eu
+
+route_line=$(awk "\$2 == \"00000000\" { print \$1 \" \" \$3; exit }" /proc/net/route)
+if [ -z "$route_line" ]; then
+    echo "default route not found" >&2
+    exit 1
+fi
+
+iface=$(printf "%s" "$route_line" | awk "{ print \$1 }")
+gateway_hex=$(printf "%s" "$route_line" | awk "{ print \$2 }")
+if [ -z "$gateway_hex" ]; then
+    echo "default gateway not found" >&2
+    exit 1
+fi
+
+gateway=$(printf "%d.%d.%d.%d" \
+    "0x$(printf "%s" "$gateway_hex" | cut -c7-8)" \
+    "0x$(printf "%s" "$gateway_hex" | cut -c5-6)" \
+    "0x$(printf "%s" "$gateway_hex" | cut -c3-4)" \
+    "0x$(printf "%s" "$gateway_hex" | cut -c1-2)")
+
+own_ip=""
+if command -v ip >/dev/null 2>&1; then
+    own_ip=$(ip -4 -o addr show dev "$iface" scope global | awk "{ split(\$4, a, \"/\"); print a[1]; exit }")
+fi
+if [ -z "$own_ip" ]; then
+    own_ip=$(hostname -i 2>/dev/null | tr " " "\n" | awk "split(\$1, a, \".\") == 4 && a[1] != \"127\" { print; exit }")
+fi
+if [ -z "$own_ip" ]; then
+    echo "probe IPv4 not found" >&2
+    exit 1
+fi
+
+clickhouse_ping_url="http://${gateway}:8123/ping"
+if ! curl -fsS "$clickhouse_ping_url" >/dev/null; then
+    echo "engine OTel stack is not reachable at ${clickhouse_ping_url}; run 'kurtosis otel start' before enabling otel_tracing" >&2
+    exit 1
+fi
+
+enclaves_json=$(curl -fsS -XPOST \
+    -H "Content-Type: application/json" \
+    -d "{}" \
+    "http://${gateway}:9710/engine_api.EngineService/GetEnclaves")
+
+cat > /tmp/engine-otel-discovery.jq <<\JQ
+def prefix16($ip):
+    ($ip | split(".")[0:2] | join("."));
+
+def prefix22($ip):
+    ($ip | split(".")) as $octets
+    | "\($octets[0]).\($octets[1]).\((($octets[2] | tonumber) / 4 | floor) * 4)";
+
+(.enclaveInfo // {})
+| to_entries
+| map(.value | select(.apiContainerInfo.ipInsideEnclave != null))
+| (
+    map(select(prefix22(.apiContainerInfo.ipInsideEnclave) == prefix22($own_ip))) as $matches22
+    | if ($matches22 | length) == 1 then
+        $matches22[0]
+      else
+        map(select(prefix16(.apiContainerInfo.ipInsideEnclave) == prefix16($own_ip))) as $matches16
+        | if ($matches16 | length) == 1 then
+            $matches16[0]
+          else
+            error("unable to identify enclave for probe IP \($own_ip)")
+          end
+      end
+  )
+| {
+    gateway: $gateway,
+    enclave_uuid: .enclaveUuid,
+    enclave_name: .name
+  }
+JQ
+
+printf "%s" "$enclaves_json" | jq -c \
+    --arg gateway "$gateway" \
+    --arg own_ip "$own_ip" \
+    -f /tmp/engine-otel-discovery.jq > /tmp/engine-otel-discovery.json
+cat /tmp/engine-otel-discovery.json
+"""
+
+
+def new_engine_otel_endpoints(gateway=None, enclave_uuid=None, enclave_name=None):
+    if gateway == None:
+        return struct(
+            gateway=None,
+            enclave_uuid=None,
+            enclave_name=None,
+            resource_attributes=None,
+            otlp_grpc_url=None,
+            otlp_http_traces_url=None,
+            clickhouse_host=None,
+            clickhouse_port=None,
+        )
+
+    return struct(
+        gateway=gateway,
+        enclave_uuid=enclave_uuid,
+        enclave_name=enclave_name,
+        resource_attributes="kurtosis.enclave.name={},kurtosis.enclave.uuid={}".format(
+            enclave_name,
+            enclave_uuid,
+        ),
+        otlp_grpc_url="http://{}:{}".format(gateway, ENGINE_OTEL_OTLP_GRPC_PORT),
+        otlp_http_traces_url="http://{}:{}/v1/traces".format(
+            gateway,
+            ENGINE_OTEL_OTLP_HTTP_PORT,
+        ),
+        clickhouse_host=gateway,
+        clickhouse_port=ENGINE_OTEL_CLICKHOUSE_HTTP_PORT,
+    )
+
+
+def detect_engine_otel_endpoints(plan, global_tolerations, global_node_selectors):
+    script_artifact = plan.render_templates(
+        {
+            ENGINE_OTEL_DISCOVERY_SCRIPT_FILENAME: shared_utils.new_template_and_data(
+                ENGINE_OTEL_DISCOVERY_SCRIPT,
+                {},
+            ),
+        },
+        name=ENGINE_OTEL_DISCOVERY_SCRIPT_ARTIFACT_NAME,
+    )
+    result = plan.run_sh(
+        name="detect-engine-otel",
+        description="Detecting enclave identity and engine OTel endpoints",
+        run="/bin/sh {}/{}".format(
+            ENGINE_OTEL_DISCOVERY_SCRIPT_MOUNT_DIR,
+            ENGINE_OTEL_DISCOVERY_SCRIPT_FILENAME,
+        ),
+        files={
+            ENGINE_OTEL_DISCOVERY_SCRIPT_MOUNT_DIR: script_artifact,
+        },
+        store=[
+            StoreSpec(
+                src=ENGINE_OTEL_DISCOVERY_OUTPUT_FILE,
+                name=ENGINE_OTEL_DISCOVERY_ARTIFACT_NAME,
+            ),
+        ],
+        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
+        node_selectors=global_node_selectors,
+    )
+    discovery_artifact = result.files_artifacts[0]
+    gateway = read_engine_otel_discovery_field(
+        plan,
+        discovery_artifact,
+        "gateway",
+        global_tolerations,
+        global_node_selectors,
+    )
+    enclave_uuid = read_engine_otel_discovery_field(
+        plan,
+        discovery_artifact,
+        "enclave_uuid",
+        global_tolerations,
+        global_node_selectors,
+    )
+    enclave_name = read_engine_otel_discovery_field(
+        plan,
+        discovery_artifact,
+        "enclave_name",
+        global_tolerations,
+        global_node_selectors,
+    )
+    plan.print(
+        "Using engine-level OTel collector via enclave gateway {} for enclave {} ({})".format(
+            gateway,
+            enclave_name,
+            enclave_uuid,
+        )
+    )
+    return new_engine_otel_endpoints(gateway, enclave_uuid, enclave_name)
+
+
+def read_engine_otel_discovery_field(
+    plan,
+    discovery_artifact,
+    field,
+    global_tolerations,
+    global_node_selectors,
+):
+    result = plan.run_sh(
+        name="read-engine-otel-{}".format(field.replace("_", "-")),
+        description="Reading engine OTel discovery field {}".format(field),
+        run='value=$(jq -er ".{}" {}/engine-otel-discovery.json) && printf "%s" "$value"'.format(
+            field,
+            ENGINE_OTEL_DISCOVERY_MOUNT_DIR,
+        ),
+        files={
+            ENGINE_OTEL_DISCOVERY_MOUNT_DIR: discovery_artifact,
+        },
+        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
+        node_selectors=global_node_selectors,
+    )
+    return result.output
+
+
+def append_otel_resource_attributes(env_vars, resource_attributes):
+    existing = env_vars.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if existing == "":
+        env_vars["OTEL_RESOURCE_ATTRIBUTES"] = resource_attributes
+    elif resource_attributes not in existing:
+        env_vars["OTEL_RESOURCE_ATTRIBUTES"] = "{},{}".format(
+            existing,
+            resource_attributes,
+        )
+
+
+def add_otel_resource_attributes_to_participants(participants, resource_attributes):
+    if resource_attributes == None:
+        return
+    for participant in participants:
+        append_otel_resource_attributes(
+            participant.el_extra_env_vars,
+            resource_attributes,
+        )
+        append_otel_resource_attributes(
+            participant.cl_extra_env_vars,
+            resource_attributes,
+        )
+        append_otel_resource_attributes(
+            participant.vc_extra_env_vars,
+            resource_attributes,
+        )
+
 
 def run(plan, args={}):
     """Launches an arbitrarily complex ethereum testnet based on the arguments provided
@@ -89,8 +326,13 @@ def run(plan, args={}):
     num_participants = len(args_with_right_defaults.participants)
     network_params = args_with_right_defaults.network_params
 
-    # Detect the backend type early - needed for binary injection validation
     detected_backend = plan.get_cluster_type()
+    if args_with_right_defaults.otel_tracing and detected_backend != "docker":
+        fail(
+            "otel_tracing requires the Docker backend because it uses the engine OTel stack published on the Docker host; detected backend: {}. Run with the Docker backend or disable otel_tracing.".format(
+                detected_backend
+            )
+        )
 
     if (
         "disruptoor" in args_with_right_defaults.additional_services
@@ -113,7 +355,6 @@ def run(plan, args={}):
             artifact = plan.render_templates(template_data, name + "_artifact")
             extra_files_artifacts[name] = artifact
 
-    # Validate binary injection - only supported with Docker backend
     for participant in args_with_right_defaults.participants:
         for bin_path in [
             participant.el_binary_path,
@@ -136,6 +377,22 @@ def run(plan, args={}):
     keymanager_enabled = args_with_right_defaults.keymanager_enabled
     nginx_port = args_with_right_defaults.nginx_port
     docker_cache_params = args_with_right_defaults.docker_cache_params
+
+    engine_otel_endpoints = new_engine_otel_endpoints()
+    if args_with_right_defaults.otel_tracing:
+        engine_otel_endpoints = detect_engine_otel_endpoints(
+            plan,
+            global_tolerations,
+            global_node_selectors,
+        )
+        add_otel_resource_attributes_to_participants(
+            args_with_right_defaults.participants,
+            engine_otel_endpoints.resource_attributes,
+        )
+    otel_clickhouse_host = engine_otel_endpoints.clickhouse_host
+    otel_clickhouse_port = engine_otel_endpoints.clickhouse_port
+    otel_otlp_grpc_url = engine_otel_endpoints.otlp_grpc_url
+    otel_otlp_http_traces_url = engine_otel_endpoints.otlp_http_traces_url
 
     for index, participant in enumerate(args_with_right_defaults.participants):
         if (
@@ -283,6 +540,8 @@ def run(plan, args={}):
         parallel_keystore_generation,
         extra_files_artifacts,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
+        otel_otlp_http_traces_url,
         detected_backend,
     )
 
@@ -938,6 +1197,8 @@ def run(plan, args={}):
                 args_with_right_defaults.port_publisher,
                 index,
                 tempo_query_url,
+                otel_clickhouse_host,
+                otel_clickhouse_port,
             )
             plan.print("Successfully launched grafana")
         elif additional_service == "tempo":
@@ -1107,6 +1368,8 @@ def run(plan, args={}):
             args_with_right_defaults.port_publisher,
             prometheus_grafana_index,
             tempo_query_url,
+            otel_clickhouse_host,
+            otel_clickhouse_port,
         )
         plan.print("Successfully launched grafana")
 
@@ -1137,9 +1400,11 @@ def run(plan, args={}):
 
     output = struct(
         grafana_info=grafana_info,
-        blockscout_sc_verif_url=None
-        if ("blockscout" in args_with_right_defaults.additional_services) == False
-        else blockscout_sc_verif_url,
+        blockscout_sc_verif_url=(
+            None
+            if ("blockscout" in args_with_right_defaults.additional_services) == False
+            else blockscout_sc_verif_url
+        ),
         all_participants=all_participants,
         pre_funded_accounts=prefunded_accounts,
         network_params=network_params,

--- a/src/cl/caplin/caplin_launcher.star
+++ b/src/cl/caplin/caplin_launcher.star
@@ -45,6 +45,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -70,6 +71,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -113,6 +115,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -240,7 +243,11 @@ def get_beacon_config(
     if cl_binary_artifact != None:
         files["/opt/bin"] = cl_binary_artifact.artifact
 
-    env_vars = participant.cl_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.cl_extra_env_vars,
+        otel_otlp_grpc_url,
+        beacon_service_name,
+    )
 
     cmd_str = " ".join(cmd)
     if cl_binary_artifact != None:

--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -30,6 +30,8 @@ def launch(
     global_tolerations,
     persistent,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url,
+    otel_otlp_http_traces_url,
     num_participants,
     validator_data,
     prysm_password_relative_filepath,
@@ -72,6 +74,7 @@ def launch(
             "launcher": prysm.new_prysm_launcher(
                 el_cl_data,
                 jwt_file,
+                otel_otlp_http_traces_url,
             ),
             "launch_method": prysm.launch,
             "get_beacon_config": prysm.get_beacon_config,
@@ -281,6 +284,7 @@ def launch(
                 extra_files_artifacts,
                 backend,
                 tempo_otlp_grpc_url,
+                otel_otlp_grpc_url,
                 bootnode_enr_override,
                 cl_binary_artifact,
             )
@@ -333,6 +337,7 @@ def launch(
                 extra_files_artifacts,
                 backend,
                 tempo_otlp_grpc_url,
+                otel_otlp_grpc_url,
                 bootnode_enr_override,
                 cl_binary_artifact,
             )

--- a/src/cl/consensoor/consensoor_launcher.star
+++ b/src/cl/consensoor/consensoor_launcher.star
@@ -45,6 +45,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -70,6 +71,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -113,6 +115,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -268,7 +271,11 @@ def get_beacon_config(
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact
 
-    env_vars = participant.cl_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.cl_extra_env_vars,
+        otel_otlp_grpc_url,
+        beacon_service_name,
+    )
 
     cmd_str = " ".join(cmd)
     cmd_str = "exec " + cmd_str

--- a/src/cl/grandine/grandine_launcher.star
+++ b/src/cl/grandine/grandine_launcher.star
@@ -58,6 +58,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -83,6 +84,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -124,6 +126,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -370,7 +373,11 @@ def get_beacon_config(
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,
-        "env_vars": participant.cl_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.cl_extra_env_vars,
+            otel_otlp_grpc_url,
+            beacon_service_name,
+        ),
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "labels": shared_utils.label_maker(
             client=constants.CL_TYPE.grandine,

--- a/src/cl/lighthouse/lighthouse_launcher.star
+++ b/src/cl/lighthouse/lighthouse_launcher.star
@@ -60,6 +60,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -85,6 +86,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -128,6 +130,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -276,9 +279,11 @@ def get_beacon_config(
     if bootnode_arg != None:
         cmd.append("--boot-nodes=" + bootnode_arg)
 
-    # Add tempo telemetry integration if tempo is enabled
-    if tempo_otlp_grpc_url != None:
-        cmd.append("--telemetry-collector-url={}".format(tempo_otlp_grpc_url))
+    telemetry_url = (
+        otel_otlp_grpc_url if otel_otlp_grpc_url != None else tempo_otlp_grpc_url
+    )
+    if telemetry_url != None:
+        cmd.append("--telemetry-collector-url={}".format(telemetry_url))
         cmd.append("--telemetry-service-name={}".format(beacon_service_name))
 
     if len(participant.cl_extra_params) > 0:
@@ -305,11 +310,13 @@ def get_beacon_config(
         )
         files[BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER] = Directory(
             persistent_key="data-{0}".format(beacon_service_name),
-            size=int(participant.cl_volume_size)
-            if int(participant.cl_volume_size) > 0
-            else constants.VOLUME_SIZE[volume_size_key][
-                constants.CL_TYPE.lighthouse + "_volume_size"
-            ],
+            size=(
+                int(participant.cl_volume_size)
+                if int(participant.cl_volume_size) > 0
+                else constants.VOLUME_SIZE[volume_size_key][
+                    constants.CL_TYPE.lighthouse + "_volume_size"
+                ]
+            ),
         )
 
     # Add extra mounts - automatically handle file uploads
@@ -325,7 +332,13 @@ def get_beacon_config(
         files["/opt/bin"] = cl_binary_artifact.artifact
 
     env_vars = {RUST_BACKTRACE_ENVVAR_NAME: RUST_FULL_BACKTRACE_KEYWORD}
-    env_vars.update(participant.cl_extra_env_vars)
+    env_vars.update(
+        shared_utils.with_otel_env_vars(
+            participant.cl_extra_env_vars,
+            otel_otlp_grpc_url,
+            beacon_service_name,
+        )
+    )
 
     # Build the command string, copying injected binary if provided
     cmd_str = " ".join(cmd)
@@ -435,9 +448,9 @@ def get_cl_context(
         peer_id=beacon_peer_id,
         snooper_enabled=participant.snooper_enabled,
         snooper_el_engine_context=snooper_el_engine_context,
-        validator_keystore_files_artifact_uuid=node_keystore_files.files_artifact_uuid
-        if node_keystore_files
-        else "",
+        validator_keystore_files_artifact_uuid=(
+            node_keystore_files.files_artifact_uuid if node_keystore_files else ""
+        ),
         supernode=participant.supernode,
     )
 

--- a/src/cl/lodestar/lodestar_launcher.star
+++ b/src/cl/lodestar/lodestar_launcher.star
@@ -49,6 +49,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -75,6 +76,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -116,6 +118,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -299,7 +302,11 @@ def get_beacon_config(
     if cl_binary_artifact != None:
         files["/opt/bin"] = cl_binary_artifact.artifact
 
-    env_vars = participant.cl_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.cl_extra_env_vars,
+        otel_otlp_grpc_url,
+        beacon_service_name,
+    )
 
     if network_params.preset == "minimal":
         env_vars["LODESTAR_PRESET"] = "minimal"

--- a/src/cl/nimbus/nimbus_launcher.star
+++ b/src/cl/nimbus/nimbus_launcher.star
@@ -68,6 +68,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -93,6 +94,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -134,6 +136,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -376,7 +379,11 @@ def get_beacon_config(
         "entrypoint": ["sh", "-c"],
         "cmd": [command_str],
         "files": files,
-        "env_vars": participant.cl_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.cl_extra_env_vars,
+            otel_otlp_grpc_url,
+            beacon_service_name,
+        ),
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "labels": shared_utils.label_maker(
             client=constants.CL_TYPE.nimbus,

--- a/src/cl/prysm/prysm_launcher.star
+++ b/src/cl/prysm/prysm_launcher.star
@@ -53,6 +53,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -78,6 +79,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -119,6 +121,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -303,6 +306,14 @@ def get_beacon_config(
     else:  # Public network
         cmd.append("--{}".format(network_params.network))
 
+    if otel_otlp_grpc_url != None:
+        otel_otlp_http_traces_url = getattr(launcher, "otel_otlp_http_traces_url", None)
+        if otel_otlp_http_traces_url == None:
+            fail("Prysm tracing requires an OTLP HTTP traces endpoint")
+        cmd.append("--enable-tracing")
+        cmd.append("--tracing-endpoint={}".format(otel_otlp_http_traces_url))
+        cmd.append("--tracing-process-name={}".format(beacon_service_name))
+
     if len(participant.cl_extra_params) > 0:
         # we do the for loop as otherwise its a proto repeated array
         cmd.extend([param for param in participant.cl_extra_params])
@@ -322,11 +333,13 @@ def get_beacon_config(
         )
         files[BEACON_DATA_DIRPATH_ON_SERVICE_CONTAINER] = Directory(
             persistent_key="data-{0}".format(beacon_service_name),
-            size=int(participant.cl_volume_size)
-            if int(participant.cl_volume_size) > 0
-            else constants.VOLUME_SIZE[volume_size_key][
-                constants.CL_TYPE.prysm + "_volume_size"
-            ],
+            size=(
+                int(participant.cl_volume_size)
+                if int(participant.cl_volume_size) > 0
+                else constants.VOLUME_SIZE[volume_size_key][
+                    constants.CL_TYPE.prysm + "_volume_size"
+                ]
+            ),
         )
 
     # Add extra mounts - automatically handle file uploads
@@ -358,7 +371,11 @@ def get_beacon_config(
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,
-        "env_vars": participant.cl_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.cl_extra_env_vars,
+            otel_otlp_grpc_url,
+            beacon_service_name,
+        ),
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "labels": shared_utils.label_maker(
             client=constants.CL_TYPE.prysm,
@@ -451,9 +468,9 @@ def get_cl_context(
         peer_id=beacon_peer_id,
         snooper_enabled=participant.snooper_enabled,
         snooper_el_engine_context=snooper_el_engine_context,
-        validator_keystore_files_artifact_uuid=node_keystore_files.files_artifact_uuid
-        if node_keystore_files
-        else "",
+        validator_keystore_files_artifact_uuid=(
+            node_keystore_files.files_artifact_uuid if node_keystore_files else ""
+        ),
         supernode=participant.supernode,
     )
 
@@ -461,10 +478,12 @@ def get_cl_context(
 def new_prysm_launcher(
     el_cl_genesis_data,
     jwt_file,
+    otel_otlp_http_traces_url=None,
 ):
     return struct(
         el_cl_genesis_data=el_cl_genesis_data,
         jwt_file=jwt_file,
+        otel_otlp_http_traces_url=otel_otlp_http_traces_url,
     )
 
 

--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -55,6 +55,7 @@ def launch(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -80,6 +81,7 @@ def launch(
         extra_files_artifacts,
         backend,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
         bootnode_enr_override,
         cl_binary_artifact,
     )
@@ -121,6 +123,7 @@ def get_beacon_config(
     extra_files_artifacts,
     backend,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
     bootnode_enr_override=None,
     cl_binary_artifact=None,
 ):
@@ -387,7 +390,11 @@ def get_beacon_config(
         "entrypoint": ["sh", "-c"],
         "cmd": [cmd_str],
         "files": files,
-        "env_vars": participant.cl_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.cl_extra_env_vars,
+            otel_otlp_grpc_url,
+            beacon_service_name,
+        ),
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "labels": shared_utils.label_maker(
             client=constants.CL_TYPE.teku,

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -47,6 +47,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -67,6 +68,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -98,6 +100,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -230,7 +233,14 @@ def get_config(
 
     cmd_str = " ".join(cmd)
 
-    env_vars = participant.el_extra_env_vars | JAVA_OPTS
+    env_vars = (
+        shared_utils.with_otel_env_vars(
+            participant.el_extra_env_vars,
+            otel_otlp_grpc_url,
+            service_name,
+        )
+        | JAVA_OPTS
+    )
 
     files = {
         constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: launcher.el_cl_genesis_data.files_artifact_uuid,

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -33,6 +33,7 @@ def launch(
     extra_files_artifacts={},
     bootnodoor_enode=None,
     binary_artifacts={},
+    otel_otlp_grpc_url=None,
 ):
     el_launchers = {
         constants.EL_TYPE.geth: {
@@ -191,6 +192,7 @@ def launch(
                 extra_files_artifacts,
                 bootnodoor_enode,
                 el_binary_artifact,
+                otel_otlp_grpc_url,
             )
 
             # Add participant el additional prometheus metrics
@@ -217,6 +219,7 @@ def launch(
                 extra_files_artifacts,
                 bootnodoor_enode,
                 el_binary_artifact,
+                otel_otlp_grpc_url,
             )
 
             el_participant_info[el_service_name] = {

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -44,6 +44,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -64,6 +65,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -95,6 +97,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -277,7 +280,11 @@ def get_config(
         else:
             command_arg_str = cmd_str
 
-    env_vars = participant.el_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.el_extra_env_vars,
+        otel_otlp_grpc_url,
+        service_name,
+    )
     config_args = {
         "image": participant.el_image,
         "ports": used_ports,

--- a/src/el/ethereumjs/ethereumjs_launcher.star
+++ b/src/el/ethereumjs/ethereumjs_launcher.star
@@ -46,6 +46,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -66,6 +67,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -97,6 +99,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -246,7 +249,11 @@ def get_config(
     if el_binary_artifact != None:
         files["/opt/bin"] = el_binary_artifact.artifact
 
-    env_vars = participant.el_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.el_extra_env_vars,
+        otel_otlp_grpc_url,
+        service_name,
+    )
     config_args = {
         "image": participant.el_image,
         "ports": used_ports,

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -61,6 +61,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -81,6 +82,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -112,6 +114,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     public_ports = {}
     public_ports_for_component = None
@@ -249,7 +252,11 @@ def get_config(
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
-        "env_vars": participant.el_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.el_extra_env_vars,
+            otel_otlp_grpc_url,
+            service_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.EL_TYPE.ethrex,
             client_type=constants.CLIENT_TYPES.el,

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -53,6 +53,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -73,6 +74,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -104,6 +106,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -254,6 +257,14 @@ def get_config(
             )
         )
 
+    if otel_otlp_grpc_url != None:
+        cmd.append("--rpc.telemetry")
+        cmd.append(
+            "--rpc.telemetry.endpoint={}".format(
+                otel_otlp_grpc_url.replace("http://", "grpc://")
+            )
+        )
+
     if len(participant.el_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark
         cmd.extend([param for param in participant.el_extra_params])
@@ -297,7 +308,11 @@ def get_config(
     else:
         cmd_str = command_str
 
-    env_vars = participant.el_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.el_extra_env_vars,
+        otel_otlp_grpc_url,
+        service_name,
+    )
     config_args = {
         "image": participant.el_image,
         "ports": used_ports,

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -42,6 +42,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -62,6 +63,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -93,6 +95,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -248,7 +251,11 @@ def get_config(
     if el_binary_artifact != None:
         files["/opt/bin"] = el_binary_artifact.artifact
 
-    env_vars = participant.el_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.el_extra_env_vars,
+        otel_otlp_grpc_url,
+        service_name,
+    )
     config_args = {
         "image": participant.el_image,
         "ports": used_ports,

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -42,6 +42,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -62,6 +63,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -93,6 +95,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -230,7 +233,11 @@ def get_config(
     if el_binary_artifact != None:
         files["/opt/bin"] = el_binary_artifact.artifact
 
-    env_vars = participant.el_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.el_extra_env_vars,
+        otel_otlp_grpc_url,
+        service_name,
+    )
     config_args = {
         "image": participant.el_image,
         "ports": used_ports,

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -248,7 +248,7 @@ def get_config(
 
     if otel_otlp_grpc_url != None:
         cmd.append("--tracing-otlp={}".format(otel_otlp_grpc_url))
-        cmd.append("--tracing-otlp.protocol=grpc")
+        cmd.append("--tracing-otlp-protocol=grpc")
 
     if len(participant.el_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -51,6 +51,7 @@ def launch(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     cl_client_name = service_name.split("-")[3]
 
@@ -71,6 +72,7 @@ def launch(
         extra_files_artifacts,
         bootnodoor_enode,
         el_binary_artifact,
+        otel_otlp_grpc_url,
     )
 
     service = plan.add_service(
@@ -102,6 +104,7 @@ def get_config(
     extra_files_artifacts,
     bootnodoor_enode=None,
     el_binary_artifact=None,
+    otel_otlp_grpc_url=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
         participant.el_log_level, global_log_level, VERBOSITY_LEVELS
@@ -243,6 +246,10 @@ def get_config(
             )
         )
 
+    if otel_otlp_grpc_url != None:
+        cmd.append("--tracing-otlp={}".format(otel_otlp_grpc_url))
+        cmd.append("--tracing-otlp.protocol=grpc")
+
     if len(participant.el_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark
         cmd.extend([param for param in participant.el_extra_params])
@@ -319,7 +326,12 @@ def get_config(
         "cmd": cmd,
         "files": files,
         "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
-        "env_vars": env_vars | participant.el_extra_env_vars,
+        "env_vars": env_vars
+        | shared_utils.with_otel_env_vars(
+            participant.el_extra_env_vars,
+            otel_otlp_grpc_url,
+            service_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.EL_TYPE.reth,
             client_type=constants.CLIENT_TYPES.el,

--- a/src/grafana/grafana_launcher.star
+++ b/src/grafana/grafana_launcher.star
@@ -50,6 +50,8 @@ def launch_grafana(
     port_publisher,
     index,
     tempo_query_url=None,
+    clickhouse_host=None,
+    clickhouse_port=None,
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
@@ -63,6 +65,8 @@ def launch_grafana(
         dashboard_providers_config_template,
         prometheus_private_url,
         tempo_query_url,
+        clickhouse_host,
+        clickhouse_port,
         additional_dashboards=grafana_params.additional_dashboards,
     )
 
@@ -88,6 +92,7 @@ def launch_grafana(
         tolerations,
         grafana_params,
         public_ports,
+        clickhouse_host,
     )
 
     plan.add_service(SERVICE_NAME, config)
@@ -99,10 +104,12 @@ def get_grafana_config_dir_artifact_uuid(
     dashboard_providers_config_template,
     prometheus_private_url,
     tempo_query_url,
+    clickhouse_host,
+    clickhouse_port,
     additional_dashboards=[],
 ):
     datasource_data = new_datasource_config_template_data(
-        prometheus_private_url, tempo_query_url
+        prometheus_private_url, tempo_query_url, clickhouse_host, clickhouse_port
     )
     datasource_template_and_data = shared_utils.new_template_and_data(
         datasource_config_template, datasource_data
@@ -149,17 +156,21 @@ def get_config(
     tolerations,
     grafana_params,
     public_ports,
+    clickhouse_host=None,
 ):
+    env_vars = {
+        CONFIG_DIRPATH_ENV_VAR: GRAFANA_CONFIG_DIRPATH_ON_SERVICE,
+        "GF_AUTH_ANONYMOUS_ENABLED": "true",
+        "GF_AUTH_ANONYMOUS_ORG_ROLE": "Admin",
+        "GF_AUTH_ANONYMOUS_ORG_NAME": "Main Org.",
+        "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH": "/dashboards/default.json",
+    }
+    if clickhouse_host != None:
+        env_vars["GF_INSTALL_PLUGINS"] = "grafana-clickhouse-datasource 4.6.0"
     return ServiceConfig(
         image=grafana_params.image,
         ports=USED_PORTS,
-        env_vars={
-            CONFIG_DIRPATH_ENV_VAR: GRAFANA_CONFIG_DIRPATH_ON_SERVICE,
-            "GF_AUTH_ANONYMOUS_ENABLED": "true",
-            "GF_AUTH_ANONYMOUS_ORG_ROLE": "Admin",
-            "GF_AUTH_ANONYMOUS_ORG_NAME": "Main Org.",
-            "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH": "/dashboards/default.json",
-        },
+        env_vars=env_vars,
         files={
             GRAFANA_CONFIG_DIRPATH_ON_SERVICE: grafana_config_artifacts_name,
             GRAFANA_DASHBOARDS_DIRPATH_ON_SERVICE: grafana_dashboards_artifacts_name,
@@ -174,10 +185,15 @@ def get_config(
     )
 
 
-def new_datasource_config_template_data(prometheus_url, tempo_query_url):
+def new_datasource_config_template_data(
+    prometheus_url, tempo_query_url, clickhouse_host, clickhouse_port
+):
     data = {"PrometheusURL": prometheus_url}
     if tempo_query_url != None:
         data["TempoURL"] = tempo_query_url
+    if clickhouse_host != None:
+        data["ClickHouseHost"] = clickhouse_host
+        data["ClickHousePort"] = clickhouse_port
     return data
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -121,6 +121,7 @@ def input_parser(plan, input_args):
     result["rakoon_params"] = get_default_rakoon_params()
     result["custom_flood_params"] = get_default_custom_flood_params()
     result["disable_peer_scoring"] = False
+    result["otel_tracing"] = False
     result["grafana_params"] = get_default_grafana_params()
     result["assertoor_params"] = get_default_assertoor_params()
     result["prometheus_params"] = get_default_prometheus_params()
@@ -856,45 +857,49 @@ def input_parser(plan, input_args):
                 "min_epochs_for_data_column_sidecars_requests"
             ],
         ),
-        mev_params=struct(
-            mev_relay_image=result["mev_params"]["mev_relay_image"],
-            mev_builder_image=result["mev_params"]["mev_builder_image"],
-            mev_builder_cl_image=result["mev_params"]["mev_builder_cl_image"],
-            mev_builder_extra_data=result["mev_params"]["mev_builder_extra_data"],
-            mev_builder_subsidy=result["mev_params"]["mev_builder_subsidy"],
-            mev_boost_image=result["mev_params"]["mev_boost_image"],
-            mev_boost_args=result["mev_params"]["mev_boost_args"],
-            mev_relay_api_extra_args=result["mev_params"]["mev_relay_api_extra_args"],
-            mev_relay_api_extra_env_vars=result["mev_params"][
-                "mev_relay_api_extra_env_vars"
-            ],
-            mev_relay_housekeeper_extra_args=result["mev_params"][
-                "mev_relay_housekeeper_extra_args"
-            ],
-            mev_relay_housekeeper_extra_env_vars=result["mev_params"][
-                "mev_relay_housekeeper_extra_env_vars"
-            ],
-            mev_relay_website_extra_args=result["mev_params"][
-                "mev_relay_website_extra_args"
-            ],
-            mev_relay_website_extra_env_vars=result["mev_params"][
-                "mev_relay_website_extra_env_vars"
-            ],
-            mev_builder_extra_args=result["mev_params"]["mev_builder_extra_args"],
-            mev_builder_cl_extra_params=result["mev_params"][
-                "mev_builder_cl_extra_params"
-            ],
-            mev_builder_prometheus_config=result["mev_params"][
-                "mev_builder_prometheus_config"
-            ],
-            mock_mev_image=result["mev_params"]["mock_mev_image"],
-            launch_adminer=result["mev_params"]["launch_adminer"],
-            run_multiple_relays=result["mev_params"]["run_multiple_relays"],
-            helix_relay_image=result["mev_params"]["helix_relay_image"],
-            commit_boost_config=result["mev_params"].get("commit_boost_config", ""),
-        )
-        if result["mev_params"]
-        else None,
+        mev_params=(
+            struct(
+                mev_relay_image=result["mev_params"]["mev_relay_image"],
+                mev_builder_image=result["mev_params"]["mev_builder_image"],
+                mev_builder_cl_image=result["mev_params"]["mev_builder_cl_image"],
+                mev_builder_extra_data=result["mev_params"]["mev_builder_extra_data"],
+                mev_builder_subsidy=result["mev_params"]["mev_builder_subsidy"],
+                mev_boost_image=result["mev_params"]["mev_boost_image"],
+                mev_boost_args=result["mev_params"]["mev_boost_args"],
+                mev_relay_api_extra_args=result["mev_params"][
+                    "mev_relay_api_extra_args"
+                ],
+                mev_relay_api_extra_env_vars=result["mev_params"][
+                    "mev_relay_api_extra_env_vars"
+                ],
+                mev_relay_housekeeper_extra_args=result["mev_params"][
+                    "mev_relay_housekeeper_extra_args"
+                ],
+                mev_relay_housekeeper_extra_env_vars=result["mev_params"][
+                    "mev_relay_housekeeper_extra_env_vars"
+                ],
+                mev_relay_website_extra_args=result["mev_params"][
+                    "mev_relay_website_extra_args"
+                ],
+                mev_relay_website_extra_env_vars=result["mev_params"][
+                    "mev_relay_website_extra_env_vars"
+                ],
+                mev_builder_extra_args=result["mev_params"]["mev_builder_extra_args"],
+                mev_builder_cl_extra_params=result["mev_params"][
+                    "mev_builder_cl_extra_params"
+                ],
+                mev_builder_prometheus_config=result["mev_params"][
+                    "mev_builder_prometheus_config"
+                ],
+                mock_mev_image=result["mev_params"]["mock_mev_image"],
+                launch_adminer=result["mev_params"]["launch_adminer"],
+                run_multiple_relays=result["mev_params"]["run_multiple_relays"],
+                helix_relay_image=result["mev_params"]["helix_relay_image"],
+                commit_boost_config=result["mev_params"].get("commit_boost_config", ""),
+            )
+            if result["mev_params"]
+            else None
+        ),
         blockscout_params=struct(
             image=result["blockscout_params"]["image"],
             verif_image=result["blockscout_params"]["verif_image"],
@@ -1044,6 +1049,7 @@ def input_parser(plan, input_args):
         xatu_sentry_enabled=result["xatu_sentry_enabled"],
         parallel_keystore_generation=result["parallel_keystore_generation"],
         disable_peer_scoring=result["disable_peer_scoring"],
+        otel_tracing=result["otel_tracing"],
         persistent=result["persistent"],
         xatu_sentry_params=struct(
             xatu_sentry_image=result["xatu_sentry_params"]["xatu_sentry_image"],
@@ -1669,6 +1675,7 @@ def default_input_args(input_args):
         "ethereum_metrics_exporter_enabled": False,
         "parallel_keystore_generation": False,
         "disable_peer_scoring": False,
+        "otel_tracing": False,
         "persistent": False,
         "mev_type": None,
         "xatu_sentry_enabled": False,
@@ -2047,9 +2054,9 @@ def get_default_mev_params(mev_type, preset):
     return {
         "mev_relay_image": mev_relay_image,
         "mev_builder_image": mev_builder_image,
-        "mock_mev_image": mev_builder_image
-        if mev_type == constants.MOCK_MEV_TYPE
-        else None,
+        "mock_mev_image": (
+            mev_builder_image if mev_type == constants.MOCK_MEV_TYPE else None
+        ),
         "mev_builder_subsidy": mev_builder_subsidy,
         "mev_builder_cl_image": mev_builder_cl_image,
         "mev_builder_extra_data": mev_builder_extra_data,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -96,7 +96,22 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "zkboost_params",
     "buildoor_params",
     "ethereum_genesis_generator_params",
+    "otel",
 )
+
+
+def merge_nested_defaults(result, input_args, category):
+    for sub_attr in input_args[category]:
+        sub_value = input_args[category][sub_attr]
+        if (
+            type(sub_value) == "dict"
+            and sub_attr in result[category]
+            and type(result[category][sub_attr]) == "dict"
+        ):
+            for nested_attr in sub_value:
+                result[category][sub_attr][nested_attr] = sub_value[nested_attr]
+        else:
+            result[category][sub_attr] = sub_value
 
 
 def input_parser(plan, input_args):
@@ -121,7 +136,7 @@ def input_parser(plan, input_args):
     result["rakoon_params"] = get_default_rakoon_params()
     result["custom_flood_params"] = get_default_custom_flood_params()
     result["disable_peer_scoring"] = False
-    result["otel_tracing"] = False
+    result["otel"] = get_default_otel_params()
     result["grafana_params"] = get_default_grafana_params()
     result["assertoor_params"] = get_default_assertoor_params()
     result["prometheus_params"] = get_default_prometheus_params()
@@ -248,6 +263,8 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["buildoor_params"]:
                 sub_value = input_args["buildoor_params"][sub_attr]
                 result["buildoor_params"][sub_attr] = sub_value
+        elif attr == "otel":
+            merge_nested_defaults(result, input_args, "otel")
 
     if result.get("snooper_enabled"):
         plan.print(
@@ -1049,7 +1066,11 @@ def input_parser(plan, input_args):
         xatu_sentry_enabled=result["xatu_sentry_enabled"],
         parallel_keystore_generation=result["parallel_keystore_generation"],
         disable_peer_scoring=result["disable_peer_scoring"],
-        otel_tracing=result["otel_tracing"],
+        otel=struct(
+            tracing=struct(
+                enabled=result["otel"]["tracing"]["enabled"],
+            ),
+        ),
         persistent=result["persistent"],
         xatu_sentry_params=struct(
             xatu_sentry_image=result["xatu_sentry_params"]["xatu_sentry_image"],
@@ -1300,6 +1321,9 @@ def parse_network_params(plan, input_args):
                         result["network_params"][target_key] * 3.0 / 2.0 + 0.5
                     )
                 # If both are set or both are 0, don't override
+
+        elif attr == "otel":
+            merge_nested_defaults(result, input_args, "otel")
 
         elif attr == "participants":
             participants = []
@@ -1675,7 +1699,7 @@ def default_input_args(input_args):
         "ethereum_metrics_exporter_enabled": False,
         "parallel_keystore_generation": False,
         "disable_peer_scoring": False,
-        "otel_tracing": False,
+        "otel": get_default_otel_params(),
         "persistent": False,
         "mev_type": None,
         "xatu_sentry_enabled": False,
@@ -1696,6 +1720,14 @@ def default_input_args(input_args):
         "spamoor_params": get_default_spamoor_params(),
         "disruptoor_params": get_default_disruptoor_params(),
         "bootnodoor_params": get_default_bootnodoor_params(),
+    }
+
+
+def get_default_otel_params():
+    return {
+        "tracing": {
+            "enabled": False,
+        },
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -96,7 +96,6 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "zkboost_params",
     "buildoor_params",
     "ethereum_genesis_generator_params",
-    "otel",
     "trueblocks_params",
 )
 
@@ -137,7 +136,6 @@ def input_parser(plan, input_args):
     result["rakoon_params"] = get_default_rakoon_params()
     result["custom_flood_params"] = get_default_custom_flood_params()
     result["disable_peer_scoring"] = False
-    result["otel"] = get_default_otel_params()
     result["grafana_params"] = get_default_grafana_params()
     result["assertoor_params"] = get_default_assertoor_params()
     result["prometheus_params"] = get_default_prometheus_params()
@@ -265,8 +263,6 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["buildoor_params"]:
                 sub_value = input_args["buildoor_params"][sub_attr]
                 result["buildoor_params"][sub_attr] = sub_value
-        elif attr == "otel":
-            merge_nested_defaults(result, input_args, "otel")
         elif attr == "trueblocks_params":
             for sub_attr in input_args["trueblocks_params"]:
                 sub_value = input_args["trueblocks_params"][sub_attr]
@@ -1099,11 +1095,6 @@ def input_parser(plan, input_args):
         xatu_sentry_enabled=result["xatu_sentry_enabled"],
         parallel_keystore_generation=result["parallel_keystore_generation"],
         disable_peer_scoring=result["disable_peer_scoring"],
-        otel=struct(
-            tracing=struct(
-                enabled=result["otel"]["tracing"]["enabled"],
-            ),
-        ),
         persistent=result["persistent"],
         xatu_sentry_params=struct(
             xatu_sentry_image=result["xatu_sentry_params"]["xatu_sentry_image"],
@@ -1367,9 +1358,6 @@ def parse_network_params(plan, input_args):
                         result["network_params"][target_key] * 3.0 / 2.0 + 0.5
                     )
                 # If both are set or both are 0, don't override
-
-        elif attr == "otel":
-            merge_nested_defaults(result, input_args, "otel")
 
         elif attr == "participants":
             participants = []
@@ -1745,7 +1733,6 @@ def default_input_args(input_args):
         "ethereum_metrics_exporter_enabled": False,
         "parallel_keystore_generation": False,
         "disable_peer_scoring": False,
-        "otel": get_default_otel_params(),
         "persistent": False,
         "mev_type": None,
         "xatu_sentry_enabled": False,
@@ -1766,14 +1753,6 @@ def default_input_args(input_args):
         "spamoor_params": get_default_spamoor_params(),
         "disruptoor_params": get_default_disruptoor_params(),
         "bootnodoor_params": get_default_bootnodoor_params(),
-    }
-
-
-def get_default_otel_params():
-    return {
-        "tracing": {
-            "enabled": False,
-        },
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -213,14 +213,6 @@ PORT_PUBLISHER_PARAMS = {
     },
 }
 
-OTEL_PARAMS = {
-    "otel": {
-        "tracing": [
-            "enabled",
-        ],
-    },
-}
-
 SUBCATEGORY_PARAMS = {
     "network_params": [
         "network",
@@ -516,6 +508,7 @@ ADDITIONAL_SERVICES_PARAMS = [
     "disruptoor",
     "zkboost",
     "trueblocks",
+    "otel",
 ]
 
 ADDITIONAL_CATEGORY_PARAMS = {
@@ -646,13 +639,6 @@ def sanity_check(plan, input_args):
         ["image", "target_rpc_url", "target_index", "env"],
     )
 
-    validate_nested_params(
-        plan,
-        input_args,
-        "otel",
-        OTEL_PARAMS["otel"],
-    )
-
     # Checks additional services
     if "additional_services" in input_args:
         for additional_services in input_args["additional_services"]:
@@ -674,7 +660,6 @@ def sanity_check(plan, input_args):
             PARTICIPANT_CATEGORIES.keys()
             + PARTICIPANT_MATRIX_PARAMS.keys()
             + PORT_PUBLISHER_PARAMS.keys()
-            + OTEL_PARAMS.keys()
             + SUBCATEGORY_PARAMS.keys()
             + ADDITIONAL_CATEGORY_PARAMS.keys()
         )

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -508,6 +508,7 @@ ADDITIONAL_CATEGORY_PARAMS = {
     "ethereum_metrics_exporter_enabled": "",
     "parallel_keystore_generation": "",
     "disable_peer_scoring": "",
+    "otel_tracing": "",
     "persistent": "",
     "mev_type": "",
     "xatu_sentry_enabled": "",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -213,6 +213,14 @@ PORT_PUBLISHER_PARAMS = {
     },
 }
 
+OTEL_PARAMS = {
+    "otel": {
+        "tracing": [
+            "enabled",
+        ],
+    },
+}
+
 SUBCATEGORY_PARAMS = {
     "network_params": [
         "network",
@@ -508,7 +516,6 @@ ADDITIONAL_CATEGORY_PARAMS = {
     "ethereum_metrics_exporter_enabled": "",
     "parallel_keystore_generation": "",
     "disable_peer_scoring": "",
-    "otel_tracing": "",
     "persistent": "",
     "mev_type": "",
     "xatu_sentry_enabled": "",
@@ -614,6 +621,13 @@ def sanity_check(plan, input_args):
         ["nat_exit_ip"],
     )
 
+    validate_nested_params(
+        plan,
+        input_args,
+        "otel",
+        OTEL_PARAMS["otel"],
+    )
+
     # Checks additional services
     if "additional_services" in input_args:
         for additional_services in input_args["additional_services"]:
@@ -635,6 +649,7 @@ def sanity_check(plan, input_args):
             PARTICIPANT_CATEGORIES.keys()
             + PARTICIPANT_MATRIX_PARAMS.keys()
             + PORT_PUBLISHER_PARAMS.keys()
+            + OTEL_PARAMS.keys()
             + SUBCATEGORY_PARAMS.keys()
             + ADDITIONAL_CATEGORY_PARAMS.keys()
         )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -50,6 +50,8 @@ def launch_participant_network(
     parallel_keystore_generation,
     extra_files_artifacts,
     tempo_otlp_grpc_url,
+    otel_otlp_grpc_url,
+    otel_otlp_http_traces_url,
     backend,
 ):
     network_id = network_params.network_id
@@ -213,6 +215,7 @@ def launch_participant_network(
         extra_files_artifacts,
         bootnodoor_enode,
         binary_artifacts,
+        otel_otlp_grpc_url,
     )
 
     # Launch all consensus layer clients
@@ -245,6 +248,8 @@ def launch_participant_network(
         global_tolerations,
         persistent,
         tempo_otlp_grpc_url,
+        otel_otlp_grpc_url,
+        otel_otlp_http_traces_url,
         num_participants,
         validator_data,
         prysm_password_relative_filepath,
@@ -573,6 +578,7 @@ def launch_participant_network(
             vc_index=current_vc_index,
             extra_files_artifacts=extra_files_artifacts,
             tempo_otlp_grpc_url=tempo_otlp_grpc_url,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
         if vc_service_config == None:

--- a/src/shared_utils/shared_utils.star
+++ b/src/shared_utils/shared_utils.star
@@ -20,6 +20,32 @@ def new_template_and_data(template, template_data_json):
     return struct(template=template, data=template_data_json)
 
 
+def with_otel_env_vars(env_vars, otel_otlp_grpc_url, service_name):
+    """Merge standard OTel SDK env vars in and append participant resource attrs."""
+    if otel_otlp_grpc_url == None:
+        return env_vars
+    resource_attributes = "service.name={},service.namespace=ethereum-package".format(
+        service_name
+    )
+    participant_resource_attributes = env_vars.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if participant_resource_attributes != "":
+        resource_attributes = "{},{}".format(
+            resource_attributes,
+            participant_resource_attributes,
+        )
+    merged = {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": otel_otlp_grpc_url,
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+        "OTEL_SERVICE_NAME": service_name,
+        "OTEL_RESOURCE_ATTRIBUTES": resource_attributes,
+    }
+    for k, v in env_vars.items():
+        if k == "OTEL_RESOURCE_ATTRIBUTES":
+            continue
+        merged[k] = v
+    return merged
+
+
 def path_join(*args):
     joined_path = "/".join(args)
     return joined_path.replace("//", "/")

--- a/src/vc/lighthouse.star
+++ b/src/vc/lighthouse.star
@@ -35,6 +35,7 @@ def get_config(
     vc_index,
     extra_files_artifacts,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
@@ -84,9 +85,11 @@ def get_config(
         cmd.append("--gas-limit={0}".format(network_params.gas_limit))
         cmd.append("--builder-proposals")
 
-    # Add tempo telemetry integration if tempo is enabled
-    if tempo_otlp_grpc_url != None:
-        cmd.append("--telemetry-collector-url={}".format(tempo_otlp_grpc_url))
+    telemetry_url = (
+        otel_otlp_grpc_url if otel_otlp_grpc_url != None else tempo_otlp_grpc_url
+    )
+    if telemetry_url != None:
+        cmd.append("--telemetry-collector-url={}".format(telemetry_url))
         cmd.append("--telemetry-service-name={}".format(service_name))
 
     if len(participant.vc_extra_params):
@@ -97,7 +100,13 @@ def get_config(
         constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER: node_keystore_files.files_artifact_uuid,
     }
     env = {RUST_BACKTRACE_ENVVAR_NAME: RUST_FULL_BACKTRACE_KEYWORD}
-    env.update(participant.vc_extra_env_vars)
+    env.update(
+        shared_utils.with_otel_env_vars(
+            participant.vc_extra_env_vars,
+            otel_otlp_grpc_url,
+            service_name,
+        )
+    )
 
     public_ports = {}
     public_keymanager_port_assignment = {}

--- a/src/vc/lodestar.star
+++ b/src/vc/lodestar.star
@@ -32,6 +32,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
@@ -137,7 +138,11 @@ def get_config(
     if vc_binary_artifact != None:
         files["/opt/bin"] = vc_binary_artifact.artifact
 
-    env_vars = participant.vc_extra_env_vars
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.vc_extra_env_vars,
+        otel_otlp_grpc_url,
+        full_name,
+    )
     if network_params.preset == "minimal":
         env_vars["LODESTAR_PRESET"] = "minimal"
 

--- a/src/vc/nimbus.star
+++ b/src/vc/nimbus.star
@@ -22,6 +22,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     validator_keys_dirpath = ""
@@ -127,7 +128,11 @@ def get_config(
         "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
-        "env_vars": participant.vc_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.vc_extra_env_vars,
+            otel_otlp_grpc_url,
+            full_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.VC_TYPE.nimbus,
             client_type=constants.CLIENT_TYPES.validator,

--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -27,6 +27,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     validator_keys_dirpath = shared_utils.path_join(
@@ -146,7 +147,11 @@ def get_config(
         "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
-        "env_vars": participant.vc_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.vc_extra_env_vars,
+            otel_otlp_grpc_url,
+            full_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.VC_TYPE.prysm,
             client_type=constants.CLIENT_TYPES.validator,

--- a/src/vc/teku.star
+++ b/src/vc/teku.star
@@ -22,6 +22,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     validator_keys_dirpath = ""
@@ -139,7 +140,11 @@ def get_config(
         "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
-        "env_vars": participant.vc_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.vc_extra_env_vars,
+            otel_otlp_grpc_url,
+            full_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.VC_TYPE.teku,
             client_type=constants.CLIENT_TYPES.validator,

--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -39,6 +39,7 @@ def get_vc_config(
     vc_index,
     extra_files_artifacts,
     tempo_otlp_grpc_url=None,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     if node_keystore_files == None:
@@ -95,6 +96,7 @@ def get_vc_config(
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
             tempo_otlp_grpc_url=tempo_otlp_grpc_url,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.lodestar:
@@ -118,6 +120,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.teku:
@@ -140,6 +143,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.nimbus:
@@ -162,6 +166,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.prysm:
@@ -186,6 +191,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.vero:
@@ -208,6 +214,7 @@ def get_vc_config(
             port_publisher=port_publisher,
             vc_index=vc_index,
             extra_files_artifacts=extra_files_artifacts,
+            otel_otlp_grpc_url=otel_otlp_grpc_url,
             vc_binary_artifact=vc_binary_artifact,
         )
     elif vc_type == constants.VC_TYPE.grandine:

--- a/src/vc/vero.star
+++ b/src/vc/vero.star
@@ -27,6 +27,7 @@ def get_config(
     port_publisher,
     vc_index,
     extra_files_artifacts,
+    otel_otlp_grpc_url=None,
     vc_binary_artifact=None,
 ):
     log_level = input_parser.get_client_log_level_or_default(
@@ -85,7 +86,11 @@ def get_config(
         "publish_udp": port_publisher.vc_enabled,
         "cmd": cmd,
         "files": files,
-        "env_vars": participant.vc_extra_env_vars,
+        "env_vars": shared_utils.with_otel_env_vars(
+            participant.vc_extra_env_vars,
+            otel_otlp_grpc_url,
+            full_name,
+        ),
         "labels": shared_utils.label_maker(
             client=constants.VC_TYPE.vero,
             client_type=constants.CLIENT_TYPES.validator,

--- a/static_files/grafana-config/templates/datasource.yml.tmpl
+++ b/static_files/grafana-config/templates/datasource.yml.tmpl
@@ -27,3 +27,22 @@ datasources:
         spanEndTimeShift: '1h'
         filterByTraceID: true
 {{- end }}
+{{- if .ClickHouseHost }}
+  - name: ClickHouse (otel)
+    type: grafana-clickhouse-datasource
+    access: proxy
+    orgId: 1
+    isDefault: false
+    editable: true
+    jsonData:
+      host: {{ .ClickHouseHost }}
+      port: {{ .ClickHousePort }}
+      protocol: http
+      secure: false
+      defaultDatabase: otel
+      logs:
+        defaultTable: otel_logs
+        timeColumn: Timestamp
+        levelColumn: SeverityText
+        messageColumn: Body
+{{- end }}

--- a/static_files/grafana-config/templates/datasource.yml.tmpl
+++ b/static_files/grafana-config/templates/datasource.yml.tmpl
@@ -42,11 +42,16 @@ datasources:
       defaultDatabase: otel
       logs:
         defaultTable: otel_logs
+        otelEnabled: true
+        otelVersion: latest
         timeColumn: Timestamp
         levelColumn: SeverityText
         messageColumn: Body
+        traceIdColumn: TraceId
       traces:
         defaultTable: otel_traces
+        otelEnabled: true
+        otelVersion: latest
         traceIdColumn: TraceId
         spanIdColumn: SpanId
         operationNameColumn: SpanName

--- a/static_files/grafana-config/templates/datasource.yml.tmpl
+++ b/static_files/grafana-config/templates/datasource.yml.tmpl
@@ -45,4 +45,16 @@ datasources:
         timeColumn: Timestamp
         levelColumn: SeverityText
         messageColumn: Body
+      traces:
+        defaultTable: otel_traces
+        traceIdColumn: TraceId
+        spanIdColumn: SpanId
+        operationNameColumn: SpanName
+        parentSpanIdColumn: ParentSpanId
+        serviceNameColumn: ServiceName
+        durationColumn: Duration
+        durationUnit: nanoseconds
+        startTimeColumn: Timestamp
+        tagsColumn: SpanAttributes
+        serviceTagsColumn: ResourceAttributes
 {{- end }}


### PR DESCRIPTION
When `otel_tracing` is enabled, the package discovers the engine's `kurtosis otel` collector via the default gateway, fails fast if it isn't running, and injects per-client OTLP trace flags plus `OTEL_*` env vars (carrying enclave name/uuid resource attributes) so client traces land in ClickHouse tenanted by enclave. This supersedes the in-enclave ClickHouse + log-bridge approach in #1393.

Depends on the engine-side `kurtosis otel` command: kurtosis-tech/kurtosis#3122.