### PR TITLE
fix: Update Teku p2p-quic-port

### DIFF
--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -224,7 +224,7 @@ def get_beacon_config(
         ),
         "--p2p-discovery-site-local-addresses-enabled=true",
         "--p2p-port={0}".format(discovery_port_tcp),
-        "--Xp2p-quic-port={0}".format(discovery_port_quic),
+        "--p2p-quic-port={0}".format(discovery_port_quic),
         "--Xp2p-quic-enabled=true",
         "--rest-api-enabled=true",
         "--rest-api-docs-enabled=true",

--- a/src/cl/teku/teku_launcher.star
+++ b/src/cl/teku/teku_launcher.star
@@ -224,8 +224,6 @@ def get_beacon_config(
         ),
         "--p2p-discovery-site-local-addresses-enabled=true",
         "--p2p-port={0}".format(discovery_port_tcp),
-        "--p2p-quic-port={0}".format(discovery_port_quic),
-        "--Xp2p-quic-enabled=true",
         "--rest-api-enabled=true",
         "--rest-api-docs-enabled=true",
         "--rest-api-interface=0.0.0.0",


### PR DESCRIPTION
Teku changed port flag from `--Xp2p-quic-port` to `--p2p-quic-port`:

- https://github.com/Consensys/teku/pull/10904