### PR TITLE
fix: emit caplin bootnode override and enable local discovery

### DIFF
--- a/src/cl/caplin/caplin_launcher.star
+++ b/src/cl/caplin/caplin_launcher.star
@@ -170,6 +170,7 @@ def get_beacon_config(
         "--sentinel.tcp.port={0}".format(p2p_port),
         "--discovery.port={0}".format(p2p_port),
         "--discovery.addr=0.0.0.0",
+        "--local-discovery",
         "--pprof",
         "--pprof.addr=0.0.0.0",
         "--pprof.port={0}".format(BEACON_METRICS_PORT_NUM),
@@ -208,7 +209,9 @@ def get_beacon_config(
                     elif ctx.multiaddr:
                         bootnodes.append(ctx.multiaddr)
                 if bootnodes:
-                    cmd.append("--sentinel.bootnodes=" + ",".join(bootnodes))
+                    bootnode_arg = ",".join(bootnodes)
+            if bootnode_arg != None:
+                cmd.append("--sentinel.bootnodes=" + bootnode_arg)
     else:
         cmd.append("--chain=" + network_params.network)
 


### PR DESCRIPTION
## Summary

Two fixes to the Caplin launcher's peer discovery on private networks:

- **Emit `bootnode_enr_override`.** The override (set when bootnodoor is the network bootnode) was assigned to `bootnode_arg` but only the `bootnode_contexts` path ever appended `--sentinel.bootnodes`, so a non-null override was silently dropped and Caplin nodes never learned the bootnode. Restructured to match the other CL launchers (assign `bootnode_arg`, emit once at the end).
- **Add `--local-discovery`.** Caplin otherwise refuses to discover peers on private IPs. Added unconditionally in the base command, matching how the package sets the equivalent flags for Lighthouse/Grandine (`--enable-private-discovery`) and Teku (`--p2p-discovery-site-local-addresses-enabled=true`).

### Testing
Verified live on docker: 2× geth/caplin + bootnodoor — with these fixes both Caplins receive `--sentinel.bootnodes=<bootnodoor ENR>` and connect to each other (previously 0 peers).