### PR TITLE
feat: state_actor_params — pre-populate EL databases with state-actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1474,6 +1474,46 @@ docker_cache_params:
   google_prefix: "/gcr/"
 
 
+# Pre-populate EL client databases with state-actor (https://github.com/ethereum/state-actor)
+# before the EL clients launch. When enabled, one state-actor run happens per unique
+# el_type among the participants, driven by the network's own genesis.json
+# (state-actor --genesis), so the produced database's genesis hash matches the hash the
+# CL genesis was built against. Each run's output is stored as a files artifact named
+# "state-actor-<el_type>-data"; participants opt in by mounting it at their execution
+# data directory via el_extra_mounts:
+#
+#   participants:
+#     - el_type: geth
+#       el_extra_mounts:
+#         /data/geth/execution-data: state-actor-geth-data
+#
+# nethermind participants additionally need:
+#   el_extra_params:
+#     - "--Init.BaseDbPath=/data/nethermind/execution-data"
+#     - "--FlatDb.Enabled=true"
+#
+# Supported el_types: geth, reth, besu, nethermind, ethrex, erigon
+# Requires state-actor images with --genesis support.
+state_actor_params:
+  # Whether to run state-actor pre-population
+  enabled: false
+  # Random seed passed to state-actor (deterministic output for a given genesis + seed)
+  seed: 1
+  # Optional DB-size budget (e.g. "1GB") for synthetic state on top of the genesis alloc.
+  # NOTE: any non-empty value changes the EL state root and therefore the genesis hash;
+  # the CL genesis must then be anchored to the state-actor output, which this
+  # integration does not do yet. Leave empty for alloc-verbatim databases.
+  target_size: ""
+  # Per-client state-actor images
+  images:
+    geth: ghcr.io/ethereum/state-actor-geth:main
+    reth: ghcr.io/ethereum/state-actor-reth:main
+    besu: ghcr.io/ethereum/state-actor-besu:main
+    nethermind: ghcr.io/ethereum/state-actor-nethermind:main
+    ethrex: ghcr.io/ethereum/state-actor-ethrex:main
+    erigon: ghcr.io/ethereum/state-actor-erigon:main
+
+
 # Configuration place for mempool bridge (https://github.com/ethpandaops/mempool-bridge)
 mempool_bridge_params:
   # The image to use for mempool bridge

--- a/README.md
+++ b/README.md
@@ -1475,17 +1475,23 @@ docker_cache_params:
 
 
 # Pre-populate EL client databases with state-actor (https://github.com/ethereum/state-actor)
-# before the EL clients launch. When enabled, one state-actor run happens per unique
-# el_type among the participants, driven by the network's own genesis.json
-# (state-actor --genesis), so the produced database's genesis hash matches the hash the
-# CL genesis was built against. Each run's output is stored as a files artifact named
-# "state-actor-<el_type>-data"; participants opt in by mounting it at their execution
-# data directory via el_extra_mounts:
+# before the EL clients launch, driven by the network's own genesis.json (state-actor
+# --genesis). Participants opt in with el_pre_populated_db: true, which also makes their
+# launcher skip genesis init/override (the pre-populated DB's chain config is
+# authoritative). When target_size / spec / snapshots add synthetic state, the genesis
+# hash changes and the CL genesis is automatically re-anchored to the state-actor
+# genesis block — no manual steps needed.
 #
-#   participants:
-#     - el_type: geth
-#       el_extra_mounts:
-#         /data/geth/execution-data: state-actor-geth-data
+# Two delivery modes:
+# - persistent: true — generation writes straight into each opted-in participant's
+#   persistent volume (required for multi-GB states; files artifacts can't carry them):
+#     participants:
+#       - el_type: geth
+#         el_pre_populated_db: true
+#     persistent: true
+# - default (non-persistent) — one files artifact per unique el_type, mounted via:
+#         el_extra_mounts:
+#           /data/geth/execution-data: state-actor-geth-data
 #
 # nethermind participants additionally need:
 #   el_extra_params:
@@ -1499,11 +1505,20 @@ state_actor_params:
   enabled: false
   # Random seed passed to state-actor (deterministic output for a given genesis + seed)
   seed: 1
-  # Optional DB-size budget (e.g. "1GB") for synthetic state on top of the genesis alloc.
-  # NOTE: any non-empty value changes the EL state root and therefore the genesis hash;
-  # the CL genesis must then be anchored to the state-actor output, which this
-  # integration does not do yet. Leave empty for alloc-verbatim databases.
+  # Optional DB-size budget (e.g. "5GB") of synthetic state on top of the genesis alloc.
+  # Empty = alloc-verbatim (genesis hash unchanged, no CL re-anchoring needed).
   target_size: ""
+  # Optional inline state-actor spec (YAML): concrete entities to write — ERC-20s, EOAs,
+  # EIP-7702 accounts, raw-bytecode contracts. Schema: docs/SPEC.md in the state-actor
+  # repo. Passed as --spec.
+  spec: ""
+  # Extra raw CLI args appended to every state-actor invocation.
+  extra_args: []
+  # Per-client URLs (s3/https) of pre-generated state-actor datadir tarballs
+  # (.tar.zst/.tar.gz/.tar), fetched instead of generating. Reuse requires launching
+  # with the same network params the snapshot was generated against, with
+  # network_params.genesis_time pinned to the original genesis time.
+  snapshots: {}
   # Per-client state-actor images
   images:
     geth: ghcr.io/ethereum/state-actor-geth:main

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -176,6 +176,11 @@ def get_config(
 
     el_shared.mount_el_binary_artifact(files, el_binary_artifact)
 
+    # A pre-populated DB already holds the genesis block; `erigon init`
+    # would compute a different hash from alloc and refuse the datadir.
+    if participant.el_pre_populated_db:
+        init_datadir_cmd_str = "true"
+
     # Build command with optional binary copy
     cmd_str = " ".join(cmd)
     if network_params.network not in constants.PUBLIC_NETWORKS:

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -108,11 +108,15 @@ def get_config(
             if network_params.network in constants.PUBLIC_NETWORKS
             else ""
         ),
+        # A pre-populated DB carries its own chain config; the override would
+        # recompute the genesis from alloc and fail with "database contains
+        # incompatible genesis".
         "{0}".format(
             "--override.genesis={0}".format(
                 constants.GENESIS_JSON_MOUNT_PATH_ON_CONTAINER
             )
             if network_params.network not in constants.PUBLIC_NETWORKS
+            and not participant.el_pre_populated_db
             else ""
         ),
         "--verbosity=" + log_level,

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -96,6 +96,7 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "buildoor_params",
     "ethereum_genesis_generator_params",
     "trueblocks_params",
+    "state_actor_params",
 )
 
 
@@ -138,6 +139,7 @@ def input_parser(plan, input_args):
     result["zkboost_params"] = get_default_zkboost_params()
     result["buildoor_params"] = get_default_buildoor_params()
     result["trueblocks_params"] = get_default_trueblocks_params()
+    result["state_actor_params"] = get_default_state_actor_params()
 
     if constants.NETWORK_NAME.shadowfork in result["network_params"]["network"]:
         shadow_base = result["network_params"]["network"].split("-shadowfork")[0]
@@ -163,6 +165,16 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["docker_cache_params"]:
                 sub_value = input_args["docker_cache_params"][sub_attr]
                 result["docker_cache_params"][sub_attr] = sub_value
+        elif attr == "state_actor_params":
+            for sub_attr in input_args["state_actor_params"]:
+                sub_value = input_args["state_actor_params"][sub_attr]
+                if sub_attr == "images":
+                    # Merge per-client so a partial images override keeps the
+                    # defaults for the other clients.
+                    for client, image in sub_value.items():
+                        result["state_actor_params"]["images"][client] = image
+                else:
+                    result["state_actor_params"][sub_attr] = sub_value
         elif attr == "mev_params":
             for sub_attr in input_args["mev_params"]:
                 sub_value = input_args["mev_params"][sub_attr]
@@ -1059,6 +1071,12 @@ def input_parser(plan, input_args):
             dockerhub_prefix=result["docker_cache_params"]["dockerhub_prefix"],
             github_prefix=result["docker_cache_params"]["github_prefix"],
             google_prefix=result["docker_cache_params"]["google_prefix"],
+        ),
+        state_actor_params=struct(
+            enabled=result["state_actor_params"]["enabled"],
+            seed=result["state_actor_params"]["seed"],
+            target_size=result["state_actor_params"]["target_size"],
+            images=result["state_actor_params"]["images"],
         ),
         tx_fuzz_params=struct(
             image=result["tx_fuzz_params"]["image"],
@@ -2182,6 +2200,32 @@ def get_default_docker_cache_params():
         "dockerhub_prefix": "/dh/",
         "github_prefix": "/gh/",
         "google_prefix": "/gcr/",
+    }
+
+
+def get_default_state_actor_params():
+    # Pre-populates EL datadirs with state-actor before launch. The images
+    # must carry a state-actor build with --genesis support; state-actor's
+    # published ghcr images are the default, overridable per client via
+    # `images` (e.g. locally built tags).
+    return {
+        "enabled": False,
+        "seed": 1,
+        # Optional DB-size budget (e.g. "1GB"). Empty = alloc-verbatim: the
+        # generated DB contains exactly the network genesis alloc, so the
+        # genesis hash matches the one the CL genesis was built against.
+        # NOTE: any non-empty value changes the EL state root and therefore
+        # the genesis hash — the CL genesis must then be anchored to the
+        # state-actor output, which this integration does not do yet.
+        "target_size": "",
+        "images": {
+            "geth": "ghcr.io/ethereum/state-actor-geth:main",
+            "reth": "ghcr.io/ethereum/state-actor-reth:main",
+            "besu": "ghcr.io/ethereum/state-actor-besu:main",
+            "nethermind": "ghcr.io/ethereum/state-actor-nethermind:main",
+            "ethrex": "ghcr.io/ethereum/state-actor-ethrex:main",
+            "erigon": "ghcr.io/ethereum/state-actor-erigon:main",
+        },
     }
 
 

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -168,11 +168,10 @@ def input_parser(plan, input_args):
         elif attr == "state_actor_params":
             for sub_attr in input_args["state_actor_params"]:
                 sub_value = input_args["state_actor_params"][sub_attr]
-                if sub_attr == "images":
-                    # Merge per-client so a partial images override keeps the
-                    # defaults for the other clients.
-                    for client, image in sub_value.items():
-                        result["state_actor_params"]["images"][client] = image
+                if sub_attr in ("images", "snapshots"):
+                    # Merge per-client so partial overrides keep defaults.
+                    for client, val in sub_value.items():
+                        result["state_actor_params"][sub_attr][client] = val
                 else:
                     result["state_actor_params"][sub_attr] = sub_value
         elif attr == "mev_params":
@@ -833,6 +832,7 @@ def input_parser(plan, input_args):
                 el_min_mem=participant["el_min_mem"],
                 el_max_mem=participant["el_max_mem"],
                 el_force_restart=participant["el_force_restart"],
+                el_pre_populated_db=participant["el_pre_populated_db"],
                 cl_min_cpu=participant["cl_min_cpu"],
                 cl_max_cpu=participant["cl_max_cpu"],
                 cl_min_mem=participant["cl_min_mem"],
@@ -1076,6 +1076,9 @@ def input_parser(plan, input_args):
             enabled=result["state_actor_params"]["enabled"],
             seed=result["state_actor_params"]["seed"],
             target_size=result["state_actor_params"]["target_size"],
+            spec=result["state_actor_params"]["spec"],
+            extra_args=result["state_actor_params"]["extra_args"],
+            snapshots=result["state_actor_params"]["snapshots"],
             images=result["state_actor_params"]["images"],
         ),
         tx_fuzz_params=struct(
@@ -2086,6 +2089,9 @@ def default_participant():
         "el_min_mem": 0,
         "el_max_mem": 0,
         "el_force_restart": False,
+        # Datadir is pre-populated (e.g. state-actor) with an authoritative
+        # chain config; launchers skip genesis init/override steps.
+        "el_pre_populated_db": False,
         "cl_type": "lighthouse",
         "cl_image": "",
         "cl_binary_path": "",
@@ -2204,20 +2210,24 @@ def get_default_docker_cache_params():
 
 
 def get_default_state_actor_params():
-    # Pre-populates EL datadirs with state-actor before launch. The images
-    # must carry a state-actor build with --genesis support; state-actor's
-    # published ghcr images are the default, overridable per client via
-    # `images` (e.g. locally built tags).
+    # Pre-populates EL datadirs with state-actor before launch; images must
+    # carry a state-actor build with --genesis support.
     return {
         "enabled": False,
         "seed": 1,
-        # Optional DB-size budget (e.g. "1GB"). Empty = alloc-verbatim: the
-        # generated DB contains exactly the network genesis alloc, so the
-        # genesis hash matches the one the CL genesis was built against.
-        # NOTE: any non-empty value changes the EL state root and therefore
-        # the genesis hash — the CL genesis must then be anchored to the
-        # state-actor output, which this integration does not do yet.
+        # DB-size budget (e.g. "1GB"). Empty = alloc-verbatim. Non-empty (or
+        # a spec) changes the genesis hash → CL genesis is re-anchored;
+        # such participants must set el_pre_populated_db.
         "target_size": "",
+        # Inline YAML state-actor spec (--spec); declares concrete entities.
+        # Schema: docs/SPEC.md in the state-actor repo.
+        "spec": "",
+        # Extra raw CLI args appended to every state-actor invocation.
+        "extra_args": [],
+        # Per-client URLs (s3/https) of pre-generated state-actor datadir
+        # tarballs (.tar.zst/.tar.gz); fetched instead of generating. Requires
+        # pinning network_params.genesis_time to the snapshot's genesis time.
+        "snapshots": {},
         "images": {
             "geth": "ghcr.io/ethereum/state-actor-geth:main",
             "reth": "ghcr.io/ethereum/state-actor-reth:main",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -312,6 +312,12 @@ SUBCATEGORY_PARAMS = {
         "github_prefix",
         "google_prefix",
     ],
+    "state_actor_params": [
+        "enabled",
+        "seed",
+        "target_size",
+        "images",
+    ],
     "tx_fuzz_params": [
         "image",
         "tx_fuzz_extra_args",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -17,6 +17,7 @@ PARTICIPANT_CATEGORIES = {
         "el_min_mem",
         "el_max_mem",
         "el_force_restart",
+        "el_pre_populated_db",
         "cl_type",
         "cl_image",
         "cl_binary_path",
@@ -100,6 +101,7 @@ PARTICIPANT_MATRIX_PARAMS = {
             "el_min_mem",
             "el_max_mem",
             "el_force_restart",
+            "el_pre_populated_db",
         ],
         "cl": [
             "cl_type",
@@ -316,6 +318,9 @@ SUBCATEGORY_PARAMS = {
         "enabled",
         "seed",
         "target_size",
+        "spec",
+        "extra_args",
+        "snapshots",
         "images",
     ],
     "tx_fuzz_params": [

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -34,6 +34,7 @@ snooper_el_launcher = import_module("./snooper/snooper_el_launcher.star")
 blobber_launcher = import_module("./blobber/blobber_launcher.star")
 cl_context_module = import_module("./cl/cl_context.star")
 bootnodoor_launcher = import_module("./bootnodoor/bootnodoor_launcher.star")
+state_actor_launcher = import_module("./state_actor/state_actor_launcher.star")
 
 
 def launch_participant_network(
@@ -185,6 +186,22 @@ def launch_participant_network(
         plan.print("Bootnodoor launched with CL ENR: {0}".format(bootnodoor_enr))
         plan.print("Bootnodoor launched with ENODE: {0}".format(bootnodoor_enode))
         plan.print("Bootnodoor launched with EL ENR: {0}".format(bootnodoor_el_enr))
+
+    # Pre-populate EL databases with state-actor when enabled. Runs after
+    # genesis generation (it consumes the network's genesis.json) and before
+    # the EL launches; participants opt in by mounting the produced
+    # "state-actor-<el_type>-data" artifact at their execution data dir via
+    # el_extra_mounts.
+    if args_with_right_defaults.state_actor_params.enabled:
+        state_actor_launcher.generate(
+            plan,
+            args_with_right_defaults.state_actor_params,
+            args_with_right_defaults.participants,
+            el_cl_data,
+            extra_files_artifacts,
+            global_tolerations,
+            global_node_selectors,
+        )
 
     # Upload binary artifacts when both binary_path and force_restart are enabled
     binary_artifacts = {}

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -187,13 +187,11 @@ def launch_participant_network(
         plan.print("Bootnodoor launched with ENODE: {0}".format(bootnodoor_enode))
         plan.print("Bootnodoor launched with EL ENR: {0}".format(bootnodoor_el_enr))
 
-    # Pre-populate EL databases with state-actor when enabled. Runs after
-    # genesis generation (it consumes the network's genesis.json) and before
-    # the EL launches; participants opt in by mounting the produced
-    # "state-actor-<el_type>-data" artifact at their execution data dir via
-    # el_extra_mounts.
+    # Pre-populate EL databases with state-actor: runs between genesis
+    # generation and EL launch; participants opt in via el_extra_mounts on
+    # the "state-actor-<el_type>-data" artifact (+ el_pre_populated_db).
     if args_with_right_defaults.state_actor_params.enabled:
-        state_actor_launcher.generate(
+        state_actor_anchor_block = state_actor_launcher.generate(
             plan,
             args_with_right_defaults.state_actor_params,
             args_with_right_defaults.participants,
@@ -201,7 +199,33 @@ def launch_participant_network(
             extra_files_artifacts,
             global_tolerations,
             global_node_selectors,
+            persistent=persistent,
+            network_params=network_params,
         )
+        # Synthetic state changes the EL genesis hash, so re-run genesis
+        # generation anchored to state-actor's genesis block — same env
+        # (identical EL genesis.json), only the beacon eth1 anchor changes.
+        if state_actor_anchor_block != "" and (
+            network_params.network == constants.NETWORK_NAME.kurtosis
+        ):
+            plan.print(
+                "state-actor added synthetic state; re-anchoring CL genesis to the state-actor genesis block"
+            )
+            el_cl_data = el_cl_genesis_data_generator.generate_el_cl_genesis_data(
+                plan,
+                ethereum_genesis_generator_image,
+                args_with_right_defaults.ethereum_genesis_generator_params,
+                el_cl_genesis_config_template,
+                el_cl_genesis_additional_contracts_template,
+                final_genesis_timestamp,
+                network_params,
+                total_number_of_validator_keys,
+                "",
+                global_tolerations,
+                global_node_selectors,
+                anchor_block=state_actor_anchor_block,
+                name_suffix="-sa-anchored",
+            )
 
     # Upload binary artifacts when both binary_path and force_restart are enabled
     binary_artifacts = {}

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -23,18 +23,29 @@ def generate_el_cl_genesis_data(
     latest_block,
     global_tolerations=[],
     global_node_selectors={},
+    anchor_block="",
+    name_suffix="",
 ):
+    # anchor_block: artifact with /latest_block.json; anchors the CL genesis
+    # to that eth1 block via SHADOW_FORK_FILE while keeping the network's
+    # own network_id and template EL genesis. name_suffix avoids collisions.
     files = {}
     shadowfork_file = ""
+    is_parent_network_shadowfork = False
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
     if latest_block != "":
         files[SHADOWFORK_FILEPATH] = latest_block
+        shadowfork_file = SHADOWFORK_FILEPATH + "/latest_block.json"
+        is_parent_network_shadowfork = True
+    elif anchor_block != "":
+        files[SHADOWFORK_FILEPATH] = anchor_block
         shadowfork_file = SHADOWFORK_FILEPATH + "/latest_block.json"
 
     template_data = new_env_file_for_el_cl_genesis_data(
         genesis_unix_timestamp,
         total_num_validator_keys_to_preregister,
         shadowfork_file,
+        is_parent_network_shadowfork,
         network_params,
         genesis_generator_params.extra_env,
     )
@@ -62,22 +73,22 @@ def generate_el_cl_genesis_data(
     ] = additional_contracts_template
 
     genesis_generation_config_artifact_name = plan.render_templates(
-        genesis_values_and_dest_filepath, "genesis-el-cl-env-file"
+        genesis_values_and_dest_filepath, "genesis-el-cl-env-file" + name_suffix
     )
 
     files[GENESIS_VALUES_PATH] = genesis_generation_config_artifact_name
 
     genesis = plan.run_sh(
-        name="run-generate-genesis",
+        name="run-generate-genesis" + name_suffix,
         description="Creating genesis",
         run="cp /opt/values.env /config/values.env && ./entrypoint.sh all && mkdir /network-configs && mv /data/metadata/* /network-configs/ && mv /data/parsed /network-configs/parsed",
         image=image,
         files=files,
         store=[
-            StoreSpec(src="/network-configs/", name="el_cl_genesis_data"),
+            StoreSpec(src="/network-configs/", name="el_cl_genesis_data" + name_suffix),
             StoreSpec(
                 src="/network-configs/genesis_validators_root.txt",
-                name="genesis_validators_root",
+                name="genesis_validators_root" + name_suffix,
             ),
         ],
         wait=None,
@@ -86,7 +97,7 @@ def generate_el_cl_genesis_data(
     )
 
     genesis_validators_root = plan.run_sh(
-        name="read-genesis-validators-root",
+        name="read-genesis-validators-root" + name_suffix,
         description="Reading genesis validators root",
         run="cat /data/genesis_validators_root.txt",
         files={"/data": genesis.files_artifacts[1]},
@@ -96,7 +107,7 @@ def generate_el_cl_genesis_data(
     )
     osaka_time = ""
     osaka_time = plan.run_sh(
-        name="read-osaka-time",
+        name="read-osaka-time" + name_suffix,
         description="Reading osaka time from genesis",
         run="jq '.config.osakaTime' /data/genesis.json | tr -d '\n'",
         files={"/data": genesis.files_artifacts[0]},
@@ -131,6 +142,7 @@ def new_env_file_for_el_cl_genesis_data(
     genesis_unix_timestamp,
     total_num_validator_keys_to_preregister,
     shadowfork_file,
+    is_parent_network_shadowfork,
     network_params,
     extra_env,
 ):
@@ -141,8 +153,8 @@ def new_env_file_for_el_cl_genesis_data(
     return {
         "UnixTimestamp": genesis_unix_timestamp,
         "NetworkId": constants.NETWORK_ID[network_params.network.split("-")[0]]
-        if shadowfork_file
-        else network_params.network_id,  # This will override the network_id if shadowfork_file is present. If you want to use the network_id, please ensure that you don't use "shadowfork" in the network name.
+        if is_parent_network_shadowfork
+        else network_params.network_id,  # This will override the network_id if shadowforking a parent network. If you want to use the network_id, please ensure that you don't use "shadowfork" in the network name.
         "DepositContractAddress": network_params.deposit_contract_address,
         "SlotDurationMs": network_params.slot_duration_ms,
         "PreregisteredValidatorKeysMnemonic": network_params.preregistered_validator_keys_mnemonic,

--- a/src/state_actor/state_actor_launcher.star
+++ b/src/state_actor/state_actor_launcher.star
@@ -1,0 +1,90 @@
+constants = import_module("../package_io/constants.star")
+shared_utils = import_module("../shared_utils/shared_utils.star")
+
+# Pre-populates client-native EL databases with state-actor
+# (https://github.com/ethereum/state-actor) before the EL clients launch.
+#
+# One generation run happens per unique el_type among the participants,
+# driven by the network's own genesis.json (state-actor --genesis), so the
+# resulting DB's genesis hash matches the hash the CL genesis was built
+# against. The produced datadir is stored as a files artifact named
+# "state-actor-<el_type>-data" and registered in extra_files_artifacts, so
+# participants opt in by mounting it at their execution data dir:
+#
+#   participants:
+#     - el_type: geth
+#       el_extra_mounts:
+#         /data/geth/execution-data: state-actor-geth-data
+#
+# --db layout per client mirrors docs/RUNBOOK.md in the state-actor repo:
+# geth wants the DB at <datadir>/geth/chaindata; every other client's --db
+# IS the datadir.
+GENERATION_TIMEOUT = "30m"
+
+SUPPORTED_EL_TYPES = ["geth", "reth", "besu", "nethermind", "ethrex", "erigon"]
+
+ARTIFACT_NAME_PATTERN = "state-actor-{0}-data"
+
+
+def generate(
+    plan,
+    state_actor_params,
+    participants,
+    el_cl_data,
+    extra_files_artifacts,
+    global_tolerations,
+    global_node_selectors,
+):
+    el_types = []
+    for participant in participants:
+        if (
+            participant.el_type in SUPPORTED_EL_TYPES
+            and participant.el_type not in el_types
+        ):
+            el_types.append(participant.el_type)
+
+    for el_type in el_types:
+        image = state_actor_params.images.get(el_type, "")
+        if image == "":
+            fail(
+                "state_actor_params.images has no image for el_type '{0}'".format(
+                    el_type
+                )
+            )
+
+        db_path = "/output"
+        if el_type == "geth":
+            db_path = "/output/geth/chaindata"
+
+        cmd = "state-actor --client={0} --db={1} --genesis={2}/genesis.json --seed={3}".format(
+            el_type,
+            db_path,
+            constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER,
+            state_actor_params.seed,
+        )
+        if state_actor_params.target_size != "":
+            cmd += " --target-size={0}".format(state_actor_params.target_size)
+
+        artifact_name = ARTIFACT_NAME_PATTERN.format(el_type)
+        result = plan.run_sh(
+            name="state-actor-{0}".format(el_type),
+            description="Pre-populating {0} database with state-actor".format(el_type),
+            run="mkdir -p /output && " + cmd,
+            image=image,
+            files={
+                constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_data.files_artifact_uuid,
+            },
+            store=[
+                StoreSpec(src="/output", name=artifact_name),
+            ],
+            wait=GENERATION_TIMEOUT,
+            tolerations=shared_utils.get_tolerations(
+                global_tolerations=global_tolerations
+            ),
+            node_selectors=global_node_selectors,
+        )
+
+        # Registering the artifact under its name makes it referenceable
+        # from participants' el_extra_mounts (process_extra_mounts resolves
+        # string sources against this dict).
+        extra_files_artifacts[artifact_name] = result.files_artifacts[0]

--- a/src/state_actor/state_actor_launcher.star
+++ b/src/state_actor/state_actor_launcher.star
@@ -2,28 +2,21 @@ constants = import_module("../package_io/constants.star")
 shared_utils = import_module("../shared_utils/shared_utils.star")
 
 # Pre-populates client-native EL databases with state-actor
-# (https://github.com/ethereum/state-actor) before the EL clients launch.
-#
-# One generation run happens per unique el_type among the participants,
-# driven by the network's own genesis.json (state-actor --genesis), so the
-# resulting DB's genesis hash matches the hash the CL genesis was built
-# against. The produced datadir is stored as a files artifact named
-# "state-actor-<el_type>-data" and registered in extra_files_artifacts, so
-# participants opt in by mounting it at their execution data dir:
-#
-#   participants:
-#     - el_type: geth
-#       el_extra_mounts:
-#         /data/geth/execution-data: state-actor-geth-data
-#
-# --db layout per client mirrors docs/RUNBOOK.md in the state-actor repo:
-# geth wants the DB at <datadir>/geth/chaindata; every other client's --db
-# IS the datadir.
-GENERATION_TIMEOUT = "30m"
+# (https://github.com/ethereum/state-actor) — one run per unique el_type,
+# driven by the network's genesis.json; see README state_actor_params.
+GENERATION_TIMEOUT = "60m"
 
 SUPPORTED_EL_TYPES = ["geth", "reth", "besu", "nethermind", "ethrex", "erigon"]
 
 ARTIFACT_NAME_PATTERN = "state-actor-{0}-data"
+ANCHOR_BLOCK_ARTIFACT_NAME = "state-actor-anchor-block"
+SPEC_MOUNT_DIRPATH = "/sa-spec"
+SPEC_FILENAME = "spec.yaml"
+FETCH_IMAGE = "alpine:3.19.1"
+
+# Exported straight from the generation/fetch container — re-mounting the
+# multi-GB datadir artifact just to copy it times out the files expander.
+ANCHOR_CMD = " && mkdir -p /anchor && cp /output/genesis_block.json /anchor/latest_block.json"
 
 
 def generate(
@@ -34,6 +27,8 @@ def generate(
     extra_files_artifacts,
     global_tolerations,
     global_node_selectors,
+    persistent=False,
+    network_params=None,
 ):
     el_types = []
     for participant in participants:
@@ -43,48 +38,207 @@ def generate(
         ):
             el_types.append(participant.el_type)
 
+    tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
+
+    # Synthetic state changes the genesis hash → CL genesis must be
+    # re-anchored. Snapshots may or may not be bloated; anchoring to their
+    # genesis_block.json is a no-op when they are alloc-verbatim.
+    uses_snapshots = False
     for el_type in el_types:
-        image = state_actor_params.images.get(el_type, "")
-        if image == "":
-            fail(
-                "state_actor_params.images has no image for el_type '{0}'".format(
-                    el_type
+        if state_actor_params.snapshots.get(el_type, "") != "":
+            uses_snapshots = True
+    adds_synthetic_state = (
+        state_actor_params.target_size != ""
+        or state_actor_params.spec != ""
+        or uses_snapshots
+    )
+
+    spec_artifact = None
+    if state_actor_params.spec != "":
+        spec_artifact = plan.render_templates(
+            {
+                SPEC_FILENAME: struct(
+                    template=state_actor_params.spec,
+                    data={},
                 )
-            )
-
-        db_path = "/output"
-        if el_type == "geth":
-            db_path = "/output/geth/chaindata"
-
-        cmd = "state-actor --client={0} --db={1} --genesis={2}/genesis.json --seed={3}".format(
-            el_type,
-            db_path,
-            constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER,
-            state_actor_params.seed,
-        )
-        if state_actor_params.target_size != "":
-            cmd += " --target-size={0}".format(state_actor_params.target_size)
-
-        artifact_name = ARTIFACT_NAME_PATTERN.format(el_type)
-        result = plan.run_sh(
-            name="state-actor-{0}".format(el_type),
-            description="Pre-populating {0} database with state-actor".format(el_type),
-            run="mkdir -p /output && " + cmd,
-            image=image,
-            files={
-                constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_data.files_artifact_uuid,
             },
-            store=[
-                StoreSpec(src="/output", name=artifact_name),
-            ],
+            "state-actor-spec",
+        )
+
+    anchor_block = ""
+    anchor_store = StoreSpec(src="/anchor", name=ANCHOR_BLOCK_ARTIFACT_NAME)
+
+    # Persistent mode: write straight into each opted-in participant's
+    # persistent volume (launchers mount the same key). Files artifacts
+    # can't ferry multi-GB datadirs — the expander times out.
+    if persistent:
+        volume_size_key = network_params.network
+        if "devnet" in network_params.network:
+            volume_size_key = "devnets"
+        for index, participant in enumerate(participants):
+            if (
+                not participant.el_pre_populated_db
+                or participant.el_type not in SUPPORTED_EL_TYPES
+            ):
+                continue
+            index_str = shared_utils.zfill_custom(
+                index + 1, len(str(len(participants)))
+            )
+            el_service_name = "el-{0}-{1}-{2}".format(
+                index_str, participant.el_type, participant.cl_type
+            )
+            volume_size = (
+                int(participant.el_volume_size)
+                if int(participant.el_volume_size) > 0
+                else constants.VOLUME_SIZE[volume_size_key][
+                    participant.el_type.replace("-", "_") + "_volume_size"
+                ]
+            )
+            files = {
+                "/output": Directory(
+                    persistent_key="data-{0}".format(el_service_name),
+                    size=volume_size,
+                ),
+            }
+            snapshot_url = state_actor_params.snapshots.get(participant.el_type, "")
+            if snapshot_url != "":
+                cmd = fetch_cmd(snapshot_url)
+                image = FETCH_IMAGE
+            else:
+                cmd = generation_cmd(
+                    participant.el_type, state_actor_params, spec_artifact
+                )
+                image = client_image(state_actor_params, participant.el_type)
+                files[
+                    constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS
+                ] = el_cl_data.files_artifact_uuid
+                if spec_artifact != None:
+                    files[SPEC_MOUNT_DIRPATH] = spec_artifact
+            wants_anchor = adds_synthetic_state and anchor_block == ""
+            if wants_anchor:
+                cmd += ANCHOR_CMD
+            # run_sh cannot mount persistent Directories, so use the
+            # shadowfork helper-service pattern: on failure the container
+            # exits (no tail) and the wait errors out immediately.
+            helper_name = "state-actor-{0}".format(el_service_name)
+            plan.add_service(
+                name=helper_name,
+                config=ServiceConfig(
+                    image=image,
+                    entrypoint=["/bin/sh", "-c"],
+                    cmd=[cmd + " && touch /tmp/finished && tail -f /dev/null"],
+                    files=files,
+                    tolerations=tolerations,
+                    node_selectors=global_node_selectors,
+                ),
+            )
+            plan.wait(
+                service_name=helper_name,
+                recipe=ExecRecipe(command=["cat", "/tmp/finished"]),
+                field="code",
+                assertion="==",
+                target_value=0,
+                interval="5s",
+                timeout=GENERATION_TIMEOUT,
+            )
+            if wants_anchor:
+                anchor_block = plan.store_service_files(
+                    service_name=helper_name,
+                    src="/anchor/latest_block.json",
+                    name=ANCHOR_BLOCK_ARTIFACT_NAME,
+                )
+            plan.remove_service(name=helper_name)
+        return anchor_block
+
+    # Artifact mode (non-persistent): one artifact per unique el_type,
+    # referenced by participants via el_extra_mounts. Suited to small /
+    # alloc-verbatim states; large states should use persistent: true.
+    for el_type in el_types:
+        artifact_name = ARTIFACT_NAME_PATTERN.format(el_type)
+        wants_anchor = adds_synthetic_state and el_type == el_types[0]
+        store = [StoreSpec(src="/output", name=artifact_name)]
+        files = {}
+
+        snapshot_url = state_actor_params.snapshots.get(el_type, "")
+        if snapshot_url != "":
+            cmd = fetch_cmd(snapshot_url)
+            image = FETCH_IMAGE
+            step_name = "state-actor-fetch-{0}".format(el_type)
+        else:
+            cmd = "mkdir -p /output && " + generation_cmd(
+                el_type, state_actor_params, spec_artifact
+            )
+            image = client_image(state_actor_params, el_type)
+            step_name = "state-actor-{0}".format(el_type)
+            files[
+                constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS
+            ] = el_cl_data.files_artifact_uuid
+            if spec_artifact != None:
+                files[SPEC_MOUNT_DIRPATH] = spec_artifact
+
+        if wants_anchor:
+            cmd += ANCHOR_CMD
+            store.append(anchor_store)
+
+        result = plan.run_sh(
+            name=step_name,
+            description="Pre-populating {0} database with state-actor".format(el_type),
+            run=cmd,
+            image=image,
+            files=files,
+            store=store,
             wait=GENERATION_TIMEOUT,
-            tolerations=shared_utils.get_tolerations(
-                global_tolerations=global_tolerations
-            ),
+            tolerations=tolerations,
             node_selectors=global_node_selectors,
         )
 
-        # Registering the artifact under its name makes it referenceable
-        # from participants' el_extra_mounts (process_extra_mounts resolves
-        # string sources against this dict).
+        # Register so participants can reference the artifact from
+        # el_extra_mounts (process_extra_mounts resolves against this dict).
         extra_files_artifacts[artifact_name] = result.files_artifacts[0]
+        if wants_anchor:
+            # All writers emit the identical genesis block (cross-client
+            # invariant), so the first datadir's anchor covers the network.
+            anchor_block = result.files_artifacts[1]
+
+    return anchor_block
+
+
+def generation_cmd(el_type, state_actor_params, spec_artifact):
+    # geth expects its DB at <datadir>/geth/chaindata; every other
+    # client's --db IS the datadir (state-actor RUNBOOK layout).
+    db_path = "/output"
+    if el_type == "geth":
+        db_path = "/output/geth/chaindata"
+    cmd = "state-actor --client={0} --db={1} --genesis={2}/genesis.json --seed={3}".format(
+        el_type,
+        db_path,
+        constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER,
+        state_actor_params.seed,
+    )
+    if state_actor_params.target_size != "":
+        cmd += " --target-size={0}".format(state_actor_params.target_size)
+    if spec_artifact != None:
+        cmd += " --spec={0}/{1}".format(SPEC_MOUNT_DIRPATH, SPEC_FILENAME)
+    for arg in state_actor_params.extra_args:
+        cmd += " {0}".format(arg)
+    return cmd
+
+
+def fetch_cmd(snapshot_url):
+    untar = "tar -xf -"
+    if snapshot_url.endswith(".zst"):
+        untar = "tar -I zstd -xf -"
+    elif snapshot_url.endswith(".gz") or snapshot_url.endswith(".tgz"):
+        untar = "tar -xzf -"
+    return "apk add --no-cache curl tar zstd >/dev/null && mkdir -p /output && curl -fsSL '{0}' | {1} -C /output && ls /output".format(
+        snapshot_url, untar
+    )
+
+
+def client_image(state_actor_params, el_type):
+    image = state_actor_params.images.get(el_type, "")
+    if image == "":
+        fail(
+            "state_actor_params.images has no image for el_type '{0}'".format(el_type)
+        )
+    return image


### PR DESCRIPTION
## Summary

Adds an opt-in `state_actor_params` package arg that pre-populates EL client databases with [state-actor](https://github.com/ethereum/state-actor) before the EL clients launch.

When enabled, one state-actor generation run happens per unique `el_type` among the participants — after genesis generation, driven by the network's own `genesis.json` (`state-actor --genesis`) — so the produced database's genesis hash matches the hash the CL genesis was built against, and no CL-side changes are needed. Each run's output datadir is stored as a files artifact named `state-actor-<el_type>-data` and registered so participants can opt in by mounting it at their execution data dir:

```yaml
participants:
  - el_type: geth
    cl_type: lighthouse
    el_extra_mounts:
      /data/geth/execution-data: state-actor-geth-data
state_actor_params:
  enabled: true
```

This follows the shadowfork pattern (pre-launch step fills the EL data location before the client starts), but generates state instead of downloading a snapshot.

## Why

state-actor writes client-native databases (Pebble for geth, MDBX/RocksDB for reth, Bonsai RocksDB for besu, flat-state for nethermind, RocksDB for ethrex, Erigon v3 snapshots) without going through each client's init path — useful for state-bloat experiments and cross-client determinism testing. This PR wires its output into participant startup. Alloc-verbatim mode (no `target_size`) is fully supported today; bloated-state mode additionally requires anchoring the CL genesis to the state-actor genesis hash, which is left for a follow-up (state-actor exports an `eth_getBlockByNumber`-shaped `genesis_block.json` for exactly that purpose).

## Changes

- `src/state_actor/state_actor_launcher.star` (new): runs the per-el_type generation via `plan.run_sh`, stores + registers the datadir artifacts
- `src/participant_network.star`: invoke the launcher after `el_cl_data` is generated, before EL launch
- `src/package_io/input_parser.star`, `src/package_io/sanity_check.star`: `state_actor_params` plumbing (`enabled`, `seed`, `target_size`, `images`)
- `README.md`: config reference entry

## Testing

Tested with one single-node enclave per supported EL (geth, reth, besu, nethermind, ethrex, erigon), each paired with lighthouse, using state-actor images built from [ethereum/state-actor compare: qu0b/ethereum-package-integration](https://github.com/ethereum/state-actor/compare/main...qu0b:state-actor:qu0b/ethereum-package-integration) (adds the `--genesis` flag; not yet upstream — until it merges, `state_actor_params.images` must point at images built from that branch):

- all six ELs booted directly from the pre-populated database (verified via manifest/DB files in the datadir and rotated RocksDB logs) with no init step
- every client's RPC `eth_getBlockByNumber(0x0)` hash equals the hash state-actor exported, so the existing CL genesis stayed valid
- all six clients produced the identical genesis state root for the same 283-account alloc
- all networks produced blocks with lighthouse (heads observed: geth 20, reth 12, besu 17, nethermind 14, ethrex 15, erigon 13) with no EL errors

Per-client notes surfaced by testing (documented in the README entry): nethermind participants need `--Init.BaseDbPath=<datadir>` + `--FlatDb.Enabled=true`; erigon's pre-launch `erigon init` coexists cleanly with the pre-seeded datadir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJoWPhxuJVSwvzpZr494X1