### PR TITLE
fix: publish remote signer HTTP port on deterministic public port

### DIFF
--- a/src/remote_signer/remote_signer_launcher.star
+++ b/src/remote_signer/remote_signer_launcher.star
@@ -145,7 +145,8 @@ def get_config(
             "remote-signer", port_publisher, remote_signer_index
         )
         public_port_assignments = {
-            constants.METRICS_PORT_ID: public_ports_for_component[0]
+            REMOTE_SIGNER_HTTP_PORT_ID: public_ports_for_component[0],
+            constants.METRICS_PORT_ID: public_ports_for_component[1],
         }
         public_ports = shared_utils.get_port_specs(public_port_assignments)
 


### PR DESCRIPTION
## Summary

Fixes #1236.

When `port_publisher.remote_signer.enabled: true`, the remote signer's **HTTP** port was not being assigned a deterministic public port — only the **metrics** port was. As a result, HTTP got a random host port while metrics correctly respected `public_port_start`.

`MAX_PORTS_PER_REMOTE_SIGNER_NODE = 2` already reserves two public ports per signer, but only one slot (`[0]`) was being consumed, leaving the HTTP port unpublished.

## Change

In `src/remote_signer/remote_signer_launcher.star`, assign both reserved public ports:

```python
public_port_assignments = {
    REMOTE_SIGNER_HTTP_PORT_ID: public_ports_for_component[0],
    constants.METRICS_PORT_ID: public_ports_for_component[1],
}
```

HTTP now takes the first reserved port (e.g. `35000`) and metrics the second (e.g. `35001`), matching the HTTP-first/metrics-second convention used by the other components.

Credit to @imnotanoob for diagnosing the issue and proposing the fix.