### PR TITLE
test: add 8GPU isolated verifier test with Assertoor checks

### DIFF
--- a/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+++ b/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
@@ -53,15 +53,6 @@ participants:
       - --proof-types=2,6
     count: 2
 
-  # Prysm CL-only node
-  - cl_type: prysm
-    cl_image: ethpandaops/prysm-beacon-chain:optional-proofs
-    el_type: None
-    cl_extra_params:
-      - --enable-zkvm
-      - --verifier-rest-api-provider=http://zkboost-verifier:3000
-    count: 1
-
 network_params:
   seconds_per_slot: 30
 

--- a/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+++ b/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
@@ -74,6 +74,11 @@ additional_services:
   - assertoor
   - spamoor
 
+assertoor_params:
+  image: assertoor:check-http-metrics
+  tests:
+    - /tests/zkboost-metrics-test.yaml
+
 zkboost_params:
   image: ghcr.io/eth-act/zkboost/zkboost:0.7.0
   env:

--- a/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+++ b/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
@@ -1,0 +1,107 @@
+# EIP-8025 testnet with GPU provers and isolated CPU verifiers.
+#
+# Architecture:
+#   - zkboost-reth: GPU prover for reth-zisk, fetches witness from reth EL (GPUs 0-3)
+#   - zkboost-ethrex: GPU prover for ethrex-zisk, fetches witness from ethrex EL (GPUs 4-7)
+#   - zkboost-verifier: In-process CPU verification for both proof types
+#
+# Run with:
+#   kurtosis run --enclave eip8025-zkboost-isolated \
+#       . \
+#       --args-file .github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+#
+# Prerequisites:
+#   - NVIDIA GPUs with drivers installed (8 GPUs: 4 per prover type)
+#   - NVIDIA Container Toolkit configured for Docker
+
+participants:
+  # Reth full node: requests reth-zisk proofs from zkboost-reth
+  - cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth
+    cl_extra_params:
+      - --target-peers=3
+      - --proof-engine-endpoint=http://zkboost-verifier:3000
+      - --proof-types=6
+    vc_extra_params:
+      - --proof-engine-endpoint=http://zkboost-reth:3000
+      - --proof-types=6
+    count: 1
+
+  # Ethrex full node: requests ethrex-zisk proofs from zkboost-ethrex
+  - cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    el_type: ethrex
+    el_image: ghcr.io/lambdaclass/ethrex:latest
+    cl_extra_params:
+      - --target-peers=3
+      - --proof-engine-endpoint=http://zkboost-verifier:3000
+      - --proof-types=2
+    vc_extra_params:
+      - --proof-engine-endpoint=http://zkboost-ethrex:3000
+      - --proof-types=2
+    count: 1
+
+  # CL-only nodes: verify both proof types
+  - cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    el_type: None
+    cl_extra_params:
+      - --target-peers=3
+      - --proof-engine-endpoint=http://zkboost-verifier:3000
+      - --proof-types=2,6
+    count: 2
+
+  # Prysm CL-only node
+  - cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:optional-proofs
+    el_type: None
+    cl_extra_params:
+      - --enable-zkvm
+      - --verifier-rest-api-provider=http://zkboost-verifier:3000
+    count: 1
+
+network_params:
+  seconds_per_slot: 30
+
+additional_services:
+  - zkboost
+  - dora
+  - prometheus
+  - grafana
+  - tempo
+  - assertoor
+  - spamoor
+
+zkboost_params:
+  image: ghcr.io/eth-act/zkboost/zkboost:0.7.0
+  env:
+    RUST_LOG: info,zkboost=debug
+  instances:
+    # Reth prover: fetches witness from reth EL, generates reth-zisk proofs
+    - name: zkboost-reth
+      el_participant_index: 0
+      zkvms:
+        - kind: ere
+          proof_type: reth-zisk
+          gpu:
+            device_ids: ["0", "1", "2", "3"]
+
+    # Ethrex prover: fetches witness from ethrex EL, generates ethrex-zisk proofs
+    - name: zkboost-ethrex
+      el_participant_index: 1
+      zkvms:
+        - kind: ere
+          proof_type: ethrex-zisk
+          gpu:
+            device_ids: ["4", "5", "6", "7"]
+
+    # CPU verifier: handles verification for both proof types
+    - name: zkboost-verifier
+      el_participant_index: 0
+      zkvms:
+        - kind: verifier
+          proof_type: reth-zisk
+        - kind: verifier
+          proof_type: ethrex-zisk

--- a/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+++ b/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
@@ -1,8 +1,11 @@
+---
 # EIP-8025 testnet with GPU provers and isolated CPU verifiers.
 #
 # Architecture:
-#   - zkboost-reth: GPU prover for reth-zisk, fetches witness from reth EL (GPUs 0-3)
-#   - zkboost-ethrex: GPU prover for ethrex-zisk, fetches witness from ethrex EL (GPUs 4-7)
+#   - zkboost-reth: GPU prover for reth-zisk, fetches witness from reth EL
+#     on GPUs 0-3
+#   - zkboost-ethrex: GPU prover for ethrex-zisk, fetches witness from
+#     ethrex EL on GPUs 4-7
 #   - zkboost-verifier: In-process CPU verification for both proof types
 #
 # Run with:
@@ -84,7 +87,7 @@ zkboost_params:
           gpu:
             device_ids: ["0", "1", "2", "3"]
 
-    # Ethrex prover: fetches witness from ethrex EL, generates ethrex-zisk proofs
+    # Ethrex prover: fetches witness from ethrex EL and generates proofs
     - name: zkboost-ethrex
       el_participant_index: 1
       zkvms:

--- a/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
+++ b/.github/tests/examples/8gpu_zkvm_isolated_verifier.yaml
@@ -69,9 +69,10 @@ additional_services:
   - spamoor
 
 assertoor_params:
-  image: assertoor:check-http-metrics
+  image: assertoor:check-http-json
   tests:
     - /tests/zkboost-metrics-test.yaml
+    - /tests/zkboost-json-test.yaml
 
 zkboost_params:
   image: ghcr.io/eth-act/zkboost/zkboost:0.7.0

--- a/static_files/assertoor-config/tests/zkboost-json-test.yaml
+++ b/static_files/assertoor-config/tests/zkboost-json-test.yaml
@@ -1,0 +1,204 @@
+---
+id: zkboost-json-test
+name: "ZKBoost JSON API Test"
+timeout: 3h
+tasks:
+  - name: check_clients_are_healthy
+    title: "Check if clients are ready"
+    timeout: 10m
+    config:
+      minClientCount: 1
+
+  - name: run_tasks_concurrent
+    title: "Verify zkboost services"
+    timeout: 2h
+    config:
+      tasks:
+        # Health checks (empty body, status-only)
+        - name: check_http_json
+          title: "zkboost-reth: health check"
+          timeout: 5m
+          config:
+            url: http://zkboost-reth:3000/health
+            pollInterval: 10s
+            assertions: []
+
+        - name: check_http_json
+          title: "zkboost-ethrex: health check"
+          timeout: 5m
+          config:
+            url: http://zkboost-ethrex:3000/health
+            pollInterval: 10s
+            assertions: []
+
+        - name: check_http_json
+          title: "zkboost-verifier: health check"
+          timeout: 5m
+          config:
+            url: http://zkboost-verifier:3000/health
+            pollInterval: 10s
+            assertions: []
+
+        # Reth prover configuration
+        - name: check_http_json
+          title: "zkboost-reth: verify proof type configuration"
+          timeout: 5m
+          config:
+            url: http://zkboost-reth:3000/v1/proof_types
+            pollInterval: 10s
+            assertions:
+              - name: has_reth_zisk
+                query: '.proof_types[] | select(.proof_type == "reth-zisk")'
+                exists: true
+              - name: kind_is_ere
+                query: >-
+                  .proof_types[] | select(.proof_type == "reth-zisk") | .kind
+                operator: eq
+                value: "ere"
+              - name: can_prove
+                query: >-
+                  .proof_types[]
+                  | select(.proof_type == "reth-zisk")
+                  | .can_prove
+                operator: eq
+                value: true
+              - name: single_proof_type
+                query: '.proof_types | length'
+                operator: eq
+                value: 1
+
+        # Ethrex prover configuration
+        - name: check_http_json
+          title: "zkboost-ethrex: verify proof type configuration"
+          timeout: 5m
+          config:
+            url: http://zkboost-ethrex:3000/v1/proof_types
+            pollInterval: 10s
+            assertions:
+              - name: has_ethrex_zisk
+                query: '.proof_types[] | select(.proof_type == "ethrex-zisk")'
+                exists: true
+              - name: kind_is_ere
+                query: >-
+                  .proof_types[] | select(.proof_type == "ethrex-zisk") | .kind
+                operator: eq
+                value: "ere"
+              - name: can_prove
+                query: >-
+                  .proof_types[]
+                  | select(.proof_type == "ethrex-zisk")
+                  | .can_prove
+                operator: eq
+                value: true
+              - name: single_proof_type
+                query: '.proof_types | length'
+                operator: eq
+                value: 1
+
+        # Verifier configuration (handles both proof types)
+        - name: check_http_json
+          title: "zkboost-verifier: verify proof type configuration"
+          timeout: 5m
+          config:
+            url: http://zkboost-verifier:3000/v1/proof_types
+            pollInterval: 10s
+            assertions:
+              - name: has_reth_zisk
+                query: '.proof_types[] | select(.proof_type == "reth-zisk")'
+                exists: true
+              - name: has_ethrex_zisk
+                query: '.proof_types[] | select(.proof_type == "ethrex-zisk")'
+                exists: true
+              - name: reth_zisk_can_verify
+                query: >-
+                  .proof_types[]
+                  | select(.proof_type == "reth-zisk")
+                  | .can_verify
+                operator: eq
+                value: true
+              - name: ethrex_zisk_can_verify
+                query: >-
+                  .proof_types[]
+                  | select(.proof_type == "ethrex-zisk")
+                  | .can_verify
+                operator: eq
+                value: true
+              - name: both_are_verifiers
+                query: '.proof_types[] | select(.kind != "verifier")'
+                exists: false
+              - name: two_proof_types
+                query: '.proof_types | length'
+                operator: eq
+                value: 2
+
+        # Dashboard state checks
+        - name: check_http_json
+          title: "zkboost-reth: dashboard state"
+          timeout: 5m
+          config:
+            url: http://zkboost-reth:3000/dashboard/state
+            pollInterval: 10s
+            assertions:
+              - name: has_build_version
+                query: '.buildVersion'
+                exists: true
+              - name: version_format
+                query: '.buildVersion'
+                operator: contains
+                value: "."
+              - name: has_reth_zisk_configured
+                query: '.proofTypes[] | select(. == "reth-zisk")'
+                exists: true
+              - name: retention_configured
+                query: '.retention'
+                operator: gt
+                value: 0
+
+        - name: check_http_json
+          title: "zkboost-ethrex: dashboard state"
+          timeout: 5m
+          config:
+            url: http://zkboost-ethrex:3000/dashboard/state
+            pollInterval: 10s
+            assertions:
+              - name: has_build_version
+                query: '.buildVersion'
+                exists: true
+              - name: has_ethrex_zisk_configured
+                query: '.proofTypes[] | select(. == "ethrex-zisk")'
+                exists: true
+
+        # Wait for proofs from both provers
+        - name: check_http_json
+          title: "zkboost-reth: wait for successful proof"
+          timeout: 2h
+          config:
+            url: http://zkboost-reth:3000/dashboard/state
+            pollInterval: 30s
+            assertions:
+              - name: has_blocks
+                query: '.historicalBlocks | length'
+                operator: gte
+                value: 1
+              - name: proof_succeeded
+                query: >-
+                  .historicalBlocks[].proofs["reth-zisk"].result
+                  | select(. == "success")
+                exists: true
+
+        - name: check_http_json
+          title: "zkboost-ethrex: wait for successful proof"
+          timeout: 2h
+          config:
+            url: http://zkboost-ethrex:3000/dashboard/state
+            pollInterval: 30s
+            assertions:
+              - name: has_blocks
+                query: '.historicalBlocks | length'
+                operator: gte
+                value: 1
+              - name: proof_succeeded
+                query: >-
+                  .historicalBlocks[].proofs["ethrex-zisk"].result
+                  | select(. == "success")
+                exists: true

--- a/static_files/assertoor-config/tests/zkboost-metrics-test.yaml
+++ b/static_files/assertoor-config/tests/zkboost-metrics-test.yaml
@@ -1,85 +1,86 @@
+---
 id: zkboost-metrics-test
 name: "ZKBoost Metrics Test"
 timeout: 3h
 tasks:
-- name: check_clients_are_healthy
-  title: "Check if clients are ready"
-  timeout: 10m
-  config:
-    minClientCount: 1
+  - name: check_clients_are_healthy
+    title: "Check if clients are ready"
+    timeout: 10m
+    config:
+      minClientCount: 1
 
-- name: run_tasks_concurrent
-  title: "Check zkboost metrics"
-  timeout: 2h
-  config:
-    tasks:
-    - name: check_http_metrics
-      title: "Check reth-zisk prover metrics"
-      timeout: 2h
-      config:
-        url: http://zkboost-reth:3000/metrics
-        pollInterval: 30s
-        requestTimeout: 5s
-        maxResponseSize: 10MB
-        missingMetric: wait
-        missingSeries: wait
-        resetBehavior: fail
-        assertions:
-        - name: reth-zisk prove success increased
-          metric: zkboost_prove_total
-          labels:
-            proof_type: reth-zisk
-            status: success
-          mode: delta
-          operator: gt
-          value: 0
+  - name: run_tasks_concurrent
+    title: "Check zkboost metrics"
+    timeout: 2h
+    config:
+      tasks:
+        - name: check_http_metrics
+          title: "Check reth-zisk prover metrics"
+          timeout: 2h
+          config:
+            url: http://zkboost-reth:3000/metrics
+            pollInterval: 30s
+            requestTimeout: 5s
+            maxResponseSize: 10MB
+            missingMetric: wait
+            missingSeries: wait
+            resetBehavior: fail
+            assertions:
+              - name: reth-zisk prove success increased
+                metric: zkboost_prove_total
+                labels:
+                  proof_type: reth-zisk
+                  status: success
+                mode: delta
+                operator: gt
+                value: 0
 
-    - name: check_http_metrics
-      title: "Check ethrex-zisk prover metrics"
-      timeout: 2h
-      config:
-        url: http://zkboost-ethrex:3000/metrics
-        pollInterval: 30s
-        requestTimeout: 5s
-        maxResponseSize: 10MB
-        missingMetric: wait
-        missingSeries: wait
-        resetBehavior: fail
-        assertions:
-        - name: ethrex-zisk prove success increased
-          metric: zkboost_prove_total
-          labels:
-            proof_type: ethrex-zisk
-            status: success
-          mode: delta
-          operator: gt
-          value: 0
+        - name: check_http_metrics
+          title: "Check ethrex-zisk prover metrics"
+          timeout: 2h
+          config:
+            url: http://zkboost-ethrex:3000/metrics
+            pollInterval: 30s
+            requestTimeout: 5s
+            maxResponseSize: 10MB
+            missingMetric: wait
+            missingSeries: wait
+            resetBehavior: fail
+            assertions:
+              - name: ethrex-zisk prove success increased
+                metric: zkboost_prove_total
+                labels:
+                  proof_type: ethrex-zisk
+                  status: success
+                mode: delta
+                operator: gt
+                value: 0
 
-    - name: check_http_metrics
-      title: "Check isolated verifier metrics"
-      timeout: 2h
-      config:
-        url: http://zkboost-verifier:3000/metrics
-        pollInterval: 30s
-        requestTimeout: 5s
-        maxResponseSize: 10MB
-        missingMetric: wait
-        missingSeries: wait
-        resetBehavior: fail
-        assertions:
-        - name: reth-zisk verify true increased
-          metric: zkboost_verify_total
-          labels:
-            proof_type: reth-zisk
-            verified: "true"
-          mode: delta
-          operator: gt
-          value: 0
-        - name: ethrex-zisk verify true increased
-          metric: zkboost_verify_total
-          labels:
-            proof_type: ethrex-zisk
-            verified: "true"
-          mode: delta
-          operator: gt
-          value: 0
+        - name: check_http_metrics
+          title: "Check isolated verifier metrics"
+          timeout: 2h
+          config:
+            url: http://zkboost-verifier:3000/metrics
+            pollInterval: 30s
+            requestTimeout: 5s
+            maxResponseSize: 10MB
+            missingMetric: wait
+            missingSeries: wait
+            resetBehavior: fail
+            assertions:
+              - name: reth-zisk verify true increased
+                metric: zkboost_verify_total
+                labels:
+                  proof_type: reth-zisk
+                  verified: "true"
+                mode: delta
+                operator: gt
+                value: 0
+              - name: ethrex-zisk verify true increased
+                metric: zkboost_verify_total
+                labels:
+                  proof_type: ethrex-zisk
+                  verified: "true"
+                mode: delta
+                operator: gt
+                value: 0

--- a/static_files/assertoor-config/tests/zkboost-metrics-test.yaml
+++ b/static_files/assertoor-config/tests/zkboost-metrics-test.yaml
@@ -1,0 +1,85 @@
+id: zkboost-metrics-test
+name: "ZKBoost Metrics Test"
+timeout: 3h
+tasks:
+- name: check_clients_are_healthy
+  title: "Check if clients are ready"
+  timeout: 10m
+  config:
+    minClientCount: 1
+
+- name: run_tasks_concurrent
+  title: "Check zkboost metrics"
+  timeout: 2h
+  config:
+    tasks:
+    - name: check_http_metrics
+      title: "Check reth-zisk prover metrics"
+      timeout: 2h
+      config:
+        url: http://zkboost-reth:3000/metrics
+        pollInterval: 30s
+        requestTimeout: 5s
+        maxResponseSize: 10MB
+        missingMetric: wait
+        missingSeries: wait
+        resetBehavior: fail
+        assertions:
+        - name: reth-zisk prove success increased
+          metric: zkboost_prove_total
+          labels:
+            proof_type: reth-zisk
+            status: success
+          mode: delta
+          operator: gt
+          value: 0
+
+    - name: check_http_metrics
+      title: "Check ethrex-zisk prover metrics"
+      timeout: 2h
+      config:
+        url: http://zkboost-ethrex:3000/metrics
+        pollInterval: 30s
+        requestTimeout: 5s
+        maxResponseSize: 10MB
+        missingMetric: wait
+        missingSeries: wait
+        resetBehavior: fail
+        assertions:
+        - name: ethrex-zisk prove success increased
+          metric: zkboost_prove_total
+          labels:
+            proof_type: ethrex-zisk
+            status: success
+          mode: delta
+          operator: gt
+          value: 0
+
+    - name: check_http_metrics
+      title: "Check isolated verifier metrics"
+      timeout: 2h
+      config:
+        url: http://zkboost-verifier:3000/metrics
+        pollInterval: 30s
+        requestTimeout: 5s
+        maxResponseSize: 10MB
+        missingMetric: wait
+        missingSeries: wait
+        resetBehavior: fail
+        assertions:
+        - name: reth-zisk verify true increased
+          metric: zkboost_verify_total
+          labels:
+            proof_type: reth-zisk
+            verified: "true"
+          mode: delta
+          operator: gt
+          value: 0
+        - name: ethrex-zisk verify true increased
+          metric: zkboost_verify_total
+          labels:
+            proof_type: ethrex-zisk
+            verified: "true"
+          mode: delta
+          operator: gt
+          value: 0


### PR DESCRIPTION
## Summary

Adds a full zkboost/EIP-8025 Kurtosis test configuration with Assertoor coverage.

This introduces an 8-GPU isolated-verifier example that runs separate reth-zisk and ethrex-zisk zkboost prover instances, plus a shared verifier instance for both proof types. It also enables Assertoor and Spamoor for the run.

The PR adds a new Assertoor test that checks zkboost Prometheus metrics for:

- reth-zisk proof generation success
- ethrex-zisk proof generation success
- verifier success for both proof types

### Dependencies:
1) [check-http-metrics task](https://github.com/ethpandaops/assertoor/pull/186/)
2) [per instance zkVM validation](https://github.com/ethpandaops/ethereum-package/pull/1407)