### PR TITLE
fix: `osakaTime` parsing for generator: breaks spamoor when fulu not set

### DIFF
--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -98,7 +98,7 @@ def generate_el_cl_genesis_data(
     osaka_time = plan.run_sh(
         name="read-osaka-time",
         description="Reading osaka time from genesis",
-        run="jq '.config.osakaTime' /data/genesis.json | tr -d '\n'",
+        run="jq -r '.config.osakaTime // empty' /data/genesis.json | tr -d '\n'",
         files={"/data": genesis.files_artifacts[0]},
         tolerations=shared_utils.get_tolerations(global_tolerations=global_tolerations),
         node_selectors=global_node_selectors,


### PR DESCRIPTION
I've been testing with ethereum-package that `spamoor` is enabled, and I found one issue for using spamoor with osaka/fulu  isn't enabled (not set or max integer value set):

```
failed to init scenario: failed to unmarshal config: strconv.ParseUint: parsing "null": invalid syntax.
```

https://github.com/ethpandaops/ethereum-package/blob/f0caa4477890d6e393ed4b61c012a67e89587c2c/src/spamoor/spamoor.star#L42-L46

This was because `osaka_time` isn't null; it was actually a string `"null"` while parsing this:

https://github.com/ethpandaops/ethereum-package/blob/f0caa4477890d6e393ed4b61c012a67e89587c2c/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star#L101

This PR fixes this issue by using jq features: an alternative operator (`//`) with special keyword `empty`. Compare those commands: 

```bash
$ echo '{"config":{"foo":1}}' | jq '.config.osakaTime' 
``` 

and

```bash
echo '{"config":{"foo":1}}' | jq '.config.osakaTime // empty'
```

Ref: https://jdriven.com/blog/2023/10/jq-Joy-Using-Default-Values-With-The-Alternative-Operator