### PR TITLE
feat: support remote_signer in participants_matrix

### DIFF
--- a/.github/tests/remote-signer-matrix.yaml
+++ b/.github/tests/remote-signer-matrix.yaml
@@ -1,0 +1,12 @@
+participants_matrix:
+  el:
+    - el_type: geth
+  cl:
+    - cl_type: prysm
+      use_separate_vc: true
+  vc:
+    - vc_type: prysm
+  remote_signer:
+    - use_remote_signer: true
+      remote_signer_type: web3signer
+      remote_signer_image: consensys/web3signer:develop

--- a/.github/tests/remote-signer-matrix.yaml
+++ b/.github/tests/remote-signer-matrix.yaml
@@ -7,6 +7,5 @@ participants_matrix:
   vc:
     - vc_type: prysm
   remote_signer:
-    - use_remote_signer: true
-      remote_signer_type: web3signer
+    - remote_signer_type: web3signer
       remote_signer_image: consensys/web3signer:develop

--- a/README.md
+++ b/README.md
@@ -696,8 +696,9 @@ participants:
     # Defaults to false
     skip_start: false
 
-# Participants matrix creates a participant for each combination of EL, CL and VC clients
-# Each EL/CL/VC item can provide the same parameters as a standard participant
+# Participants matrix creates a participant for each combination of EL, CL, VC
+# and remote signer clients.
+# Each el/cl/vc/remote_signer item can provide the same parameters as a standard participant.
 participants_matrix: {}
   # el:
   #   - el_type: geth
@@ -708,6 +709,11 @@ participants_matrix: {}
   # vc:
   #   - vc_type: prysm
   #   - vc_type: lighthouse
+  # remote_signer:
+  #   - use_remote_signer: true
+  #     remote_signer_type: web3signer
+  #     remote_signer_image: consensys/web3signer:develop
+  # NOTE: a remote signer requires `use_separate_vc: true` on the matching cl item.
 
 
 # Default configuration parameters for the network

--- a/README.md
+++ b/README.md
@@ -710,9 +710,10 @@ participants_matrix: {}
   #   - vc_type: prysm
   #   - vc_type: lighthouse
   # remote_signer:
-  #   - use_remote_signer: true
-  #     remote_signer_type: web3signer
+  #   - remote_signer_type: web3signer
   #     remote_signer_image: consensys/web3signer:develop
+  # Defining a remote_signer entry enables it automatically (set
+  # `use_remote_signer: false` to keep the config but disable it).
   # NOTE: a remote signer requires `use_separate_vc: true` on the matching cl item.
 
 

--- a/README.md
+++ b/README.md
@@ -712,8 +712,7 @@ participants_matrix: {}
   # remote_signer:
   #   - remote_signer_type: web3signer
   #     remote_signer_image: consensys/web3signer:develop
-  # Defining a remote_signer entry enables it automatically (set
-  # `use_remote_signer: false` to keep the config but disable it).
+  # Defining a remote_signer entry enables it automatically.
   # NOTE: a remote signer requires `use_separate_vc: true` on the matching cl item.
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1362,12 +1362,8 @@ def parse_network_params(plan, input_args):
                                 participant[k] = v
                             for k, v in remote_signer.items():
                                 participant[k] = v
-                            # Defining a remote_signer matrix entry implies using
-                            # it, unless the user explicitly opted out.
-                            if (
-                                remote_signer
-                                and "use_remote_signer" not in remote_signer
-                            ):
+                            # Defining a remote_signer matrix entry implies using it.
+                            if remote_signer:
                                 participant["use_remote_signer"] = True
                             participants.append(participant)
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1343,18 +1343,26 @@ def parse_network_params(plan, input_args):
         vc_matrix = []
         if "vc" in input_args["participants_matrix"]:
             vc_matrix = input_args["participants_matrix"]["vc"]
+        remote_signer_matrix = []
+        if "remote_signer" in input_args["participants_matrix"]:
+            remote_signer_matrix = input_args["participants_matrix"]["remote_signer"]
         count = input_args["participants_matrix"].get("count", 1)
 
         for el in el_matrix:
             for cl in cl_matrix:
                 for vc in vc_matrix if vc_matrix else [{}]:
-                    for _ in range(count):
-                        participant = {k: v for k, v in el.items()}
-                        for k, v in cl.items():
-                            participant[k] = v
-                        for k, v in vc.items():
-                            participant[k] = v
-                        participants.append(participant)
+                    for remote_signer in (
+                        remote_signer_matrix if remote_signer_matrix else [{}]
+                    ):
+                        for _ in range(count):
+                            participant = {k: v for k, v in el.items()}
+                            for k, v in cl.items():
+                                participant[k] = v
+                            for k, v in vc.items():
+                                participant[k] = v
+                            for k, v in remote_signer.items():
+                                participant[k] = v
+                            participants.append(participant)
 
         if "participants" in input_args:
             input_args["participants"].extend(participants)

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1362,6 +1362,13 @@ def parse_network_params(plan, input_args):
                                 participant[k] = v
                             for k, v in remote_signer.items():
                                 participant[k] = v
+                            # Defining a remote_signer matrix entry implies using
+                            # it, unless the user explicitly opted out.
+                            if (
+                                remote_signer
+                                and "use_remote_signer" not in remote_signer
+                            ):
+                                participant["use_remote_signer"] = True
                             participants.append(participant)
 
         if "participants" in input_args:

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -158,6 +158,7 @@ PARTICIPANT_MATRIX_PARAMS = {
             "validator_count",
         ],
         "remote_signer": [
+            "use_remote_signer",
             "remote_signer_type",
             "remote_signer_image",
             "remote_signer_extra_env_vars",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -158,7 +158,6 @@ PARTICIPANT_MATRIX_PARAMS = {
             "validator_count",
         ],
         "remote_signer": [
-            "use_remote_signer",
             "remote_signer_type",
             "remote_signer_image",
             "remote_signer_extra_env_vars",


### PR DESCRIPTION
## Summary

Fixes #1169.

`participants_matrix` could not configure a remote signer. A `remote_signer` dimension was already declared in `sanity_check.star`'s `PARTICIPANT_MATRIX_PARAMS`, but `input_parser.star` only iterated `el`/`cl`/`vc` and never merged it into participants — so it was dead config. Putting remote-signer fields under `cl` also failed sanity validation (`use_remote_signer is not an attribute`).

## Changes

- **`input_parser.star`**: the matrix builder now also reads the `remote_signer` dimension and merges each item's keys into the participant (same way `vc` is merged), wrapped in a `for ... else [{}]` so it's optional. Defining a non-empty `remote_signer` entry implies `use_remote_signer = true` — no separate flag to set.
- **`README.md`**: documented the `remote_signer` matrix dimension with an example, noting that defining an entry enables it automatically and that it requires `use_separate_vc: true` on the matching `cl` item.
- **`.github/tests/remote-signer-matrix.yaml`**: example/config exercising the new dimension.

## Usage

```yaml
participants_matrix:
  el:
    - el_type: geth
  cl:
    - cl_type: prysm
      use_separate_vc: true
  vc:
    - vc_type: prysm
  remote_signer:
    - remote_signer_type: web3signer
      remote_signer_image: consensys/web3signer:develop
```

Just defining the `remote_signer` entry enables it. A remote signer requires `use_separate_vc: true` on the matching `cl` item (existing validation in `input_parser.star`).

`kurtosis lint` passes.