### PR TITLE
chore: bump ethereum-genesis-generator to 6.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1792,7 +1792,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.1.1
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -269,7 +269,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.1
+  image: ethpandaops/ethereum-genesis-generator:6.1.2
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -111,7 +111,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.1.1"
+    "ethpandaops/ethereum-genesis-generator:6.1.2"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
Bumps the bundled `ethereum-genesis-generator` (egg) image from **6.1.1 → 6.1.2**.

Updated in all three pin locations:
- `src/package_io/constants.star`
- `network_params.yaml`
- `README.md`

egg [v6.1.2](https://github.com/ethpandaops/ethereum-genesis-generator/releases/tag/v6.1.2) is the latest release.