### PR TITLE
docs(skill): default to kurtosis otel/ClickHouse for log + trace collection

### DIFF
--- a/.claude/skills/kurtosis-ethereum/SKILL.md
+++ b/.claude/skills/kurtosis-ethereum/SKILL.md
@@ -15,8 +15,11 @@ Run Ethereum consensus/execution client devnets via [kurtosis](https://github.co
 ## Quick Start
 
 ```bash
-# ALWAYS start grafloki first — enables Loki log collection for debugging
-kurtosis loki start
+# ALWAYS start the OTel stack first — runs an OTel collector + ClickHouse on the
+# Docker host for centralized log (and trace) collection while debugging.
+# Docker-only. Logs are stamped with the enclave name; traces require the
+# `otel` additional_service (see below). ClickHouse on :18123, OTLP on :14317/:14318.
+kurtosis otel start
 
 # Write a network_params.yaml, then:
 kurtosis run github.com/ethpandaops/ethereum-package \
@@ -72,6 +75,8 @@ network_params:
 additional_services:
   - dora                     # block explorer
   - assertoor                # automated testing
+  - otel                     # ship EL/CL/VC traces to the engine OTel/ClickHouse
+                             # stack (Docker-only; requires `kurtosis otel start`)
 ```
 
 ## Reference Tool


### PR DESCRIPTION
## What

Updates the `kurtosis-ethereum` Claude skill to make the OTel/ClickHouse stack the default for log and trace collection, replacing the old `kurtosis loki start` grafloki path.

- **Quick Start** now opens with `kurtosis otel start` — runs an OTel collector + single-node ClickHouse on the Docker host for centralized logs (enclave-name stamped) and traces. Notes Docker-only + host ports (ClickHouse `:18123`, OTLP `:14317`/`:14318`).
- **`additional_services`** documents the `otel` service that ships EL/CL/VC traces to that engine stack.

## Why

Reflects the new flow from:
- ethpandaops/ethereum-package#1405 — `otel` additional_service ships traces to the engine OTel/ClickHouse stack
- kurtosis-tech/kurtosis#3122 — `kurtosis otel start`/`stop` side containers; Vector also exports logs to ClickHouse

`kurtosis loki start` still exists in the CLI and keeps working, but is no longer the recommended default. SKILL.md was the only file in the repo referencing loki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)