### PR TITLE
fix(buildoor): correct teku payload-attributes flag to double-dash --X

### DIFF
--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -2580,7 +2580,7 @@ def enrich_mev_extra_params(parsed_arguments_dict, mev_prefix, mev_port, mev_typ
                 participant["cl_extra_params"].append("--emit-payload-attributes")
             elif participant["cl_type"] == "teku":
                 participant["cl_extra_params"].append(
-                    "-Xfork-choice-updated-always-send-payload-attributes=true"
+                    "--Xfork-choice-updated-always-send-payload-attributes=true"
                 )
             else:
                 # nimbus has no flag to emit payload_attributes.


### PR DESCRIPTION
## Problem

#1430 wired teku as a buildoor first participant using `-Xfork-choice-updated-always-send-payload-attributes=true` (**single** dash). Teku rejects that as an unknown option, so teku + `mev_type: buildoor` fails to boot:

```
Unknown option: '-Xfork-choice-updated-always-send-payload-attributes=true'
```

`main` is currently broken for this combination.

## Root cause

Teku's experimental (`-X`) options use the **`--X`** prefix (double dash), not `-X`. The correct option, confirmed via `teku --Xhelp` and `Eth2NetworkOptions.java`:

```
--Xfork-choice-updated-always-send-payload-attributes[=<BOOLEAN>]
   Calculate and send payload attributes on every forkChoiceUpdated
   regardless if a connected validator is due to be a block proposer
```

`[=<BOOLEAN>]` → `=true` is valid (bare also defaults to true).

## Fix

One character: `-X` → `--X`.

```diff
-                    "-Xfork-choice-updated-always-send-payload-attributes=true"
+                    "--Xfork-choice-updated-always-send-payload-attributes=true"
```

## Verification

- The double-dash form parses (no "Unknown option") on `ethpandaops/teku:glamsterdam-devnet-6` for bare, `=true`, and `=false`.
- `kurtosis run --dry-run` with teku + buildoor parses and runs end-to-end.

(Earlier confusion came from testing with `--version`, which short-circuits before teku validates options and masks unknown-option errors.)