### PR TITLE
feat(buildoor): support multiple per-participant buildoor instances

### DIFF
--- a/.github/tests/buildoor-instances-matrix.yaml
+++ b/.github/tests/buildoor-instances-matrix.yaml
@@ -27,6 +27,7 @@ buildoor_params:
     - participant: 2
       count: 1
 additional_services:
+  - buildoor
   - dora
 dora_params:
   image: ethpandaops/dora:glamsterdam-devnet-6

--- a/.github/tests/buildoor-instances-matrix.yaml
+++ b/.github/tests/buildoor-instances-matrix.yaml
@@ -1,0 +1,32 @@
+# Multiple buildoor builders on top of a participants_matrix. The matrix expands
+# to one participant per el x cl combination; buildoor_params.instances then wires
+# a dedicated builder (by 1-based participant index) to chosen participants. The
+# builder config stays independent of the participants. Builders onboard
+# themselves after genesis via their lifecycle deposit (default on).
+participants_matrix:
+  el:
+    - el_type: geth
+      el_image: ethpandaops/geth:glamsterdam-devnet-6
+  cl:
+    - cl_type: lighthouse
+      cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+    - cl_type: lodestar
+      cl_image: ethpandaops/lodestar:glamsterdam-devnet-6
+network_params:
+  preset: minimal
+  gloas_fork_epoch: 6
+  gas_limit: 150000000
+buildoor_params:
+  image: ethpandaops/buildoor:glamsterdam-devnet-6
+  builder_api: true
+  epbs_builder: true
+  lifecycle: true
+  instances:
+    - participant: 1
+      count: 2
+    - participant: 2
+      count: 1
+additional_services:
+  - dora
+dora_params:
+  image: ethpandaops/dora:glamsterdam-devnet-6

--- a/.github/tests/buildoor-instances.yaml
+++ b/.github/tests/buildoor-instances.yaml
@@ -29,6 +29,7 @@ buildoor_params:
     - participant: 2
       count: 2
 additional_services:
+  - buildoor
   - dora
   - spamoor
 spamoor_params:

--- a/.github/tests/buildoor-instances.yaml
+++ b/.github/tests/buildoor-instances.yaml
@@ -1,0 +1,41 @@
+# Multiple dedicated per-participant buildoor builders via buildoor_params.instances.
+# No mev_type: builders are configured independently of the participants and
+# onboard themselves after genesis via their lifecycle deposit (default on), so
+# gloas does not have to be at genesis. This spins up three buildoor services:
+#   buildoor-lighthouse-geth-1     (participant 1)
+#   buildoor-lodestar-geth-2-1     (participant 2, instance 1)
+#   buildoor-lodestar-geth-2-2     (participant 2, instance 2)
+participants:
+  - el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-6
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:glamsterdam-devnet-6
+  - el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-6
+    cl_type: lodestar
+    cl_image: ethpandaops/lodestar:glamsterdam-devnet-6
+network_params:
+  preset: minimal
+  gloas_fork_epoch: 6
+  gas_limit: 150000000
+buildoor_params:
+  image: ethpandaops/buildoor:glamsterdam-devnet-6
+  builder_api: true
+  epbs_builder: true
+  lifecycle: true
+  instances:
+    - participant: 1
+      count: 1
+    - participant: 2
+      count: 2
+additional_services:
+  - dora
+  - spamoor
+spamoor_params:
+  image: ethpandaops/spamoor:master
+  spammers:
+    - scenario: eoatx
+      config:
+        throughput: 2
+dora_params:
+  image: ethpandaops/dora:glamsterdam-devnet-6

--- a/README.md
+++ b/README.md
@@ -656,18 +656,8 @@ participants:
       # Additional labels to be added. Default to empty
       labels: {}
 
-    # Buildoor can be enabled per participant with the `buildoor_enabled` flag.
-    # When set, a dedicated buildoor builder+relay instance (service
-    # `buildoor-<index>`) is spun up and wired directly to this participant's own
-    # CL/EL, and the CL is configured to emit payload_attributes on every slot.
-    # This is the per-participant alternative to the network-wide `mev_type: buildoor`
-    # (a single shared builder) and the two cannot be combined.
-    # Each enabled participant is its own builder and gets its own builder BLS key,
-    # so `network_params.builder_count` must be >= the number of buildoor-enabled
-    # participants (builders are registered at genesis, which requires gloas at
-    # genesis / gloas_fork_epoch: 0).
-    # Defaults to false
-    buildoor_enabled: false
+    # Buildoor (a self-contained block builder) is configured independently of the
+    # participants via `buildoor_params.instances` (see below), not per participant.
 
     # Blobber can be enabled with the `blobber_enabled` flag per client or globally
     # Defaults to false
@@ -1521,6 +1511,8 @@ mempool_bridge_params:
 #            Note: Helix uses TimescaleDB (PostgreSQL with time-series extension) for data storage
 # "buildoor" - a self-contained builder+relay service & mev-boost are spun up, powered by [buildoor](https://github.com/ethpandaops/buildoor)
 #              Supports both legacy builder API and ePBS bidding. No separate relay infrastructure or builder participant needed.
+#              DEPRECATED: this single shared-builder mode will be dropped after the gloas fork. Use
+#              `buildoor_params.instances` for dedicated per-participant builders instead.
 # We have seen instances of multibuilder instances failing to start mev-relay-api with non zero epochs
 mev_type: null
 
@@ -1590,7 +1582,7 @@ mev_params:
   #     level = "debug"
   commit_boost_config: ""
 
-# Parameters for the buildoor builder+relay service (used when mev_type is "buildoor")
+# Parameters for the buildoor builder service
 buildoor_params:
   # The image to use for buildoor
   image: ethpandaops/buildoor:main
@@ -1600,6 +1592,31 @@ buildoor_params:
   epbs_builder: true
   # Extra parameters to pass to the buildoor service
   extra_args: []
+  # Enable buildoor's builder lifecycle: each builder deposits/onboards itself
+  # after genesis (and tops itself up) via the EL, so builders work even when
+  # gloas is not at genesis. Built blocks are tagged with the instance's service
+  # name in their extra-data so they can be traced back to the builder.
+  # Defaults to true
+  lifecycle: true
+  # Dedicated per-participant buildoor builders, configured independently of the
+  # participants (a builder is independent of the network: it reads one
+  # participant's CL payload_attributes stream and, under ePBS, gossips bids to
+  # the whole network). Each entry spins up `count` buildoor builder instances
+  # wired to the named participant's CL/EL. Services are named
+  # `buildoor-<cl>-<el>-<participant>` (with a `-<n>` suffix when count > 1).
+  # No `mev_type` is required - declaring instances is enough to spin buildoor up,
+  # and it cannot be combined with the (deprecated) network-wide `mev_type: buildoor`.
+  # Each instance is its own builder; with lifecycle enabled (default) it onboards
+  # itself after genesis, so genesis builder registration is not required and gloas
+  # may activate at any epoch.
+  # Defaults to [] (no per-participant buildoors).
+  # Example:
+  # instances:
+  #   - participant: 1   # 1-based participant index
+  #     count: 1
+  #   - participant: 3
+  #     count: 2
+  instances: []
 
 # Enables Xatu Sentry for all participants
 # Defaults to false
@@ -1984,14 +2001,43 @@ network_params:
 </details>
 
 <details>
-    <summary>A 2-node Ethereum network with buildoor (self-contained builder+relay)</summary>
+    <summary>A 2-node Ethereum network with dedicated per-participant buildoor builders</summary>
+
+```yaml
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+  - el_type: reth
+    cl_type: prysm
+buildoor_params:
+  builder_api: true
+  epbs_builder: true
+  # one buildoor wired to participant 1, two wired to participant 2
+  instances:
+    - participant: 1
+      count: 1
+    - participant: 2
+      count: 2
+additional_services:
+  - dora
+  - spamoor
+```
+
+</details>
+
+<details>
+    <summary>A 2-node Ethereum network with the (deprecated) shared buildoor builder</summary>
 
 ```yaml
 participants:
   - el_type: geth
     cl_type: lighthouse
     count: 2
+# Deprecated: prefer buildoor_params.instances (see example above).
 mev_type: buildoor
+network_params:
+  builder_count: 1
+  gloas_fork_epoch: 0
 buildoor_params:
   builder_api: true
   epbs_builder: true
@@ -2206,7 +2252,7 @@ The package also supports other MEV implementations:
 - `"mev_type": "helix"` - Uses the high-performance [Helix relay](https://github.com/gattaca-com/helix) with TimescaleDB backend for data storage
 - `"mev_type": "mev-rs"` - Alternative relay implementation powered by [mev-rs](https://github.com/ralexstokes/mev-rs/)
 - `"mev_type": "commit-boost"` - Infrastructure powered by [commit-boost](https://github.com/Commit-Boost/commit-boost-client)
-- `"mev_type": "buildoor"` - A self-contained builder+relay service powered by [buildoor](https://github.com/ethpandaops/buildoor). Supports both legacy builder API and ePBS bidding without requiring separate relay infrastructure or a dedicated builder participant.
+- `"mev_type": "buildoor"` - A self-contained builder+relay service powered by [buildoor](https://github.com/ethpandaops/buildoor). Supports both legacy builder API and ePBS bidding without requiring separate relay infrastructure or a dedicated builder participant. **Deprecated:** this single shared-builder mode will be dropped after the gloas fork - use `buildoor_params.instances` for dedicated per-participant builders instead.
 
 Each implementation provides different features and performance characteristics suitable for various testing and development scenarios.
 

--- a/README.md
+++ b/README.md
@@ -1582,7 +1582,10 @@ mev_params:
   #     level = "debug"
   commit_boost_config: ""
 
-# Parameters for the buildoor builder service
+# Parameters for the buildoor builder service.
+# buildoor is an additional_service: add "buildoor" to additional_services to spin
+# it up, then configure its targeting here. With "buildoor" enabled and no
+# instances set, a single builder is wired to the first participant by default.
 buildoor_params:
   # The image to use for buildoor
   image: ethpandaops/buildoor:main
@@ -1604,8 +1607,8 @@ buildoor_params:
   # the whole network). Each entry spins up `count` buildoor builder instances
   # wired to the named participant's CL/EL. Services are named
   # `buildoor-<cl>-<el>-<participant>` (with a `-<n>` suffix when count > 1).
-  # No `mev_type` is required - declaring instances is enough to spin buildoor up,
-  # and it cannot be combined with the (deprecated) network-wide `mev_type: buildoor`.
+  # Requires "buildoor" in additional_services; no `mev_type` is needed, and it
+  # cannot be combined with the (deprecated) network-wide `mev_type: buildoor`.
   # Each instance is its own builder; with lifecycle enabled (default) it onboards
   # itself after genesis, so genesis builder registration is not required and gloas
   # may activate at any epoch.
@@ -2019,6 +2022,7 @@ buildoor_params:
     - participant: 2
       count: 2
 additional_services:
+  - buildoor
   - dora
   - spamoor
 ```

--- a/README.md
+++ b/README.md
@@ -656,6 +656,19 @@ participants:
       # Additional labels to be added. Default to empty
       labels: {}
 
+    # Buildoor can be enabled per participant with the `buildoor_enabled` flag.
+    # When set, a dedicated buildoor builder+relay instance (service
+    # `buildoor-<index>`) is spun up and wired directly to this participant's own
+    # CL/EL, and the CL is configured to emit payload_attributes on every slot.
+    # This is the per-participant alternative to the network-wide `mev_type: buildoor`
+    # (a single shared builder) and the two cannot be combined.
+    # Each enabled participant is its own builder and gets its own builder BLS key,
+    # so `network_params.builder_count` must be >= the number of buildoor-enabled
+    # participants (builders are registered at genesis, which requires gloas at
+    # genesis / gloas_fork_epoch: 0).
+    # Defaults to false
+    buildoor_enabled: false
+
     # Blobber can be enabled with the `blobber_enabled` flag per client or globally
     # Defaults to false
     blobber_enabled: false

--- a/main.star
+++ b/main.star
@@ -317,6 +317,29 @@ def add_otel_resource_attributes_to_participants(participants, resource_attribut
         )
 
 
+# Derive a builder BLS private key from the mnemonic at key_index, using the
+# m/12381/3600/{index}/0/0 path convention. Genesis registers builders at
+# consecutive indices starting right after the regular validators, so each
+# builder (and therefore each buildoor instance) gets a distinct key.
+def derive_builder_bls_key(
+    plan, mnemonic, key_index, service_name, global_node_selectors, global_tolerations
+):
+    builder_key_result = plan.run_sh(
+        name=service_name,
+        description="Deriving builder BLS private key (index {0}) from mnemonic".format(
+            key_index
+        ),
+        run='/app/ethdo account derive --mnemonic="{0}" --path="m/12381/3600/{1}/0/0" --show-private-key | grep "Private key" | sed "s/Private key: 0x//" | tr -d "\n"'.format(
+            mnemonic,
+            key_index,
+        ),
+        image="wealdtech/ethdo:latest",
+        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
+        node_selectors=global_node_selectors,
+    )
+    return builder_key_result.output
+
+
 def run(plan, args={}):
     """Launches an arbitrarily complex ethereum testnet based on the arguments provided
 
@@ -559,25 +582,20 @@ def run(plan, args={}):
             )
             break
 
+    total_validator_count = 0
+    for participant in args_with_right_defaults.participants:
+        total_validator_count += participant.validator_count
+
     builder_bls_secret_key = None
     if network_params.builder_count > 0:
-        total_validator_count = 0
-        for participant in args_with_right_defaults.participants:
-            total_validator_count += participant.validator_count
-        builder_key_result = plan.run_sh(
-            name="derive-builder-bls-key",
-            description="Deriving builder BLS private key from mnemonic",
-            run='/app/ethdo account derive --mnemonic="{0}" --path="m/12381/3600/{1}/0/0" --show-private-key | grep "Private key" | sed "s/Private key: 0x//" | tr -d "\n"'.format(
-                network_params.preregistered_validator_keys_mnemonic,
-                total_validator_count,
-            ),
-            image="wealdtech/ethdo:latest",
-            tolerations=shared_utils.get_tolerations(
-                global_tolerations=global_tolerations
-            ),
-            node_selectors=global_node_selectors,
+        builder_bls_secret_key = derive_builder_bls_key(
+            plan,
+            network_params.preregistered_validator_keys_mnemonic,
+            total_validator_count,
+            "derive-builder-bls-key",
+            global_node_selectors,
+            global_tolerations,
         )
-        builder_bls_secret_key = builder_key_result.output
         plan.print(
             "Builder configuration: {0} builder(s) registered at genesis with 0x03 credentials".format(
                 network_params.builder_count
@@ -821,6 +839,62 @@ def run(plan, args={}):
             mev_endpoint_names.append(args_with_right_defaults.mev_type)
         else:
             fail("Invalid MEV type")
+
+    # Per-participant buildoor: launch a dedicated buildoor instance for every
+    # participant with buildoor_enabled, wired directly to that participant's own
+    # CL/EL. The CL builder endpoint and payload_attributes flags are already set
+    # in enrich_buildoor_per_participant. This is independent of the global
+    # mev_type buildoor flow (which spins up a single shared buildoor).
+    buildoor_builder_index = 0
+    for index, participant in enumerate(all_participants):
+        if not args_with_right_defaults.participants[index].buildoor_enabled:
+            continue
+        buildoor_service_name = "{0}-{1}".format(constants.BUILDOOR_SERVICE_NAME, index)
+        cl_context = participant.cl_context
+        el_context = participant.el_context
+        beacon_uri = "http://{0}:{1}".format(
+            cl_context.beacon_service_name,
+            cl_context.http_port,
+        )
+        el_rpc_uri = "http://{0}:{1}".format(
+            el_context.dns_name,
+            el_context.rpc_port_num,
+        )
+        engine_rpc_uri = "http://{0}:{1}".format(
+            el_context.dns_name,
+            el_context.engine_rpc_port_num,
+        )
+        # Each instance uses a distinct prefunded account so concurrent buildoors
+        # do not collide on transaction nonces.
+        buildoor_account = prefunded_accounts[index % len(prefunded_accounts)]
+        # Each instance is its own builder, so it needs its own builder BLS key.
+        # Keys are derived at consecutive indices following the regular
+        # validators; the parser guarantees builder_count covers them, so each is
+        # registered at genesis with 0x03 credentials.
+        instance_builder_bls_key = derive_builder_bls_key(
+            plan,
+            network_params.preregistered_validator_keys_mnemonic,
+            total_validator_count + buildoor_builder_index,
+            "derive-buildoor-bls-key-{0}".format(index),
+            global_node_selectors,
+            global_tolerations,
+        )
+        buildoor_builder_index += 1
+        buildoor_endpoints = buildoor.launch_buildoor(
+            plan,
+            beacon_uri,
+            el_rpc_uri,
+            engine_rpc_uri,
+            jwt_file,
+            buildoor_account.private_key,
+            args_with_right_defaults.buildoor_params,
+            global_node_selectors,
+            global_tolerations,
+            instance_builder_bls_key,
+            ranges,
+            buildoor_service_name,
+        )
+        buildoor_api_urls.append(buildoor_endpoints["api_url"])
 
     # spin up the mev boost contexts if some endpoints for relays have been passed
     all_mevboost_contexts = []

--- a/main.star
+++ b/main.star
@@ -317,29 +317,6 @@ def add_otel_resource_attributes_to_participants(participants, resource_attribut
         )
 
 
-# Derive a builder BLS private key from the mnemonic at key_index, using the
-# m/12381/3600/{index}/0/0 path convention. Genesis registers builders at
-# consecutive indices starting right after the regular validators, so each
-# builder (and therefore each buildoor instance) gets a distinct key.
-def derive_builder_bls_key(
-    plan, mnemonic, key_index, service_name, global_node_selectors, global_tolerations
-):
-    builder_key_result = plan.run_sh(
-        name=service_name,
-        description="Deriving builder BLS private key (index {0}) from mnemonic".format(
-            key_index
-        ),
-        run='/app/ethdo account derive --mnemonic="{0}" --path="m/12381/3600/{1}/0/0" --show-private-key | grep "Private key" | sed "s/Private key: 0x//" | tr -d "\n"'.format(
-            mnemonic,
-            key_index,
-        ),
-        image="wealdtech/ethdo:latest",
-        tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
-        node_selectors=global_node_selectors,
-    )
-    return builder_key_result.output
-
-
 def run(plan, args={}):
     """Launches an arbitrarily complex ethereum testnet based on the arguments provided
 
@@ -586,23 +563,19 @@ def run(plan, args={}):
     for participant in args_with_right_defaults.participants:
         total_validator_count += participant.validator_count
 
-    builder_bls_secret_key = None
     if network_params.builder_count > 0:
-        builder_bls_secret_key = derive_builder_bls_key(
-            plan,
-            network_params.preregistered_validator_keys_mnemonic,
-            total_validator_count,
-            "derive-builder-bls-key",
-            global_node_selectors,
-            global_tolerations,
-        )
         plan.print(
             "Builder configuration: {0} builder(s) registered at genesis with 0x03 credentials".format(
                 network_params.builder_count
             )
         )
-        plan.print("Builder mnemonic: '{0}'".format(constants.DEFAULT_MNEMONIC))
-        plan.print("Builder BLS private key: {0}".format(builder_bls_secret_key))
+        plan.print(
+            "Builder mnemonic: '{0}', keys derived at indices {1}..{2}".format(
+                network_params.preregistered_validator_keys_mnemonic,
+                total_validator_count,
+                total_validator_count + network_params.builder_count - 1,
+            )
+        )
 
     all_el_contexts = []
     all_cl_contexts = []
@@ -722,8 +695,10 @@ def run(plan, args={}):
             args_with_right_defaults.buildoor_params,
             global_node_selectors,
             global_tolerations,
-            builder_bls_secret_key,
+            network_params.preregistered_validator_keys_mnemonic,
+            total_validator_count,
             ranges,
+            constants.BUILDOOR_SERVICE_NAME,
         )
         mev_endpoints.append(buildoor_endpoints["mev_endpoint"])
         mev_endpoint_names.append(constants.BUILDOOR_MEV_TYPE)
@@ -840,16 +815,22 @@ def run(plan, args={}):
         else:
             fail("Invalid MEV type")
 
-    # Per-participant buildoor: launch a dedicated buildoor instance for every
-    # participant with buildoor_enabled, wired directly to that participant's own
-    # CL/EL. The CL builder endpoint and payload_attributes flags are already set
-    # in enrich_buildoor_per_participant. This is independent of the global
-    # mev_type buildoor flow (which spins up a single shared buildoor).
+    # Per-participant buildoor: launch the dedicated buildoor instances declared
+    # in buildoor_params.instances, each wired to the named participant's own
+    # CL/EL. Builders are configured independently of the participants. The CL
+    # builder endpoint and payload_attributes flags are already set in
+    # enrich_buildoor_per_participant. No global mev_type is required. Each builder
+    # derives its key from the network's validator mnemonic and onboards itself
+    # after genesis via its lifecycle deposit (so gloas need not be at genesis).
     buildoor_builder_index = 0
-    for index, participant in enumerate(all_participants):
-        if not args_with_right_defaults.participants[index].buildoor_enabled:
-            continue
-        buildoor_service_name = "{0}-{1}".format(constants.BUILDOOR_SERVICE_NAME, index)
+    for buildoor_instance in args_with_right_defaults.buildoor_params.instances:
+        index = buildoor_instance.participant - 1
+        instance_count = buildoor_instance.count
+        participant = all_participants[index]
+        participant_config = args_with_right_defaults.participants[index]
+        index_str = shared_utils.zfill_custom(
+            index + 1, len(str(len(all_participants)))
+        )
         cl_context = participant.cl_context
         el_context = participant.el_context
         beacon_uri = "http://{0}:{1}".format(
@@ -867,34 +848,44 @@ def run(plan, args={}):
         # Each instance uses a distinct prefunded account so concurrent buildoors
         # do not collide on transaction nonces.
         buildoor_account = prefunded_accounts[index % len(prefunded_accounts)]
-        # Each instance is its own builder, so it needs its own builder BLS key.
-        # Keys are derived at consecutive indices following the regular
-        # validators; the parser guarantees builder_count covers them, so each is
-        # registered at genesis with 0x03 credentials.
-        instance_builder_bls_key = derive_builder_bls_key(
-            plan,
-            network_params.preregistered_validator_keys_mnemonic,
-            total_validator_count + buildoor_builder_index,
-            "derive-buildoor-bls-key-{0}".format(index),
-            global_node_selectors,
-            global_tolerations,
-        )
-        buildoor_builder_index += 1
-        buildoor_endpoints = buildoor.launch_buildoor(
-            plan,
-            beacon_uri,
-            el_rpc_uri,
-            engine_rpc_uri,
-            jwt_file,
-            buildoor_account.private_key,
-            args_with_right_defaults.buildoor_params,
-            global_node_selectors,
-            global_tolerations,
-            instance_builder_bls_key,
-            ranges,
-            buildoor_service_name,
-        )
-        buildoor_api_urls.append(buildoor_endpoints["api_url"])
+        for instance in range(instance_count):
+            # Name the instance after the participant it is wired to, e.g.
+            # buildoor-lighthouse-geth-1, matching the cl/el naming convention.
+            buildoor_service_name = shared_utils.get_buildoor_service_name(
+                constants.BUILDOOR_SERVICE_NAME,
+                participant_config.cl_type,
+                participant_config.el_type,
+                index_str,
+                instance,
+                instance_count,
+            )
+            # Each instance is its own builder with its own builder BLS key,
+            # derived by buildoor from the builder mnemonic at consecutive indices
+            # after the validators and any genesis-registered builders, so they do
+            # not collide. The builder is onboarded after genesis via its lifecycle
+            # deposit (buildoor_params.lifecycle), not registered at genesis.
+            instance_builder_key_index = (
+                total_validator_count
+                + network_params.builder_count
+                + buildoor_builder_index
+            )
+            buildoor_builder_index += 1
+            buildoor_endpoints = buildoor.launch_buildoor(
+                plan,
+                beacon_uri,
+                el_rpc_uri,
+                engine_rpc_uri,
+                jwt_file,
+                buildoor_account.private_key,
+                args_with_right_defaults.buildoor_params,
+                global_node_selectors,
+                global_tolerations,
+                network_params.preregistered_validator_keys_mnemonic,
+                instance_builder_key_index,
+                ranges,
+                buildoor_service_name,
+            )
+            buildoor_api_urls.append(buildoor_endpoints["api_url"])
 
     # spin up the mev boost contexts if some endpoints for relays have been passed
     all_mevboost_contexts = []

--- a/main.star
+++ b/main.star
@@ -815,13 +815,20 @@ def run(plan, args={}):
         else:
             fail("Invalid MEV type")
 
-    # Per-participant buildoor: launch the dedicated buildoor instances declared
-    # in buildoor_params.instances, each wired to the named participant's own
-    # CL/EL. Builders are configured independently of the participants. The CL
-    # builder endpoint and payload_attributes flags are already set in
+    # buildoor is an additional_service: launch the dedicated buildoor instances
+    # declared in buildoor_params.instances only when "buildoor" is in
+    # additional_services, each wired to the named participant's own CL/EL.
+    # Builders are configured independently of the participants. The CL builder
+    # endpoint and payload_attributes flags are already set in
     # enrich_buildoor_per_participant. No global mev_type is required. Each builder
     # derives its key from the network's validator mnemonic and onboards itself
     # after genesis via its lifecycle deposit (so gloas need not be at genesis).
+    # Remove it from additional_services so the generic dispatch loop below (which
+    # fails on unknown services) skips it.
+    if constants.BUILDOOR_SERVICE_NAME in args_with_right_defaults.additional_services:
+        args_with_right_defaults.additional_services.remove(
+            constants.BUILDOOR_SERVICE_NAME
+        )
     buildoor_builder_index = 0
     for buildoor_instance in args_with_right_defaults.buildoor_params.instances:
         index = buildoor_instance.participant - 1

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -25,9 +25,11 @@ def launch_buildoor(
     buildoor_params,
     global_node_selectors,
     global_tolerations,
-    builder_bls_secret_key=None,
+    builder_mnemonic=None,
+    builder_key_index=None,
     validator_ranges_artifact=None,
     service_name=BUILDOOR_SERVICE_NAME,
+    extra_data=None,
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
@@ -36,28 +38,42 @@ def launch_buildoor(
     if wallet_key.startswith("0x"):
         wallet_key = wallet_key[2:]
 
-    # Use injected builder BLS key if provided, otherwise fall back to default
-    if builder_bls_secret_key != None:
-        builder_bls_key = builder_bls_secret_key
-    else:
-        builder_bls_key = constants.DEFAULT_MEV_SECRET_KEY[2:]
-
     cmd = [
         "run",
         "--cl-client={0}".format(beacon_uri),
         "--el-rpc={0}".format(el_rpc_uri),
         "--el-engine-api={0}".format(engine_rpc_uri),
         "--el-jwt-secret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
-        "--builder-privkey={0}".format(builder_bls_key),
         "--wallet-privkey={0}".format(wallet_key),
         "--api-port={0}".format(BUILDOOR_API_PORT),
     ]
+
+    # Builder BLS key: let buildoor derive it from the mnemonic at the given
+    # index (matching the 0x03 builder keys registered at genesis) when provided,
+    # otherwise fall back to the default static secret key.
+    if builder_mnemonic != None:
+        cmd.append("--builder-mnemonic={0}".format(builder_mnemonic))
+        cmd.append("--builder-key-index={0}".format(builder_key_index))
+    else:
+        cmd.append("--builder-privkey={0}".format(constants.DEFAULT_MEV_SECRET_KEY[2:]))
+
+    # Tag built blocks so a given block can be traced back to the buildoor
+    # instance that built it. Defaults to the service name (a unique identifier);
+    # buildoor injects it as the extra-data prefix (truncated to 32 bytes).
+    cmd.append(
+        "--extra-data={0}".format(extra_data if extra_data != None else service_name)
+    )
 
     if buildoor_params.builder_api:
         cmd.append("--builder-api-enabled")
 
     if buildoor_params.epbs_builder:
         cmd.append("--epbs-enabled")
+
+    # Lifecycle lets buildoor deposit/onboard its own builder after genesis (and
+    # top it up), so builders work without genesis registration / gloas-at-genesis.
+    if buildoor_params.lifecycle:
+        cmd.append("--lifecycle")
 
     if validator_ranges_artifact != None:
         cmd.append(

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -27,6 +27,7 @@ def launch_buildoor(
     global_tolerations,
     builder_bls_secret_key=None,
     validator_ranges_artifact=None,
+    service_name=BUILDOOR_SERVICE_NAME,
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
@@ -75,7 +76,7 @@ def launch_buildoor(
         files[VALIDATOR_RANGES_MOUNT_DIRPATH_ON_SERVICE] = validator_ranges_artifact
 
     buildoor_service = plan.add_service(
-        name=BUILDOOR_SERVICE_NAME,
+        name=service_name,
         config=ServiceConfig(
             image=buildoor_params.image,
             ports={
@@ -98,11 +99,11 @@ def launch_buildoor(
     return {
         "mev_endpoint": "http://{0}@{1}:{2}".format(
             constants.DEFAULT_MEV_PUBKEY,
-            BUILDOOR_SERVICE_NAME,
+            service_name,
             BUILDOOR_API_PORT,
         ),
         "api_url": "http://{0}:{1}".format(
-            BUILDOOR_SERVICE_NAME,
+            service_name,
             BUILDOOR_API_PORT,
         ),
     }

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -38,6 +38,12 @@ def launch_buildoor(
     if wallet_key.startswith("0x"):
         wallet_key = wallet_key[2:]
 
+    # The builder API URL buildoor advertises in its bids. With multiple
+    # instances each one must advertise its OWN service URL; otherwise every
+    # instance but one is rejected by consumers as a builder_url mismatch and
+    # never wins a bid. Computed once and reused as the registered api_url.
+    api_url = "http://{0}:{1}".format(service_name, BUILDOOR_API_PORT)
+
     cmd = [
         "run",
         "--cl-client={0}".format(beacon_uri),
@@ -46,6 +52,7 @@ def launch_buildoor(
         "--el-jwt-secret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--wallet-privkey={0}".format(wallet_key),
         "--api-port={0}".format(BUILDOOR_API_PORT),
+        "--builder-api-url={0}".format(api_url),
     ]
 
     # Builder BLS key: let buildoor derive it from the mnemonic at the given
@@ -118,8 +125,5 @@ def launch_buildoor(
             service_name,
             BUILDOOR_API_PORT,
         ),
-        "api_url": "http://{0}:{1}".format(
-            service_name,
-            BUILDOOR_API_PORT,
-        ),
+        "api_url": api_url,
     }

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -304,6 +304,38 @@ def input_parser(plan, input_args):
             )
         )
 
+    # Per-participant buildoor instances (buildoor_enabled flag). Independent of
+    # the global mev_type. Each flagged participant gets its own buildoor wired
+    # directly to its own CL, so it must not be combined with a global mev_type
+    # (that would double-wire the participant's builder endpoint).
+    buildoor_participant_count = 0
+    for participant in result["participants"]:
+        if participant.get("buildoor_enabled"):
+            buildoor_participant_count += 1
+    if buildoor_participant_count > 0:
+        if result.get("mev_type") != None:
+            fail(
+                "Per-participant buildoor_enabled cannot be combined with a global mev_type ({0}). ".format(
+                    result.get("mev_type")
+                )
+                + "Use buildoor_enabled on participants for dedicated per-participant builders, "
+                + "or mev_type: buildoor for a single shared builder, but not both."
+            )
+        # Every buildoor instance is its own builder and needs its own builder BLS
+        # key registered at genesis. builder_count must cover all of them.
+        if result["network_params"]["builder_count"] < buildoor_participant_count:
+            fail(
+                "buildoor_enabled is set on {0} participant(s) but network_params.builder_count is {1}. ".format(
+                    buildoor_participant_count,
+                    result["network_params"]["builder_count"],
+                )
+                + "Each per-participant buildoor needs its own builder BLS key registered at genesis; "
+                + "set network_params.builder_count to at least {0}.".format(
+                    buildoor_participant_count
+                )
+            )
+        result = enrich_buildoor_per_participant(result)
+
     if (
         result["mev_params"].get("mev_builder_subsidy") != 0
         and result["network_params"].get("prefunded_accounts") == {}
@@ -795,6 +827,7 @@ def input_parser(plan, input_args):
                 blobber_enabled=participant["blobber_enabled"],
                 blobber_extra_params=participant["blobber_extra_params"],
                 blobber_image=participant["blobber_image"],
+                buildoor_enabled=participant["buildoor_enabled"],
                 keymanager_enabled=participant["keymanager_enabled"],
                 vc_beacon_node_indices=participant["vc_beacon_node_indices"],
                 checkpoint_sync_enabled=participant["checkpoint_sync_enabled"],
@@ -2047,6 +2080,7 @@ def default_participant():
         "blobber_enabled": False,
         "blobber_extra_params": [],
         "blobber_image": "ethpandaops/blobber:latest",
+        "buildoor_enabled": False,
         "builder_network_params": None,
         "keymanager_enabled": None,
         "vc_beacon_node_indices": None,
@@ -2491,6 +2525,98 @@ def enrich_disable_peer_scoring(parsed_arguments_dict):
     return parsed_arguments_dict
 
 
+# Wire the CL (and VC) of a single participant to an external builder/relay at
+# mev_url. Shared by the global mev_type flow and the per-participant buildoor
+# flow so both stay in sync as new clients are added.
+def apply_external_builder_flags(participant, mev_url, gas_limit):
+    if participant["cl_type"] == "lighthouse":
+        participant["cl_extra_params"].append("--builder={0}".format(mev_url))
+    if participant["vc_type"] == "lighthouse":
+        if (
+            gas_limit == 0
+        ):  # if the gas limit is set we already enable builder-proposals
+            participant["vc_extra_params"].append("--builder-proposals")
+    if participant["cl_type"] == "lodestar":
+        participant["cl_extra_params"].append("--builder")
+        participant["cl_extra_params"].append("--builder.urls={0}".format(mev_url))
+    if participant["vc_type"] == "lodestar":
+        participant["vc_extra_params"].append("--builder")
+    if participant["cl_type"] == "nimbus":
+        participant["cl_extra_params"].append("--payload-builder=true")
+        participant["cl_extra_params"].append(
+            "--payload-builder-url={0}".format(mev_url)
+        )
+    if participant["vc_type"] == "nimbus":
+        participant["vc_extra_params"].append("--payload-builder=true")
+    if participant["cl_type"] == "teku":
+        participant["cl_extra_params"].append("--builder-endpoint={0}".format(mev_url))
+        participant["cl_extra_params"].append(
+            "--validators-builder-registration-default-enabled=true"
+        )
+    if participant["vc_type"] == "teku":
+        participant["vc_extra_params"].append(
+            "--validators-builder-registration-default-enabled=true"
+        )
+    if participant["cl_type"] == "prysm":
+        participant["cl_extra_params"].append("--http-mev-relay={0}".format(mev_url))
+    if participant["vc_type"] == "prysm":
+        participant["vc_extra_params"].append("--enable-builder")
+    if participant["cl_type"] == "grandine":
+        participant["cl_extra_params"].append("--builder-url={0}".format(mev_url))
+    if participant["vc_type"] == "vero":
+        participant["vc_extra_params"].append("--use-external-builder")
+
+
+# buildoor builds a payload from the CL's payload_attributes SSE stream, so the
+# CL feeding a buildoor instance must emit them on every slot.
+def apply_buildoor_payload_attributes_flags(participant):
+    if participant["cl_type"] == "lodestar":
+        participant["cl_extra_params"].append("--emitPayloadAttributes=true")
+    elif participant["cl_type"] == "prysm":
+        participant["cl_extra_params"].append("--prepare-all-payloads")
+    elif participant["cl_type"] == "lighthouse":
+        participant["cl_extra_params"].append("--always-prepare-payload")
+    elif participant["cl_type"] == "grandine":
+        participant["cl_extra_params"].append(
+            "--features=AlwaysPrepareExecutionPayload"
+        )
+    elif participant["cl_type"] == "consensoor":
+        participant["cl_extra_params"].append("--emit-payload-attributes")
+    elif participant["cl_type"] == "teku":
+        participant["cl_extra_params"].append(
+            "--Xfork-choice-updated-always-send-payload-attributes=true"
+        )
+    else:
+        # nimbus has no flag to emit payload_attributes.
+        fail(
+            "buildoor requires the CL feeding it to be one of "
+            + "[lodestar, prysm, lighthouse, grandine, consensoor, teku]: '{0}' has no flag to build a payload on each slot ".format(
+                participant["cl_type"]
+            )
+            + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."
+        )
+
+
+# Per-participant buildoor: every participant with buildoor_enabled gets its own
+# dedicated buildoor service (buildoor-<index>) wired directly to its own CL.
+# This is independent of the global mev_type buildoor flow (which runs a single
+# shared buildoor for the whole network).
+def enrich_buildoor_per_participant(parsed_arguments_dict):
+    participants = parsed_arguments_dict["participants"]
+    gas_limit = parsed_arguments_dict["network_params"]["gas_limit"]
+    for index, participant in enumerate(participants):
+        if not participant.get("buildoor_enabled"):
+            continue
+        mev_url = "http://{0}-{1}:{2}".format(
+            constants.BUILDOOR_SERVICE_NAME,
+            index,
+            constants.BUILDOOR_API_PORT,
+        )
+        apply_external_builder_flags(participant, mev_url, gas_limit)
+        apply_buildoor_payload_attributes_flags(participant)
+    return parsed_arguments_dict
+
+
 # TODO perhaps clean this up into a map
 def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_type):
     for index, participant in enumerate(parsed_arguments_dict["participants"]):
@@ -2521,76 +2647,16 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 mev_port,
             )
 
-        if participant["cl_type"] == "lighthouse":
-            participant["cl_extra_params"].append("--builder={0}".format(mev_url))
-        if participant["vc_type"] == "lighthouse":
-            if (
-                parsed_arguments_dict["network_params"]["gas_limit"] == 0
-            ):  # if the gas limit is set we already enable builder-proposals
-                participant["vc_extra_params"].append("--builder-proposals")
-        if participant["cl_type"] == "lodestar":
-            participant["cl_extra_params"].append("--builder")
-            participant["cl_extra_params"].append("--builder.urls={0}".format(mev_url))
-        if participant["vc_type"] == "lodestar":
-            participant["vc_extra_params"].append("--builder")
-        if participant["cl_type"] == "nimbus":
-            participant["cl_extra_params"].append("--payload-builder=true")
-            participant["cl_extra_params"].append(
-                "--payload-builder-url={0}".format(mev_url)
-            )
-        if participant["vc_type"] == "nimbus":
-            participant["vc_extra_params"].append("--payload-builder=true")
-        if participant["cl_type"] == "teku":
-            participant["cl_extra_params"].append(
-                "--builder-endpoint={0}".format(mev_url)
-            )
-            participant["cl_extra_params"].append(
-                "--validators-builder-registration-default-enabled=true"
-            )
-        if participant["vc_type"] == "teku":
-            participant["vc_extra_params"].append(
-                "--validators-builder-registration-default-enabled=true"
-            )
-        if participant["cl_type"] == "prysm":
-            participant["cl_extra_params"].append(
-                "--http-mev-relay={0}".format(mev_url)
-            )
-        if participant["vc_type"] == "prysm":
-            participant["vc_extra_params"].append("--enable-builder")
-        if participant["cl_type"] == "grandine":
-            participant["cl_extra_params"].append("--builder-url={0}".format(mev_url))
-
-        if participant["vc_type"] == "vero":
-            participant["vc_extra_params"].append("--use-external-builder")
+        apply_external_builder_flags(
+            participant,
+            mev_url,
+            parsed_arguments_dict["network_params"]["gas_limit"],
+        )
 
         # buildoor builds against the first participant's payload_attributes
         # SSE stream, so that CL must emit them on every slot.
         if mev_type == constants.BUILDOOR_MEV_TYPE and index == 0:
-            if participant["cl_type"] == "lodestar":
-                participant["cl_extra_params"].append("--emitPayloadAttributes=true")
-            elif participant["cl_type"] == "prysm":
-                participant["cl_extra_params"].append("--prepare-all-payloads")
-            elif participant["cl_type"] == "lighthouse":
-                participant["cl_extra_params"].append("--always-prepare-payload")
-            elif participant["cl_type"] == "grandine":
-                participant["cl_extra_params"].append(
-                    "--features=AlwaysPrepareExecutionPayload"
-                )
-            elif participant["cl_type"] == "consensoor":
-                participant["cl_extra_params"].append("--emit-payload-attributes")
-            elif participant["cl_type"] == "teku":
-                participant["cl_extra_params"].append(
-                    "--Xfork-choice-updated-always-send-payload-attributes=true"
-                )
-            else:
-                # nimbus has no flag to emit payload_attributes.
-                fail(
-                    "mev_type 'buildoor' requires the first participant's cl_type to be one of "
-                    + "[lodestar, prysm, lighthouse, grandine, consensoor, teku]: '{0}' has no flag to build a payload on each slot ".format(
-                        participant["cl_type"]
-                    )
-                    + "(emit payload_attributes for all slots), which buildoor needs to trigger block building."
-                )
+            apply_buildoor_payload_attributes_flags(participant)
 
     num_participants = len(parsed_arguments_dict["participants"])
     index_str = shared_utils.zfill_custom(

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -157,15 +157,15 @@ def input_parser(plan, input_args):
 
     if constants.NETWORK_NAME.shadowfork in result["network_params"]["network"]:
         shadow_base = result["network_params"]["network"].split("-shadowfork")[0]
-        result["network_params"]["deposit_contract_address"] = (
-            constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
-        )
+        result["network_params"][
+            "deposit_contract_address"
+        ] = constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
 
     if constants.NETWORK_NAME.shadowfork in result["network_params"]["network"]:
         shadow_base = result["network_params"]["network"].split("-shadowfork")[0]
-        result["network_params"]["deposit_contract_address"] = (
-            constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
-        )
+        result["network_params"][
+            "deposit_contract_address"
+        ] = constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
 
     for attr in input_args:
         value = input_args[attr]

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -157,15 +157,15 @@ def input_parser(plan, input_args):
 
     if constants.NETWORK_NAME.shadowfork in result["network_params"]["network"]:
         shadow_base = result["network_params"]["network"].split("-shadowfork")[0]
-        result["network_params"][
-            "deposit_contract_address"
-        ] = constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
+        result["network_params"]["deposit_contract_address"] = (
+            constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
+        )
 
     if constants.NETWORK_NAME.shadowfork in result["network_params"]["network"]:
         shadow_base = result["network_params"]["network"].split("-shadowfork")[0]
-        result["network_params"][
-            "deposit_contract_address"
-        ] = constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
+        result["network_params"]["deposit_contract_address"] = (
+            constants.DEPOSIT_CONTRACT_ADDRESS[shadow_base]
+        )
 
     for attr in input_args:
         value = input_args[attr]
@@ -281,6 +281,14 @@ def input_parser(plan, input_args):
     if result.get("disable_peer_scoring"):
         result = enrich_disable_peer_scoring(result)
 
+    if result.get("mev_type") == constants.BUILDOOR_MEV_TYPE:
+        plan.print(
+            "DEPRECATION WARNING: mev_type: buildoor (single shared builder) is "
+            + "deprecated and will be dropped after the gloas fork. Use the "
+            + "buildoor_params.instances config instead, which spins up dedicated "
+            + "buildoor builders wired to specific participants."
+        )
+
     if result.get("mev_type") in (
         constants.MOCK_MEV_TYPE,
         constants.FLASHBOTS_MEV_TYPE,
@@ -304,36 +312,57 @@ def input_parser(plan, input_args):
             )
         )
 
-    # Per-participant buildoor instances (buildoor_enabled flag). Independent of
-    # the global mev_type. Each flagged participant gets its own buildoor wired
-    # directly to its own CL, so it must not be combined with a global mev_type
-    # (that would double-wire the participant's builder endpoint).
-    buildoor_participant_count = 0
-    for participant in result["participants"]:
-        if participant.get("buildoor_enabled"):
-            buildoor_participant_count += 1
-    if buildoor_participant_count > 0:
+    # Per-participant buildoor instances, configured independently of the
+    # participants via buildoor_params.instances (a builder is independent of the
+    # network - it reads one participant's CL/EL and, in ePBS, gossips bids to all).
+    # No global mev_type is required; configuring instances is enough. Cannot be
+    # combined with the global mev_type flow (that would double-wire the builder).
+    buildoor_instances = result["buildoor_params"]["instances"]
+    total_buildoor_instances = 0
+    seen_buildoor_participants = {}
+    for instance in buildoor_instances:
+        participant_num = instance["participant"]
+        if (
+            type(participant_num) != "int"
+            or participant_num < 1
+            or participant_num > len(result["participants"])
+        ):
+            fail(
+                "buildoor_params.instances participant must be a 1-based participant index between 1 and {0}, got {1}.".format(
+                    len(result["participants"]),
+                    participant_num,
+                )
+            )
+        if participant_num in seen_buildoor_participants:
+            fail(
+                "buildoor_params.instances has duplicate entries for participant {0}; use a single entry with the desired count.".format(
+                    participant_num
+                )
+            )
+        seen_buildoor_participants[participant_num] = True
+        if type(instance["count"]) != "int" or instance["count"] < 1:
+            fail(
+                "buildoor_params.instances count for participant {0} must be an integer >= 1, got {1}.".format(
+                    participant_num,
+                    instance["count"],
+                )
+            )
+        total_buildoor_instances += instance["count"]
+    if total_buildoor_instances > 0:
         if result.get("mev_type") != None:
             fail(
-                "Per-participant buildoor_enabled cannot be combined with a global mev_type ({0}). ".format(
+                "buildoor_params.instances cannot be combined with a global mev_type ({0}). ".format(
                     result.get("mev_type")
                 )
-                + "Use buildoor_enabled on participants for dedicated per-participant builders, "
+                + "Use buildoor_params.instances for dedicated per-participant builders, "
                 + "or mev_type: buildoor for a single shared builder, but not both."
             )
-        # Every buildoor instance is its own builder and needs its own builder BLS
-        # key registered at genesis. builder_count must cover all of them.
-        if result["network_params"]["builder_count"] < buildoor_participant_count:
-            fail(
-                "buildoor_enabled is set on {0} participant(s) but network_params.builder_count is {1}. ".format(
-                    buildoor_participant_count,
-                    result["network_params"]["builder_count"],
-                )
-                + "Each per-participant buildoor needs its own builder BLS key registered at genesis; "
-                + "set network_params.builder_count to at least {0}.".format(
-                    buildoor_participant_count
-                )
-            )
+        # Each buildoor instance is its own builder, onboarded after genesis via
+        # its lifecycle deposit (buildoor_params.lifecycle) rather than registered
+        # at genesis. So no genesis builder registration is needed and gloas does
+        # not have to be at genesis - buildoor works with gloas at any epoch. Its
+        # builder keys are derived at indices after any genesis builders (see
+        # main.star) to avoid colliding with validator/genesis-builder keys.
         result = enrich_buildoor_per_participant(result)
 
     if (
@@ -827,7 +856,6 @@ def input_parser(plan, input_args):
                 blobber_enabled=participant["blobber_enabled"],
                 blobber_extra_params=participant["blobber_extra_params"],
                 blobber_image=participant["blobber_image"],
-                buildoor_enabled=participant["buildoor_enabled"],
                 keymanager_enabled=participant["keymanager_enabled"],
                 vc_beacon_node_indices=participant["vc_beacon_node_indices"],
                 checkpoint_sync_enabled=participant["checkpoint_sync_enabled"],
@@ -1236,6 +1264,14 @@ def input_parser(plan, input_args):
             extra_args=result["buildoor_params"]["extra_args"],
             builder_api=result["buildoor_params"]["builder_api"],
             epbs_builder=result["buildoor_params"]["epbs_builder"],
+            lifecycle=result["buildoor_params"]["lifecycle"],
+            instances=[
+                struct(
+                    participant=instance["participant"],
+                    count=instance["count"],
+                )
+                for instance in result["buildoor_params"]["instances"]
+            ],
         ),
         trueblocks_params=struct(
             image=result["trueblocks_params"]["image"],
@@ -1735,7 +1771,9 @@ def parse_network_params(plan, input_args):
                 )
             )
         builder_mnemonic_entry = {
-            "mnemonic": constants.DEFAULT_MNEMONIC,
+            "mnemonic": result["network_params"][
+                "preregistered_validator_keys_mnemonic"
+            ],
             "start": actual_num_validators,
             "count": result["network_params"]["builder_count"],
             "wd_prefix": "0x03",
@@ -2080,7 +2118,6 @@ def default_participant():
         "blobber_enabled": False,
         "blobber_extra_params": [],
         "blobber_image": "ethpandaops/blobber:latest",
-        "buildoor_enabled": False,
         "builder_network_params": None,
         "keymanager_enabled": None,
         "vc_beacon_node_indices": None,
@@ -2450,6 +2487,16 @@ def get_default_buildoor_params():
         "extra_args": [],
         "builder_api": True,
         "epbs_builder": True,
+        # Enable buildoor's builder lifecycle (it deposits/onboards its own
+        # builder after genesis and tops it up), so builders work even when gloas
+        # is not at genesis. Requires the EL RPC + wallet key, both already wired.
+        "lifecycle": True,
+        # List of {participant: <1-based index>, count: <n>} entries. Each entry
+        # spins up `count` dedicated buildoor builder instances wired to that
+        # participant's CL/EL. Builders are independent of the participants - a
+        # builder reads one CL's payload_attributes stream and (in ePBS) gossips
+        # bids to the whole network. Empty => no per-participant buildoors.
+        "instances": [],
     }
 
 
@@ -2597,19 +2644,34 @@ def apply_buildoor_payload_attributes_flags(participant):
         )
 
 
-# Per-participant buildoor: every participant with buildoor_enabled gets its own
-# dedicated buildoor service (buildoor-<index>) wired directly to its own CL.
-# This is independent of the global mev_type buildoor flow (which runs a single
+# Per-participant buildoor: each buildoor_params.instances entry spins up
+# `count` dedicated buildoor services wired to the named participant's CL/EL.
+# Builders are configured independently of the participants (a builder reads one
+# CL's payload_attributes stream and, in ePBS, gossips bids to the whole
+# network). This is independent of the global mev_type buildoor flow (a single
 # shared buildoor for the whole network).
 def enrich_buildoor_per_participant(parsed_arguments_dict):
     participants = parsed_arguments_dict["participants"]
     gas_limit = parsed_arguments_dict["network_params"]["gas_limit"]
-    for index, participant in enumerate(participants):
-        if not participant.get("buildoor_enabled"):
-            continue
-        mev_url = "http://{0}-{1}:{2}".format(
+    num_participants = len(participants)
+    for instance in parsed_arguments_dict["buildoor_params"]["instances"]:
+        index = instance["participant"] - 1
+        count = instance["count"]
+        participant = participants[index]
+        index_str = shared_utils.zfill_custom(index + 1, len(str(num_participants)))
+        # The CL has a single external-builder endpoint, so it is wired to the
+        # participant's first buildoor instance. Any additional instances still
+        # spin up (e.g. competing ePBS builders) but are not the CL's builder.
+        service_name = shared_utils.get_buildoor_service_name(
             constants.BUILDOOR_SERVICE_NAME,
-            index,
+            participant["cl_type"],
+            participant["el_type"],
+            index_str,
+            0,
+            count,
+        )
+        mev_url = "http://{0}:{1}".format(
+            service_name,
             constants.BUILDOOR_API_PORT,
         )
         apply_external_builder_flags(participant, mev_url, gas_limit)

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -312,51 +312,59 @@ def input_parser(plan, input_args):
             )
         )
 
-    # Per-participant buildoor instances, configured independently of the
-    # participants via buildoor_params.instances (a builder is independent of the
-    # network - it reads one participant's CL/EL and, in ePBS, gossips bids to all).
-    # No global mev_type is required; configuring instances is enough. Cannot be
-    # combined with the global mev_type flow (that would double-wire the builder).
+    # Per-participant buildoor builders. buildoor is an additional_service: it is
+    # only spun up when "buildoor" is in additional_services. Its targeting is
+    # configured (independently of the participants) via buildoor_params.instances
+    # ([{participant, count}]); a builder is independent of the network - it reads
+    # one participant's CL/EL and, in ePBS, gossips bids to all.
+    buildoor_enabled = constants.BUILDOOR_SERVICE_NAME in result["additional_services"]
     buildoor_instances = result["buildoor_params"]["instances"]
-    total_buildoor_instances = 0
-    seen_buildoor_participants = {}
-    for instance in buildoor_instances:
-        participant_num = instance["participant"]
-        if (
-            type(participant_num) != "int"
-            or participant_num < 1
-            or participant_num > len(result["participants"])
-        ):
-            fail(
-                "buildoor_params.instances participant must be a 1-based participant index between 1 and {0}, got {1}.".format(
-                    len(result["participants"]),
-                    participant_num,
-                )
-            )
-        if participant_num in seen_buildoor_participants:
-            fail(
-                "buildoor_params.instances has duplicate entries for participant {0}; use a single entry with the desired count.".format(
-                    participant_num
-                )
-            )
-        seen_buildoor_participants[participant_num] = True
-        if type(instance["count"]) != "int" or instance["count"] < 1:
-            fail(
-                "buildoor_params.instances count for participant {0} must be an integer >= 1, got {1}.".format(
-                    participant_num,
-                    instance["count"],
-                )
-            )
-        total_buildoor_instances += instance["count"]
-    if total_buildoor_instances > 0:
+    if buildoor_instances and not buildoor_enabled:
+        fail(
+            "buildoor_params.instances is set but 'buildoor' is not in additional_services. "
+            + "Add 'buildoor' to additional_services to spin it up."
+        )
+    if buildoor_enabled:
         if result.get("mev_type") != None:
             fail(
-                "buildoor_params.instances cannot be combined with a global mev_type ({0}). ".format(
+                "additional_services buildoor cannot be combined with a global mev_type ({0}). ".format(
                     result.get("mev_type")
                 )
-                + "Use buildoor_params.instances for dedicated per-participant builders, "
-                + "or mev_type: buildoor for a single shared builder, but not both."
+                + "Use additional_services: [buildoor] with buildoor_params.instances for dedicated "
+                + "per-participant builders, or mev_type: buildoor for a single shared builder, but not both."
             )
+        # Default to a single builder on the first participant when none configured.
+        if not buildoor_instances:
+            buildoor_instances = [{"participant": 1, "count": 1}]
+            result["buildoor_params"]["instances"] = buildoor_instances
+        seen_buildoor_participants = {}
+        for instance in buildoor_instances:
+            participant_num = instance["participant"]
+            if (
+                type(participant_num) != "int"
+                or participant_num < 1
+                or participant_num > len(result["participants"])
+            ):
+                fail(
+                    "buildoor_params.instances participant must be a 1-based participant index between 1 and {0}, got {1}.".format(
+                        len(result["participants"]),
+                        participant_num,
+                    )
+                )
+            if participant_num in seen_buildoor_participants:
+                fail(
+                    "buildoor_params.instances has duplicate entries for participant {0}; use a single entry with the desired count.".format(
+                        participant_num
+                    )
+                )
+            seen_buildoor_participants[participant_num] = True
+            if type(instance["count"]) != "int" or instance["count"] < 1:
+                fail(
+                    "buildoor_params.instances count for participant {0} must be an integer >= 1, got {1}.".format(
+                        participant_num,
+                        instance["count"],
+                    )
+                )
         # Each buildoor instance is its own builder, onboarded after genesis via
         # its lifecycle deposit (buildoor_params.lifecycle) rather than registered
         # at genesis. So no genesis builder registration is needed and gloas does

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -72,6 +72,7 @@ PARTICIPANT_CATEGORIES = {
         "blobber_enabled",
         "blobber_extra_params",
         "blobber_image",
+        "buildoor_enabled",
         "builder_network_params",
         "keymanager_enabled",
         "vc_beacon_node_indices",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -72,7 +72,6 @@ PARTICIPANT_CATEGORIES = {
         "blobber_enabled",
         "blobber_extra_params",
         "blobber_image",
-        "buildoor_enabled",
         "builder_network_params",
         "keymanager_enabled",
         "vc_beacon_node_indices",
@@ -469,6 +468,8 @@ SUBCATEGORY_PARAMS = {
         "extra_args",
         "builder_api",
         "epbs_builder",
+        "lifecycle",
+        "instances",
     ],
     "trueblocks_params": [
         "image",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -512,6 +512,7 @@ ADDITIONAL_SERVICES_PARAMS = [
     "zkboost",
     "trueblocks",
     "otel",
+    "buildoor",
 ]
 
 ADDITIONAL_CATEGORY_PARAMS = {

--- a/src/shared_utils/shared_utils.star
+++ b/src/shared_utils/shared_utils.star
@@ -100,6 +100,18 @@ def zfill_custom(value, width):
     return ("0" * (width - len(str(value)))) + str(value)
 
 
+# Builds the service name for a per-participant buildoor instance, e.g.
+# buildoor-lighthouse-geth-1. When a participant runs more than one buildoor
+# (count > 1) a 1-based instance suffix is appended, e.g.
+# buildoor-lighthouse-geth-1-2. Used by both the input parser (to wire the CL's
+# builder endpoint) and main.star (to add the service), so they never drift.
+def get_buildoor_service_name(prefix, cl_type, el_type, index_str, instance, count):
+    base = "{0}-{1}-{2}-{3}".format(prefix, cl_type, el_type, index_str)
+    if count <= 1:
+        return base
+    return "{0}-{1}".format(base, instance + 1)
+
+
 def label_maker(
     client, client_type, image, connected_client, extra_labels, supernode=False
 ):


### PR DESCRIPTION
## What

Adds support for **multiple dedicated buildoor builder instances**, configured independently of the participants via `buildoor_params.instances` and enabled as an `additional_services` entry.

```yaml
participants:
  - el_type: geth
    cl_type: lighthouse
  - el_type: reth
    cl_type: prysm
additional_services:
  - buildoor          # enables buildoor (like dora/spamoor/etc)
buildoor_params:
  builder_api: true
  epbs_builder: true
  lifecycle: true
  instances:
    - participant: 1  # 1-based participant index
      count: 1
    - participant: 2
      count: 2        # two competing builders wired to participant 2
```

This spins up `buildoor-lighthouse-geth-1`, `buildoor-reth-prysm-2-1`, and `buildoor-reth-prysm-2-2`, each wired to the named participant's own CL/EL.

## Why

A block builder is independent of the network — it reads one CL's `payload_attributes` stream and (under ePBS) gossips bids to everyone. The previous model only allowed a single shared builder via `mev_type: buildoor` against participant 0. This lets you run many builders, target specific participants, and run more than one per participant.

## How

- **buildoor as an additional_service** — buildoor only spins up when `buildoor` is in `additional_services` (consistent with other optional services), instead of being implied by config. With `buildoor` enabled and no `instances` set, it defaults to a single builder on the first participant. Mutually exclusive with the (deprecated) `mev_type: buildoor`.
- **`buildoor_params.instances`** — `[{participant, count}]` declares which participants get builders and how many each. Validated for index range, duplicates, and count.
- **Cleaner key derivation** — buildoor derives its builder BLS key itself via `--builder-mnemonic` + `--builder-key-index`, dropping the per-instance `ethdo` `run_sh` containers.
- **Lifecycle / post-genesis onboarding (default on)** — each builder onboards itself after genesis via its lifecycle deposit (`--lifecycle`), so builders no longer need genesis registration and **gloas does not have to be at genesis** (works at any gloas epoch). Builder keys are derived at indices after any genesis-registered builders to avoid collisions.
- **Block attribution** — each instance passes `--extra-data=<service-name>` so built blocks can be traced back to the builder that produced them.
- **Service naming** — `buildoor-<cl>-<el>-<participant>` (with a `-<n>` suffix when count > 1), matching the cl/el naming convention.
- **Deprecation** — `mev_type: buildoor` (single shared builder) is marked deprecated and will be dropped after the gloas fork; a runtime warning is printed.
- **Docs + validation + tests** — README updated; sanity checks added for the new params; nightly tests added (`buildoor-instances.yaml`, `buildoor-instances-matrix.yaml`).

## Notes / limitations

- The `--extra-data` flag and lifecycle/early-deposit onboarding require a buildoor build that supports them (in `glamsterdam-devnet-6`; not yet in `:main`). Bump the default `buildoor_params.image` once buildoor PRs #115/#110 land on main.
- The CL has a single external-builder endpoint, so it is wired to its participant's first buildoor instance; additional instances still run (e.g. competing ePBS builders) but are not the CL's Builder-API endpoint.
- Each instance uses a distinct prefunded account so concurrent buildoors don't collide on tx nonces; with a custom single-account `prefunded_accounts` they would share a wallet.

## Testing

Validated with `kurtosis run . --dry-run`:
- `additional_services: [buildoor]` + instances → all instances spin up.
- `additional_services: [buildoor]`, no instances → one builder on participant 1.
- instances set without `buildoor` in additional_services → clear failure.
- gloas at a non-genesis epoch → builders spin up (lifecycle onboarding).
- combining with `mev_type: buildoor` → conflict failure; deprecated `mev_type: buildoor` alone still works.
- `black`-formatted.
