### PR TITLE
docs: clarify grafana additional_dashboards requires a github/http locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,7 +1191,13 @@ prometheus_params:
 
 # Configuration place for grafana
 grafana_params:
-  # A list of locators for grafana dashboards to be loaded be the grafana service
+  # A list of locators for grafana dashboards to be loaded by the grafana service.
+  # Each entry must be a Kurtosis locator: a GitHub locator (e.g.
+  # "github.com/<org>/<repo>/path/to/dashboards") or an absolute http(s) URL.
+  # When inheriting this package from your own, a local/relative path will NOT
+  # work: upload_files runs inside the ethereum-package and resolves relative
+  # paths against it, not against your package. Use a github.com/... locator
+  # pointing at your own repo instead.
   additional_dashboards: []
   # Resource management for grafana container
   # CPU is milicores


### PR DESCRIPTION
## Summary

Closes #784.

`grafana_params.additional_dashboards` is passed to `plan.upload_files(...)` in `grafana_launcher.star`. Per Kurtosis, `upload_files` accepts a GitHub locator, a path within the **current package**, or an absolute http(s) URL. Because that call executes inside `ethpandaops/ethereum-package`, a relative/local path supplied by a **consumer** package resolves against ethereum-package and fails:

```
'/src/grafana/tools/grafana/dashboards' doesn't exist in the package 'ethpandaops/ethereum-package'
```

This is inherent to Kurtosis's locator model — a relative consumer path cannot resolve against the consumer when the `upload_files` call lives in the dependency. The supported approach is an absolute `github.com/<org>/<repo>/path` locator (or an http(s) URL) pointing at your own repo.

## Change

Documentation only — expands the `additional_dashboards` comment in `README.md` to spell out that entries must be a GitHub locator or absolute http(s) URL, and that local/relative paths won't work when inheriting the package.

```yaml
grafana_params:
  additional_dashboards:
    - github.com/<your-org>/<your-repo>/path/to/dashboards
```