### PR TITLE
feat(buildoor): auto-add payload-attributes flag to first participant

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2576,10 +2576,12 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 participant["cl_extra_params"].append(
                     "--features=AlwaysPrepareExecutionPayload"
                 )
-            else:
+            elif participant["cl_type"] != "consensoor":
+                # consensoor emits payload_attributes on every slot natively, so
+                # it needs no flag. teku and nimbus have no way to, so fail.
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
-                    + "[lodestar, prysm, lighthouse, grandine]: '{0}' has no flag to build a payload on each slot ".format(
+                    + "[lodestar, prysm, lighthouse, grandine, consensoor]: '{0}' has no flag to build a payload on each slot ".format(
                         participant["cl_type"]
                     )
                     + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2576,9 +2576,10 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 participant["cl_extra_params"].append(
                     "--features=AlwaysPrepareExecutionPayload"
                 )
-            elif participant["cl_type"] != "consensoor":
-                # consensoor emits payload_attributes on every slot natively, so
-                # it needs no flag. teku and nimbus have no way to, so fail.
+            elif participant["cl_type"] == "consensoor":
+                participant["cl_extra_params"].append("--emit-payload-attributes")
+            else:
+                # teku and nimbus have no flag to emit payload_attributes.
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
                     + "[lodestar, prysm, lighthouse, grandine, consensoor]: '{0}' has no flag to build a payload on each slot ".format(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2563,6 +2563,33 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
         if participant["vc_type"] == "vero":
             participant["vc_extra_params"].append("--use-external-builder")
 
+        # buildoor connects directly to the first participant's beacon node and
+        # subscribes to its payload_attributes SSE stream to know when to build.
+        # The CL only emits these events for slots it proposes unless forced to
+        # always prepare payloads, so the relevant flag must be added to the
+        # first participant's CL when buildoor is the MEV type.
+        if mev_type == constants.BUILDOOR_MEV_TYPE and index == 0:
+            if participant["cl_type"] == "lodestar":
+                participant["cl_extra_params"].append("--emitPayloadAttributes=true")
+            elif participant["cl_type"] == "prysm":
+                participant["cl_extra_params"].append("--prepare-all-payloads")
+            elif participant["cl_type"] == "lighthouse":
+                # lighthouse requires --suggested-fee-recipient alongside this,
+                # which the beacon node always sets when an EL is attached.
+                participant["cl_extra_params"].append("--always-prepare-payload")
+            else:
+                # teku, nimbus, grandine and consensoor have no flag to emit
+                # payload_attributes for non-proposed slots, so buildoor cannot
+                # reliably trigger block building against them as the first
+                # participant. Fail fast rather than silently misbehave.
+                fail(
+                    "mev_type 'buildoor' requires the first participant's cl_type to be one of "
+                    + "[lodestar, prysm, lighthouse]: '{0}' has no flag to build a payload on each slot ".format(
+                        participant["cl_type"]
+                    )
+                    + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."
+                )
+
     num_participants = len(parsed_arguments_dict["participants"])
     index_str = shared_utils.zfill_custom(
         num_participants + 1, len(str(num_participants + 1))

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2577,14 +2577,18 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 # lighthouse requires --suggested-fee-recipient alongside this,
                 # which the beacon node always sets when an EL is attached.
                 participant["cl_extra_params"].append("--always-prepare-payload")
+            elif participant["cl_type"] == "grandine":
+                participant["cl_extra_params"].append(
+                    "--features=AlwaysPrepareExecutionPayload"
+                )
             else:
-                # teku, nimbus, grandine and consensoor have no flag to emit
+                # teku, nimbus and consensoor have no flag to emit
                 # payload_attributes for non-proposed slots, so buildoor cannot
                 # reliably trigger block building against them as the first
                 # participant. Fail fast rather than silently misbehave.
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
-                    + "[lodestar, prysm, lighthouse]: '{0}' has no flag to build a payload on each slot ".format(
+                    + "[lodestar, prysm, lighthouse, grandine]: '{0}' has no flag to build a payload on each slot ".format(
                         participant["cl_type"]
                     )
                     + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2563,29 +2563,20 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
         if participant["vc_type"] == "vero":
             participant["vc_extra_params"].append("--use-external-builder")
 
-        # buildoor connects directly to the first participant's beacon node and
-        # subscribes to its payload_attributes SSE stream to know when to build.
-        # The CL only emits these events for slots it proposes unless forced to
-        # always prepare payloads, so the relevant flag must be added to the
-        # first participant's CL when buildoor is the MEV type.
+        # buildoor builds against the first participant's payload_attributes
+        # SSE stream, so that CL must emit them on every slot.
         if mev_type == constants.BUILDOOR_MEV_TYPE and index == 0:
             if participant["cl_type"] == "lodestar":
                 participant["cl_extra_params"].append("--emitPayloadAttributes=true")
             elif participant["cl_type"] == "prysm":
                 participant["cl_extra_params"].append("--prepare-all-payloads")
             elif participant["cl_type"] == "lighthouse":
-                # lighthouse requires --suggested-fee-recipient alongside this,
-                # which the beacon node always sets when an EL is attached.
                 participant["cl_extra_params"].append("--always-prepare-payload")
             elif participant["cl_type"] == "grandine":
                 participant["cl_extra_params"].append(
                     "--features=AlwaysPrepareExecutionPayload"
                 )
             else:
-                # teku, nimbus and consensoor have no flag to emit
-                # payload_attributes for non-proposed slots, so buildoor cannot
-                # reliably trigger block building against them as the first
-                # participant. Fail fast rather than silently misbehave.
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
                     + "[lodestar, prysm, lighthouse, grandine]: '{0}' has no flag to build a payload on each slot ".format(


### PR DESCRIPTION
## What

When `mev_type: buildoor` is set, automatically add the "build a payload on every slot" flag to the **first participant's** consensus client.

## Why

Buildoor connects directly to the first participant's beacon node (`all_cl_contexts[0]`) and subscribes to its `/eth/v1/events?topics=payload_attributes` SSE stream to know when to start building. Beacon nodes only emit these events for slots they propose unless explicitly told to always prepare a payload — so without this flag buildoor wouldn't reliably trigger block building. Previously this flag had to be added manually via `cl_extra_params`.

## Changes

In `enrich_mev_extra_params` (`src/package_io/input_parser.star`), gated on `mev_type == buildoor` and `index == 0`:

| CL | Flag added |
|---|---|
| lodestar | `--emitPayloadAttributes=true` |
| prysm | `--prepare-all-payloads` |
| lighthouse | `--always-prepare-payload` |
| grandine | `--features=AlwaysPrepareExecutionPayload` |

`teku`, `nimbus` and `consensoor` have no equivalent flag, so the parser now **fails fast** with a clear message naming the offending client when one of them is the first participant.

> Notes:
> - The lighthouse flag is `--always-prepare-payload` (singular); it requires `--suggested-fee-recipient`, which the beacon node already sets when an EL is attached (`lighthouse_launcher.star`).
> - consensoor support is being added separately (it needs to *emit* the `payload_attributes` SSE event first).

## Testing

`kurtosis run --dry-run` confirmed:
- lodestar + buildoor → parses and runs end-to-end (exit 0).
- grandine + buildoor → parses and runs end-to-end (exit 0).
- teku + buildoor → fails with the intended error message.