### PR TITLE
fix(buildoor): drop teku first-participant support (flag no longer exists in teku)

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2578,15 +2578,13 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 )
             elif participant["cl_type"] == "consensoor":
                 participant["cl_extra_params"].append("--emit-payload-attributes")
-            elif participant["cl_type"] == "teku":
-                participant["cl_extra_params"].append(
-                    "-Xfork-choice-updated-always-send-payload-attributes=true"
-                )
             else:
-                # nimbus has no flag to emit payload_attributes.
+                # teku and nimbus have no flag to emit payload_attributes.
+                # (teku's -Xfork-choice-updated-always-send-payload-attributes
+                # was removed from recent builds.)
                 fail(
                     "mev_type 'buildoor' requires the first participant's cl_type to be one of "
-                    + "[lodestar, prysm, lighthouse, grandine, consensoor, teku]: '{0}' has no flag to build a payload on each slot ".format(
+                    + "[lodestar, prysm, lighthouse, grandine, consensoor]: '{0}' has no flag to build a payload on each slot ".format(
                         participant["cl_type"]
                     )
                     + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."


### PR DESCRIPTION
## Problem

#1430 added teku as a buildoor first participant via `-Xfork-choice-updated-always-send-payload-attributes=true`. That option **no longer exists in any current teku build**, so teku+buildoor dies at startup with:

```
Unknown option: '-Xfork-choice-updated-always-send-payload-attributes=true'
```

`main` is currently broken for this combination.

## Verification

Tested the flag with a real parse (not `--version`, which short-circuits and masks unknown-option errors):

| image | teku version | result |
|---|---|---|
| `ethpandaops/teku:glamsterdam-devnet-6` | v26.6.0+24 | ❌ Unknown option |
| `consensys/teku:latest` | v26.6.1 | ❌ Unknown option |
| `consensys/teku:develop` | g27d3501 | ❌ Unknown option |
| `ethpandaops/teku:master` | v26.6.0+27 | ❌ Unknown option |

Bare and `=true` both rejected everywhere. The option appears to have been removed from teku (~24.1.1).

## Fix

Put teku back in the buildoor fail list. Supported first participants are now: **lodestar, prysm, lighthouse, grandine, consensoor**. teku and nimbus fail fast at config-parse time with a clear message.

`kurtosis run --dry-run` with teku+buildoor now errors cleanly at parse time instead of booting teku with a bad flag.

If teku reintroduces an equivalent option, we can re-add it (verified against a real run next time).