### PR TITLE
fix: validate per-instance zkvm configs

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -551,25 +551,26 @@ def input_parser(plan, input_args):
                         )
                     )
                 instance_proof_types.append(proof_type)
-                effective_zkvms.append(zkvm)
+                effective_zkvms.append((instance_idx, zkvm_idx, zkvm))
                 if zkvm.get("kind") == "ere" and proof_type not in effective_ere_zkvms_by_proof_type:
                     effective_ere_zkvms_by_proof_type[proof_type] = zkvm
 
-        for idx, zkvm in enumerate(effective_zkvms):
+        for inst_idx, zkvm_idx, zkvm in effective_zkvms:
             kind = zkvm.get("kind")
             proof_type = zkvm.get("proof_type")
+            zkvm_path = "zkboost_params.instances[{0}].zkvms[{1}]".format(inst_idx, zkvm_idx)
 
             if kind not in ["mock", "ere", "external", "verifier"]:
                 fail(
-                    "zkboost_params.zkvms[{0}]: unsupported kind '{1}', please use 'mock', 'ere', 'external', or 'verifier'".format(
-                        idx, kind
+                    "{0}: unsupported kind '{1}', please use 'mock', 'ere', 'external', or 'verifier'".format(
+                        zkvm_path, kind
                     )
                 )
 
             if proof_type not in valid_proof_types:
                 fail(
-                    "zkboost_params.zkvms[{0}]: unsupported proof_type '{1}', please use one of: {2}".format(
-                        idx, proof_type, ", ".join(valid_proof_types)
+                    "{0}: unsupported proof_type '{1}', please use one of: {2}".format(
+                        zkvm_path, proof_type, ", ".join(valid_proof_types)
                     )
                 )
 
@@ -579,18 +580,14 @@ def input_parser(plan, input_args):
             proof_timeout = zkvm.get("proof_timeout_secs", 12)
             if proof_timeout <= 0:
                 fail(
-                    "zkboost_params.zkvms[{0}]: proof_timeout_secs must be > 0, got {1}".format(
-                        idx, proof_timeout
+                    "{0}: proof_timeout_secs must be > 0, got {1}".format(
+                        zkvm_path, proof_timeout
                     )
                 )
 
             if kind == "external":
                 if zkvm.get("endpoint", "") == "":
-                    fail(
-                        "zkboost_params.zkvms[{0}]: external zkvm requires 'endpoint'".format(
-                            idx
-                        )
-                    )
+                    fail("{0}: external zkvm requires 'endpoint'".format(zkvm_path))
 
             if kind == "mock":
                 mock_proving_time = zkvm.get("mock_proving_time")
@@ -598,8 +595,8 @@ def input_parser(plan, input_args):
                     pt_kind = mock_proving_time.get("kind", "constant")
                     if pt_kind not in ["constant", "random", "linear"]:
                         fail(
-                            "zkboost_params.zkvms[{0}]: unsupported mock_proving_time kind '{1}', please use 'constant', 'random' or 'linear'".format(
-                                idx, pt_kind
+                            "{0}: unsupported mock_proving_time kind '{1}', please use 'constant', 'random' or 'linear'".format(
+                                zkvm_path, pt_kind
                             )
                         )
                     if pt_kind == "random":
@@ -607,16 +604,16 @@ def input_parser(plan, input_args):
                         max_ms = mock_proving_time.get("max_ms", 0)
                         if min_ms > max_ms:
                             fail(
-                                "zkboost_params.zkvms[{0}]: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
-                                    idx, min_ms, max_ms
+                                "{0}: mock_proving_time random min_ms ({1}) must be <= max_ms ({2})".format(
+                                    zkvm_path, min_ms, max_ms
                                 )
                             )
 
                 mock_proof_size = zkvm.get("mock_proof_size", 128 << 10)
                 if mock_proof_size < 32:
                     fail(
-                        "zkboost_params.zkvms[{0}]: mock_proof_size must be >= 32, got {1}".format(
-                            idx, mock_proof_size
+                        "{0}: mock_proof_size must be >= 32, got {1}".format(
+                            zkvm_path, mock_proof_size
                         )
                     )
 
@@ -1237,7 +1234,7 @@ def _validate_requested_proof_types(participants, configured_proof_types):
                         "participants[{0}] requests proof_type '{1}' (ID {2}) via --proof-types flag, ".format(
                             idx, proof_type, proof_type_id
                         )
-                        + "but no zkvm is configured for it in zkboost_params.zkvms. "
+                        + "but no zkvm is configured for it in zkboost_params.instances[*].zkvms. "
                         + "Either add a zkvm entry for '{0}' or remove ID {1} from --proof-types. ".format(
                             proof_type, proof_type_id
                         )

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -483,8 +483,13 @@ def input_parser(plan, input_args):
             )
 
     if "zkboost" in result["additional_services"]:
-        # Inject default mock zkvm if none configured.
-        if len(result["zkboost_params"]["zkvms"]) == 0:
+        has_instance_zkvms = False
+        for instance in result["zkboost_params"]["instances"]:
+            if len(instance.get("zkvms", [])) > 0:
+                has_instance_zkvms = True
+
+        # Inject default mock zkvm if none configured globally or per instance.
+        if len(result["zkboost_params"]["zkvms"]) == 0 and not has_instance_zkvms:
             result["zkboost_params"]["zkvms"] = [
                 {
                     "kind": "mock",
@@ -529,7 +534,28 @@ def input_parser(plan, input_args):
             "reth-zisk",
         ]
         configured_proof_types = []
-        for idx, zkvm in enumerate(result["zkboost_params"]["zkvms"]):
+        effective_zkvms = []
+        effective_ere_zkvms_by_proof_type = {}
+        for instance_idx, instance in enumerate(result["zkboost_params"]["instances"]):
+            instance_zkvms = instance.get("zkvms", result["zkboost_params"]["zkvms"])
+            instance_proof_types = []
+            for zkvm_idx, zkvm in enumerate(instance_zkvms):
+                proof_type = zkvm.get("proof_type")
+                if proof_type in instance_proof_types:
+                    fail(
+                        "zkboost_params.instances[{0}].zkvms[{1}]: duplicate proof_type '{2}' in instance '{3}'".format(
+                            instance_idx,
+                            zkvm_idx,
+                            proof_type,
+                            instance.get("name", str(instance_idx)),
+                        )
+                    )
+                instance_proof_types.append(proof_type)
+                effective_zkvms.append(zkvm)
+                if zkvm.get("kind") == "ere" and proof_type not in effective_ere_zkvms_by_proof_type:
+                    effective_ere_zkvms_by_proof_type[proof_type] = zkvm
+
+        for idx, zkvm in enumerate(effective_zkvms):
             kind = zkvm.get("kind")
             proof_type = zkvm.get("proof_type")
 
@@ -547,13 +573,8 @@ def input_parser(plan, input_args):
                     )
                 )
 
-            if proof_type in configured_proof_types:
-                fail(
-                    "zkboost_params.zkvms[{0}]: duplicate proof_type '{1}'".format(
-                        idx, proof_type
-                    )
-                )
-            configured_proof_types.append(proof_type)
+            if proof_type not in configured_proof_types:
+                configured_proof_types.append(proof_type)
 
             proof_timeout = zkvm.get("proof_timeout_secs", 12)
             if proof_timeout <= 0:
@@ -599,7 +620,7 @@ def input_parser(plan, input_args):
                         )
                     )
 
-        _validate_ere_gpu_config(result["zkboost_params"]["zkvms"])
+        _validate_ere_gpu_config(effective_ere_zkvms_by_proof_type.values())
         _validate_requested_proof_types(result["participants"], configured_proof_types)
 
     if (

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -552,13 +552,18 @@ def input_parser(plan, input_args):
                     )
                 instance_proof_types.append(proof_type)
                 effective_zkvms.append((instance_idx, zkvm_idx, zkvm))
-                if zkvm.get("kind") == "ere" and proof_type not in effective_ere_zkvms_by_proof_type:
+                if (
+                    zkvm.get("kind") == "ere"
+                    and proof_type not in effective_ere_zkvms_by_proof_type
+                ):
                     effective_ere_zkvms_by_proof_type[proof_type] = zkvm
 
         for inst_idx, zkvm_idx, zkvm in effective_zkvms:
             kind = zkvm.get("kind")
             proof_type = zkvm.get("proof_type")
-            zkvm_path = "zkboost_params.instances[{0}].zkvms[{1}]".format(inst_idx, zkvm_idx)
+            zkvm_path = "zkboost_params.instances[{0}].zkvms[{1}]".format(
+                inst_idx, zkvm_idx
+            )
 
             if kind not in ["mock", "ere", "external", "verifier"]:
                 fail(


### PR DESCRIPTION
## Summary

- Validate zkboost instances using the effective zkvm list that the launcher renders: per-instance zkvms when present, otherwise top-level zkvms.

- Avoid injecting the default mock when any instance defines its own zkvms, fail early on duplicate proof types within a single rendered instance, and keep requested proof type plus ERE GPU validation aligned with the launcher behavior.

- Add dry-run fixtures covering global zkvms, per-instance zkvms, default mock injection, duplicate proof types, missing requested proof types, and GPU overlap validation.

Written by [Claude Code](https://code.claude.com)