### PR TITLE
feat(dora): auto-configure buildoor inventory when mev_type: buildoor

### DIFF
--- a/main.star
+++ b/main.star
@@ -635,6 +635,7 @@ def run(plan, args={}):
 
     mev_endpoints = []
     mev_endpoint_names = []
+    buildoor_api_urls = []
     # passed external relays get priority
     # perhaps add mev_type External or remove this
     if (
@@ -688,7 +689,7 @@ def run(plan, args={}):
             all_el_contexts[0].dns_name,
             all_el_contexts[0].engine_rpc_port_num,
         )
-        endpoint = buildoor.launch_buildoor(
+        buildoor_endpoints = buildoor.launch_buildoor(
             plan,
             beacon_uri,
             el_rpc_uri,
@@ -701,8 +702,9 @@ def run(plan, args={}):
             builder_bls_secret_key,
             ranges,
         )
-        mev_endpoints.append(endpoint)
+        mev_endpoints.append(buildoor_endpoints["mev_endpoint"])
         mev_endpoint_names.append(constants.BUILDOOR_MEV_TYPE)
+        buildoor_api_urls.append(buildoor_endpoints["api_url"])
     elif args_with_right_defaults.mev_type and (
         args_with_right_defaults.mev_type == constants.FLASHBOTS_MEV_TYPE
         or args_with_right_defaults.mev_type == constants.MEV_RS_MEV_TYPE
@@ -1007,6 +1009,7 @@ def run(plan, args={}):
                 index,
                 args_with_right_defaults.docker_cache_params,
                 el_cl_data_files_artifact_uuid,
+                buildoor_api_urls,
             )
             plan.print("Successfully launched dora")
         elif additional_service == "checkpointz":

--- a/src/dora/dora_launcher.star
+++ b/src/dora/dora_launcher.star
@@ -42,6 +42,7 @@ def launch_dora(
     additional_service_index,
     docker_cache_params,
     el_cl_data_files_artifact_uuid,
+    buildoor_api_urls=[],
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
@@ -100,6 +101,7 @@ def launch_dora(
         all_cl_client_info,
         all_el_client_info,
         mev_endpoint_info,
+        buildoor_api_urls,
     )
 
     template_and_data = shared_utils.new_template_and_data(
@@ -173,7 +175,12 @@ def get_config(
 
 
 def new_config_template_data(
-    network, listen_port_num, cl_client_info, el_client_info, mev_endpoint_info
+    network,
+    listen_port_num,
+    cl_client_info,
+    el_client_info,
+    mev_endpoint_info,
+    buildoor_api_urls,
 ):
     public_rpc = ""
     if len(el_client_info) > 0:
@@ -186,6 +193,7 @@ def new_config_template_data(
         "CLClientInfo": cl_client_info,
         "ELClientInfo": el_client_info,
         "MEVRelayInfo": mev_endpoint_info,
+        "BuildoorAPIURLs": buildoor_api_urls,
         "PublicNetwork": True if network in constants.PUBLIC_NETWORKS else False,
         "IsDevnet": True if "devnet" in network else False,
     }

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -99,6 +99,14 @@ def launch_buildoor(
             tolerations=tolerations,
         ),
     )
-    return "http://{0}@{1}:{2}".format(
-        constants.DEFAULT_MEV_PUBKEY, BUILDOOR_SERVICE_NAME, BUILDOOR_BUILDER_API_PORT
-    )
+    return {
+        "mev_endpoint": "http://{0}@{1}:{2}".format(
+            constants.DEFAULT_MEV_PUBKEY,
+            BUILDOOR_SERVICE_NAME,
+            BUILDOOR_BUILDER_API_PORT,
+        ),
+        "api_url": "http://{0}:{1}".format(
+            BUILDOOR_SERVICE_NAME,
+            BUILDOOR_API_PORT,
+        ),
+    }

--- a/static_files/dora-config/config.yaml.tmpl
+++ b/static_files/dora-config/config.yaml.tmpl
@@ -32,6 +32,14 @@ frontend:
   validatorNamesYaml: "/validator-ranges/validator-ranges.yaml"
 {{- end }}
 
+{{- if .BuildoorAPIURLs }}
+  buildoorUrls:
+{{- range $url := .BuildoorAPIURLs }}
+    - "{{ $url }}"
+{{- end }}
+  buildoorRefreshInterval: 5m
+{{- end }}
+
   rainbowkitProjectId: "15fe4ab4d5c0bcb6f0dc7c398301ff0e"
   showSubmitDeposit: true
   showSubmitElRequests: true


### PR DESCRIPTION

<img width="1043" height="346" alt="Screenshot 2026-06-05 at 16 29 05" src="https://github.com/user-attachments/assets/c44fba32-6841-416d-aa62-af7aebbea5e3" />

## Summary
When `mev_type: buildoor` is set, dora's generated config now includes a `buildoorUrls` list pointing at the launched buildoor service's API port (8080), so dora can resolve builder names + external links via `/api/buildoor/overview` automatically — no manual config tweaks needed.

**Blocked on** https://github.com/ethpandaops/dora/pull/728, which introduces the `buildoorUrls` frontend config knob this template targets. Merge dora's PR first (or wait for a release), otherwise dora will ignore the unknown key.

## Changes

- **`src/mev/buildoor/buildoor_launcher.star`** — `launch_buildoor` now returns `{mev_endpoint, api_url}`. `mev_endpoint` (port 9000, the mev-boost-style URL) keeps feeding `mev_endpoints` as before; `api_url` (port 8080, the general API) is the new endpoint dora needs.
- **`main.star`** — accumulates `buildoor_api_urls` alongside `mev_endpoints` and threads them into `launch_dora`.
- **`src/dora/dora_launcher.star`** — accepts `buildoor_api_urls` (default `[]` for backward compat) and exposes them as `BuildoorAPIURLs` in the template data.
- **`static_files/dora-config/config.yaml.tmpl`** — renders a `buildoorUrls: [...]` block under `frontend:` when `BuildoorAPIURLs` is non-empty.

## Generated config diff

Before (mev_type: buildoor):
```yaml
frontend:
  enabled: true
  ...
  rainbowkitProjectId: "..."
```

After:
```yaml
frontend:
  enabled: true
  ...
  buildoorUrls:
    - "http://buildoor:8080"
  buildoorRefreshInterval: 5m
  rainbowkitProjectId: "..."
```

## Test plan

- [ ] `kurtosis lint --format` clean (verified locally — 108 files unchanged)
- [ ] Stand up a devnet with `mev_type: buildoor` + `additional_services: [dora]`, inspect `dora-config.yaml`, confirm `buildoorUrls` is populated.
- [ ] Stand up without `mev_type: buildoor`, confirm `buildoorUrls` block is absent (template gated on `.BuildoorAPIURLs`).
- [ ] With both PRs merged: dora UI shows builder names + external-link icons on the slot bids page.