### PR TITLE
feat(buildoor): support teku as first participant

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2578,11 +2578,15 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 )
             elif participant["cl_type"] == "consensoor":
                 participant["cl_extra_params"].append("--emit-payload-attributes")
+            elif participant["cl_type"] == "teku":
+                participant["cl_extra_params"].append(
+                    "-Xfork-choice-updated-always-send-payload-attributes=true"
+                )
             else:
-                # teku and nimbus have no flag to emit payload_attributes.
+                # nimbus has no flag to emit payload_attributes.
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
-                    + "[lodestar, prysm, lighthouse, grandine, consensoor]: '{0}' has no flag to build a payload on each slot ".format(
+                    + "[lodestar, prysm, lighthouse, grandine, consensoor, teku]: '{0}' has no flag to build a payload on each slot ".format(
                         participant["cl_type"]
                     )
                     + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."


### PR DESCRIPTION
Follow-up to #1429.

teku can emit `payload_attributes` on every slot via `-Xfork-choice-updated-always-send-payload-attributes`, so it can serve as buildoor's first participant. Wire up the flag and drop teku from the fail list.

## Changes

`enrich_mev_extra_params` (`src/package_io/input_parser.star`), gated on `mev_type == buildoor` and `index == 0`:

| CL | Flag added |
|---|---|
| lodestar | `--emitPayloadAttributes=true` |
| prysm | `--prepare-all-payloads` |
| lighthouse | `--always-prepare-payload` |
| grandine | `--features=AlwaysPrepareExecutionPayload` |
| consensoor | `--emit-payload-attributes` |
| **teku** | **`-Xfork-choice-updated-always-send-payload-attributes=true`** |
| nimbus | fail fast (no equivalent flag) |

Only **nimbus** is left unsupported.

## Testing

`kurtosis run --dry-run`:
- teku + buildoor → parses and runs end-to-end (exit 0).
- nimbus + buildoor → fails with the intended error message.