### PR TITLE
fix(prysm): keep the VC on gRPC when paired with a Prysm beacon node

### DIFF
--- a/src/vc/prysm.star
+++ b/src/vc/prysm.star
@@ -60,7 +60,6 @@ def get_config(
         + constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER
         + "/config.yaml",
         "--suggested-fee-recipient=" + constants.VALIDATING_REWARDS_ACCOUNT,
-        "--beacon-rest-api-provider=" + ",".join(beacon_http_urls),
         # vvvvvvvvvvvvvvvvvvv METRICS CONFIG vvvvvvvvvvvvvvvvvvvvv
         "--disable-monitoring=false",
         "--monitoring-host=0.0.0.0",
@@ -68,9 +67,20 @@ def get_config(
         # ^^^^^^^^^^^^^^^^^^^ METRICS CONFIG ^^^^^^^^^^^^^^^^^^^^^
     ]
 
-    # Only add RPC provider if we're not using a blobber (blobber doesn't proxy RPC)
-    # Blobber uses port 5000, so check if that's in the URL
-    if ":5000" not in beacon_http_urls[0]:
+    # Setting --beacon-rest-api-provider implicitly enables the REST API (prysm#17159),
+    # so the two providers are mutually exclusive. gRPC is only usable when the VC talks
+    # straight to its own Prysm BN: blobber and snooper proxy the REST API only, and
+    # --beacon-rpc-provider takes a single endpoint so it cannot express multiple BNs.
+    use_beacon_api = (
+        cl_context.client_name != constants.CL_TYPE.prysm
+        or participant.blobber_enabled
+        or beacon_http_urls != [cl_context.beacon_http_url]
+    )
+
+    if use_beacon_api:
+        cmd.append("--beacon-rest-api-provider=" + ",".join(beacon_http_urls))
+        cmd.append("--enable-beacon-rest-api")
+    else:
         cmd.append("--beacon-rpc-provider=" + cl_context.beacon_grpc_url)
 
     if remote_signer_context == None:
@@ -99,15 +109,6 @@ def get_config(
         "--http-host=0.0.0.0",
         "--keymanager-token-file=" + constants.KEYMANAGER_MOUNT_PATH_ON_CONTAINER,
     ]
-
-    # Check if we're using a blobber by checking for port 5000
-    is_using_blobber = ":5000" in beacon_http_urls[0]
-
-    if cl_context.client_name != constants.CL_TYPE.prysm or is_using_blobber:
-        # Use Beacon API if:
-        # 1. Prysm VC wants to connect to a non-Prysm BN, OR
-        # 2. Blobber is enabled (since blobber only proxies REST, not RPC)
-        cmd.append("--enable-beacon-rest-api")
 
     if len(participant.vc_extra_params) > 0:
         # this is a repeated<proto type>, we convert it into Starlark


### PR DESCRIPTION
## Problem

Prysm changed the beacon API flag UX in [prysmaticlabs/prysm#17159](https://github.com/OffchainLabs/prysm/pull/17159) (merged 2026-07-13): setting `--beacon-rest-api-provider` now *implicitly* enables the REST API, so `--enable-beacon-rest-api` is no longer required.

```go
// config/features/config.go
if ctx.Bool(EnableBeaconRESTApi.Name) || ctx.IsSet(validatorflags.BeaconRESTApiProviderFlag.Name) {
	cfg.EnableBeaconRESTApi = true
}
```

This package passed `--beacon-rest-api-provider` unconditionally, and additionally passed `--beacon-rpc-provider` when the VC was paired with a Prysm BN. With the new Prysm behaviour the REST provider wins, so **every Prysm VC silently runs on REST** — including the Prysm VC ↔ Prysm BN pairing that is meant to exercise the gRPC path. The `--beacon-rpc-provider` we pass is simply ignored.

## Fix

Make the two providers mutually exclusive and derive the transport from the beacon node the VC is actually pointed at. gRPC is only usable when the VC talks straight to its own Prysm BN — blobber and snooper proxy the REST API only, and `--beacon-rpc-provider` takes a single endpoint so it cannot express a multi-BN setup.

```python
use_beacon_api = (
    cl_context.client_name != constants.CL_TYPE.prysm
    or participant.blobber_enabled
    or beacon_http_urls != [cl_context.beacon_http_url]
)
```

Side effects of expressing it this way, all in the "was already subtly wrong" category:

- Drops the `":5000" in beacon_http_urls[0]` string sniffing for blobber detection in favour of `participant.blobber_enabled`.
- **snooper**: previously a Prysm VC ↔ Prysm BN pair with `snooper_enabled` got `--beacon-rpc-provider` pointing straight at the BN, so (pre-#17159) the traffic bypassed the snooper entirely. It now goes over REST through the snooper, as intended.
- **multi-BN** (`vc_beacon_node_indices`): gRPC has no failover/multi-endpoint support and `cl_context` is the participant's own BN, so a Prysm VC pointed at other/multiple BNs stays on REST instead of quietly talking gRPC to the wrong node.

`--enable-beacon-rest-api` is still passed alongside the REST provider so pinned older Prysm images keep working. Anyone who wants a Prysm VC ↔ Prysm BN pair on REST can still add `--beacon-rest-api-provider=...` via `vc_extra_params`.

## Verification

Flags produced per scenario (`kurtosis run --dry-run`, minimal preset):

| scenario | flags on the Prysm VC |
| --- | --- |
| geth/prysm + prysm VC | `--beacon-rpc-provider=cl-1-prysm-geth:4000` |
| geth/lighthouse + prysm VC | `--beacon-rest-api-provider=http://cl-1-lighthouse-geth:4000` `--enable-beacon-rest-api` |
| prysm + `snooper_enabled` | `--beacon-rest-api-provider=http://<snooper>:8562` `--enable-beacon-rest-api` |
| prysm + `blobber_enabled` | `--beacon-rest-api-provider=http://blobber-cl-1-prysm-geth:5000` `--enable-beacon-rest-api` |
| prysm + `vc_beacon_node_indices: [0, 1]` | `--beacon-rest-api-provider=http://cl-1-prysm-geth:3500,http://cl-2-prysm-geth:3500` `--enable-beacon-rest-api` |

Full run of the geth/prysm + prysm VC case on the current `stable` images confirms the gRPC path is healthy: validators activate, and the VC submits attestations, aggregates, sync committee messages/contributions and a block.

```
INFO client: Submitted new attestations  slot=0 ...
INFO client: Submitted new aggregate attestations  slot=0 ...
INFO client: Submitted sync committee contributions and proofs  slot=0 ...
INFO client: Submitted new block  fork=fulu  blockNumber=1  slot=1 ...
```

One thing reviewers may want to weigh in on: on gRPC the VC logs `gRPC only supports the head topic, other topics will be ignored` — it subscribes to `head_v2` + `execution_payload_available`, and the latter is dropped. If Glamsterdam/ePBS testing needs that event, the Prysm↔Prysm default may want to move to REST deliberately rather than by accident, which this PR makes a one-line change.

Reported by the Prysm team after the flag UX change landed.
