### PR TITLE
feat: run ethereum-package topologies in E2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ Where `network_params.yaml` contains the parameters for your network in your hom
 
 Kurtosis packages work the same way over Docker or on Kubernetes. Please visit our [Kubernetes docs](https://docs.kurtosis.com/k8s) to learn how to spin up a private testnet on a Kubernetes cluster.
 
+#### Run Lighthouse and Geth on E2B
+
+The `e2b/` bridge runs pinned Lighthouse and Geth binaries in separate E2B
+sandboxes, each provisioned with 8 CPUs and 8 GiB of memory. Lighthouse reaches
+Geth through its JWT-authenticated Engine API over E2B's HTTPS proxy. The bridge
+targets public networks rather than the Kurtosis devnet path, so it does not
+require Docker at runtime.
+
+```bash
+cd e2b
+npm install
+npm run template:build
+npm run launch -- --network hoodi --timeout 60
+```
+
+Set `E2B_API_KEY` before building or launching. Supported networks are
+`mainnet`, `sepolia`, and `hoodi`; pass `--checkpoint-url URL` to override the
+network's default community checkpoint endpoint. The launcher prints both
+sandbox IDs and the Lighthouse API and metrics URLs with its ephemeral E2B
+traffic access token.
+
+The Geth sandbox permits public proxy traffic only so the separate Lighthouse
+sandbox can reach port 8551, which remains protected by their random shared JWT.
+Geth's ordinary JSON-RPC and metrics listeners bind to loopback and are
+accessible only through the E2B SDK. Lighthouse's HTTP endpoints retain E2B
+traffic-token protection.
+
+E2B's HTTPS proxy does not expose the clients' TCP/UDP discovery ports. The
+clients can dial peers over sandbox egress, but the bridge is not a replacement
+for Kurtosis when inbound P2P, custom genesis generation, validators, or a
+multi-node devnet is required.
+
 ### Considerations for Running on a Public Testnet with a Cloud Provider
 
 When running on a public testnet using a cloud provider's Kubernetes cluster, there are a few important factors to consider:

--- a/README.md
+++ b/README.md
@@ -55,37 +55,55 @@ Where `network_params.yaml` contains the parameters for your network in your hom
 
 Kurtosis packages work the same way over Docker or on Kubernetes. Please visit our [Kubernetes docs](https://docs.kurtosis.com/k8s) to learn how to spin up a private testnet on a Kubernetes cluster.
 
-#### Run Lighthouse and Geth on E2B
+#### Launch ethereum-package participants on E2B
 
-The `e2b/` bridge runs pinned Lighthouse and Geth binaries in separate E2B
-sandboxes, each provisioned with 8 CPUs and 8 GiB of memory. Lighthouse reaches
-Geth through its JWT-authenticated Engine API over E2B's HTTPS proxy. The bridge
-targets public networks rather than the Kurtosis devnet path, so it does not
-require Docker at runtime.
+The `e2b/` bridge reads the same `participants`, `participants_matrix`, and
+`network_params.network` fields as an ethereum-package network parameters YAML
+file. It expands participant counts and matrix combinations, then creates one
+8 CPU, 8 GiB E2B sandbox for every execution and consensus client. Each pair
+gets a unique JWT-authenticated Engine API connection.
 
 ```bash
 cd e2b
 npm install
 npm run template:build
-npm run launch -- --network hoodi --timeout 60
+npm run launch -- --config ../network_params.yaml --timeout 60
 ```
 
-Set `E2B_API_KEY` before building or launching. Supported networks are
-`mainnet`, `sepolia`, and `hoodi`; pass `--checkpoint-url URL` to override the
-network's default community checkpoint endpoint. The launcher prints both
-sandbox IDs and the Lighthouse API and metrics URLs with its ephemeral E2B
-traffic access token.
+Set `E2B_API_KEY` before building or launching. The YAML must select `mainnet`,
+`sepolia`, or `hoodi` in `network_params.network`; alternatively pass
+`--network hoodi` to override it. Pass `--checkpoint-url URL` to override the
+network's default community checkpoint endpoint.
 
-The Geth sandbox permits public proxy traffic only so the separate Lighthouse
-sandbox can reach port 8551, which remains protected by their random shared JWT.
-Geth's ordinary JSON-RPC and metrics listeners bind to loopback and are
-accessible only through the E2B SDK. Lighthouse's HTTP endpoints retain E2B
-traffic-token protection.
+The native E2B template currently supports Geth execution clients and
+Lighthouse or Prysm consensus clients. `count` has ethereum-package semantics:
 
-E2B's HTTPS proxy does not expose the clients' TCP/UDP discovery ports. The
-clients can dial peers over sandbox egress, but the bridge is not a replacement
-for Kurtosis when inbound P2P, custom genesis generation, validators, or a
-multi-node devnet is required.
+```yaml
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: prysm
+    count: 2
+  - el_type: geth
+    cl_type: lighthouse
+    count: 2
+```
+
+This configuration expands to four EL-CL pairs and eight sandboxes. The
+launcher returns a manifest containing every participant, pairing, sandbox ID,
+consensus API and metrics URL, and E2B traffic access token.
+
+The Geth sandboxes permit public proxy traffic only so their paired consensus
+sandboxes can reach port 8551, which remains protected by a random per-pair
+JWT. Geth JSON-RPC and metrics bind to loopback. Consensus HTTP endpoints retain
+E2B traffic-token protection.
+
+The adapter rejects unsupported client types, Docker image overrides,
+additional services, separate validator clients, and custom `kurtosis`
+networks instead of silently ignoring them. E2B's HTTPS proxy does not expose
+the TCP/UDP discovery ports or provide the genesis services needed for private
+devnets.
 
 ### Considerations for Running on a Public Testnet with a Cloud Provider
 

--- a/README.md
+++ b/README.md
@@ -57,23 +57,23 @@ Kurtosis packages work the same way over Docker or on Kubernetes. Please visit o
 
 #### Launch ethereum-package participants on E2B
 
-The `e2b/` bridge reads the same `participants`, `participants_matrix`, and
-`network_params.network` fields as an ethereum-package network parameters YAML
-file. It expands participant counts and matrix combinations, then creates one
-8 CPU, 8 GiB E2B sandbox for every execution and consensus client. Each pair
-gets a unique JWT-authenticated Engine API connection.
+The `e2b/` bridge reads ethereum-package-style `participants`,
+`participants_matrix`, and `network_params` YAML. It expands participant counts
+and matrix combinations, then creates one 8 CPU, 8 GiB E2B sandbox for every
+execution and consensus client. Each pair gets a unique JWT-authenticated
+Engine API connection.
 
 ```bash
 cd e2b
 npm install
 npm run template:build
-npm run launch -- --config ../network_params.yaml --timeout 60
+npm run launch -- --network hoodi --timeout 60
 ```
 
-Set `E2B_API_KEY` before building or launching. The YAML must select `mainnet`,
-`sepolia`, or `hoodi` in `network_params.network`; alternatively pass
-`--network hoodi` to override it. Pass `--checkpoint-url URL` to override the
-network's default community checkpoint endpoint.
+Set `E2B_API_KEY` before building or launching. Public-network YAML may select
+`mainnet`, `sepolia`, or `hoodi` in `network_params.network`; alternatively pass
+`--network hoodi` to override it. Pass an HTTPS `--checkpoint-url URL` to
+override the network's default community checkpoint endpoint.
 
 The native E2B template currently supports Geth execution clients and
 Lighthouse or Prysm consensus clients. `count` has ethereum-package semantics:
@@ -90,20 +90,37 @@ participants:
     count: 2
 ```
 
-This configuration expands to four EL-CL pairs and eight sandboxes. The
-launcher returns a manifest containing every participant, pairing, sandbox ID,
-consensus API and metrics URL, and E2B traffic access token.
+This configuration expands to four EL-CL pairs and eight sandboxes. For public
+networks, the launcher returns a manifest containing every participant,
+pairing, sandbox ID, consensus API and metrics URL, and E2B traffic access
+token. Geth sandboxes permit public proxy traffic only so their paired
+consensus sandboxes can reach port 8551, which remains protected by a random
+per-pair JWT. Geth JSON-RPC and metrics bind to loopback. Consensus HTTP
+endpoints retain E2B traffic-token protection.
 
-The Geth sandboxes permit public proxy traffic only so their paired consensus
-sandboxes can reach port 8551, which remains protected by a random per-pair
-JWT. Geth JSON-RPC and metrics bind to loopback. Consensus HTTP endpoints retain
-E2B traffic-token protection.
+The included `e2b/testnet.yaml` launches a private, post-Fulu testnet with one
+Geth, one Lighthouse beacon node, and 64 Lighthouse validators:
 
-The adapter rejects unsupported client types, Docker image overrides,
-additional services, separate validator clients, and custom `kurtosis`
-networks instead of silently ignoring them. E2B's HTTPS proxy does not expose
-the TCP/UDP discovery ports or provide the genesis services needed for private
-devnets.
+```bash
+cd e2b
+npm run launch -- --config testnet.yaml --timeout 60
+```
+
+For `network: kurtosis`, the adapter supports `network_id`, `preset`,
+`seconds_per_slot`, `genesis_delay`, `genesis_time`,
+`num_validator_keys_per_node`, `preregistered_validator_count`, and
+`preregistered_validator_keys_mnemonic`. The launcher creates genesis and
+validator artifacts with the digest-pinned ethereum-genesis-generator, uploads
+the same artifacts to both client sandboxes, initializes Geth, and starts the
+configured validator client. The cross-sandbox Engine API uses E2B's HTTPS
+proxy and a random JWT; all other private-testnet APIs remain bound to loopback
+and are accessible through the E2B SDK.
+
+Private E2B devnets support exactly one EL-CL pair because E2B's HTTPS proxy
+does not expose the native TCP/UDP ports needed for multi-node Ethereum P2P.
+The adapter rejects unsupported root and `network_params` options, multi-pair
+private networks, public validator counts, unsupported client types, Docker
+image overrides, and additional services rather than silently ignoring them.
 
 ### Considerations for Running on a Public Testnet with a Cloud Provider
 

--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -4,6 +4,8 @@ ARG EL_CLIENT_URL=https://gethstore.blob.core.windows.net/builds/geth-linux-amd6
 ARG EL_CLIENT_SHA256=9113657e52d41879b8feaca8a4163d325ccce5b038aea59775a0bb3b26d2100a
 ARG CL_CLIENT_URL=https://github.com/sigp/lighthouse/releases/download/v8.2.1/lighthouse-v8.2.1-x86_64-unknown-linux-gnu.tar.gz
 ARG CL_CLIENT_SHA256=51754fc07e337a2ccbc9afa0037e268d4cf1b19fb69e9b2a272b5dd44a401496
+ARG PRYSM_URL=https://github.com/OffchainLabs/prysm/releases/download/v7.1.7/beacon-chain-v7.1.7-linux-amd64
+ARG PRYSM_SHA256=a30973627c52516c2fb044469875f99e53fa00bf4cfa2c2f71b655f2df6cf7e4
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -15,11 +17,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
  && curl -fsSL "$CL_CLIENT_URL" -o /tmp/lighthouse.tar.gz \
  && echo "$CL_CLIENT_SHA256  /tmp/lighthouse.tar.gz" | sha256sum -c - \
  && tar -xzf /tmp/lighthouse.tar.gz -C /usr/local/bin lighthouse \
- && rm -rf /tmp/geth* /tmp/lighthouse.tar.gz \
- && mkdir -p /home/user/ethereum/geth /home/user/ethereum/lighthouse \
+ && curl -fsSL "$PRYSM_URL" -o /tmp/beacon-chain \
+ && echo "$PRYSM_SHA256  /tmp/beacon-chain" | sha256sum -c - \
+ && install -m 0755 /tmp/beacon-chain /usr/local/bin/beacon-chain \
+ && rm -rf /tmp/geth* /tmp/lighthouse.tar.gz /tmp/beacon-chain \
+ && mkdir -p /home/user/ethereum/geth /home/user/ethereum/lighthouse /home/user/ethereum/prysm \
  && chown -R user:user /home/user/ethereum \
  && geth version \
- && lighthouse --version
+ && lighthouse --version \
+ && beacon-chain --version
 
 USER user
 WORKDIR /home/user

--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -1,4 +1,7 @@
-FROM e2bdev/code-interpreter:latest
+FROM e2bdev/code-interpreter@sha256:442ec598ec8ca4ed01b5bb24ad6e4f2e6ac80fd88f1564ff9a01e82da18e1e3b
+ARG CRANE_URL=https://github.com/google/go-containerregistry/releases/download/v0.20.6/go-containerregistry_Linux_x86_64.tar.gz
+ARG CRANE_SHA256=c1d593d01551f2c9a3df5ca0a0be4385a839bd9b86d4a76e18d7b17d16559127
+ARG GENESIS_GENERATOR_IMAGE=ethpandaops/ethereum-genesis-generator@sha256:e6c136de21d1502cacf14a56b4e47e82a8774ff7cec3de993439440a96a74cfd
 
 ARG EL_CLIENT_URL=https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.17.4-36a7dc72.tar.gz
 ARG EL_CLIENT_SHA256=9113657e52d41879b8feaca8a4163d325ccce5b038aea59775a0bb3b26d2100a
@@ -6,26 +9,46 @@ ARG CL_CLIENT_URL=https://github.com/sigp/lighthouse/releases/download/v8.2.1/li
 ARG CL_CLIENT_SHA256=51754fc07e337a2ccbc9afa0037e268d4cf1b19fb69e9b2a272b5dd44a401496
 ARG PRYSM_URL=https://github.com/OffchainLabs/prysm/releases/download/v7.1.7/beacon-chain-v7.1.7-linux-amd64
 ARG PRYSM_SHA256=a30973627c52516c2fb044469875f99e53fa00bf4cfa2c2f71b655f2df6cf7e4
+ARG PRYSM_VALIDATOR_URL=https://github.com/OffchainLabs/prysm/releases/download/v7.1.7/validator-v7.1.7-linux-amd64
+ARG PRYSM_VALIDATOR_SHA256=1c080dfb141fa7fee74c588c3158aa74682a860bf2dc9974f65994b1df6649f2
 
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bc ca-certificates curl gettext-base jq openssl wget yq \
  && rm -rf /var/lib/apt/lists/* \
- && curl -fsSL "$EL_CLIENT_URL" -o /tmp/geth.tar.gz \
- && echo "$EL_CLIENT_SHA256  /tmp/geth.tar.gz" | sha256sum -c - \
+ && download_verified() { curl -fsSL --connect-timeout 15 --max-time 600 --retry 5 --retry-all-errors --retry-delay 2 "$1" -o "$3" && echo "$2  $3" | sha256sum -c -; } \
+ && download_verified "$CRANE_URL" "$CRANE_SHA256" /tmp/crane.tar.gz \
+ && mkdir -p /tmp/crane /tmp/genesis-root /work \
+ && tar -xzf /tmp/crane.tar.gz -C /tmp/crane crane \
+ && timeout 600 /tmp/crane/crane export "$GENESIS_GENERATOR_IMAGE" /tmp/genesis-root.tar \
+ && tar -xf /tmp/genesis-root.tar -C /tmp/genesis-root \
+ && cp -a /tmp/genesis-root/apps /apps \
+ && cp -a /tmp/genesis-root/config /config \
+ && cp -a /tmp/genesis-root/defaults /defaults \
+ && cp -a /tmp/genesis-root/work/entrypoint.sh /work/entrypoint.sh \
+ && install -m 0755 /tmp/genesis-root/usr/local/bin/eth-genesis-state-generator /usr/local/bin/eth-genesis-state-generator \
+ && install -m 0755 /tmp/genesis-root/usr/local/bin/eth2-val-tools /usr/local/bin/eth2-val-tools \
+ && install -m 0755 /tmp/genesis-root/usr/local/bin/geth-hdwallet /usr/local/bin/geth-hdwallet \
+ && rm -rf /tmp/crane /tmp/crane.tar.gz /tmp/genesis-root /tmp/genesis-root.tar \
+ && download_verified "$EL_CLIENT_URL" "$EL_CLIENT_SHA256" /tmp/geth.tar.gz \
  && tar -xzf /tmp/geth.tar.gz -C /tmp \
  && install -m 0755 /tmp/geth-linux-amd64-1.17.4-36a7dc72/geth /usr/local/bin/geth \
- && curl -fsSL "$CL_CLIENT_URL" -o /tmp/lighthouse.tar.gz \
- && echo "$CL_CLIENT_SHA256  /tmp/lighthouse.tar.gz" | sha256sum -c - \
+ && download_verified "$CL_CLIENT_URL" "$CL_CLIENT_SHA256" /tmp/lighthouse.tar.gz \
  && tar -xzf /tmp/lighthouse.tar.gz -C /usr/local/bin lighthouse \
- && curl -fsSL "$PRYSM_URL" -o /tmp/beacon-chain \
- && echo "$PRYSM_SHA256  /tmp/beacon-chain" | sha256sum -c - \
+ && download_verified "$PRYSM_URL" "$PRYSM_SHA256" /tmp/beacon-chain \
  && install -m 0755 /tmp/beacon-chain /usr/local/bin/beacon-chain \
- && rm -rf /tmp/geth* /tmp/lighthouse.tar.gz /tmp/beacon-chain \
- && mkdir -p /home/user/ethereum/geth /home/user/ethereum/lighthouse /home/user/ethereum/prysm \
+ && download_verified "$PRYSM_VALIDATOR_URL" "$PRYSM_VALIDATOR_SHA256" /tmp/validator \
+ && install -m 0755 /tmp/validator /usr/local/bin/validator \
+ && rm -rf /tmp/geth* /tmp/lighthouse.tar.gz /tmp/beacon-chain /tmp/validator \
+ && mkdir -p /home/user/ethereum/geth /home/user/ethereum/lighthouse /home/user/ethereum/prysm /data /work \
  && chown -R user:user /home/user/ethereum \
  && geth version \
  && lighthouse --version \
  && beacon-chain --version
+
+RUN chown -R user:user /config /data /home/user /work \
+ && validator --version \
+ && eth2-val-tools --help >/dev/null
 
 USER user
 WORKDIR /home/user

--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -1,0 +1,25 @@
+FROM e2bdev/code-interpreter:latest
+
+ARG EL_CLIENT_URL=https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.17.4-36a7dc72.tar.gz
+ARG EL_CLIENT_SHA256=9113657e52d41879b8feaca8a4163d325ccce5b038aea59775a0bb3b26d2100a
+ARG CL_CLIENT_URL=https://github.com/sigp/lighthouse/releases/download/v8.2.1/lighthouse-v8.2.1-x86_64-unknown-linux-gnu.tar.gz
+ARG CL_CLIENT_SHA256=51754fc07e337a2ccbc9afa0037e268d4cf1b19fb69e9b2a272b5dd44a401496
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -fsSL "$EL_CLIENT_URL" -o /tmp/geth.tar.gz \
+ && echo "$EL_CLIENT_SHA256  /tmp/geth.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/geth.tar.gz -C /tmp \
+ && install -m 0755 /tmp/geth-linux-amd64-1.17.4-36a7dc72/geth /usr/local/bin/geth \
+ && curl -fsSL "$CL_CLIENT_URL" -o /tmp/lighthouse.tar.gz \
+ && echo "$CL_CLIENT_SHA256  /tmp/lighthouse.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/lighthouse.tar.gz -C /usr/local/bin lighthouse \
+ && rm -rf /tmp/geth* /tmp/lighthouse.tar.gz \
+ && mkdir -p /home/user/ethereum/geth /home/user/ethereum/lighthouse \
+ && chown -R user:user /home/user/ethereum \
+ && geth version \
+ && lighthouse --version
+
+USER user
+WORKDIR /home/user

--- a/e2b/package-lock.json
+++ b/e2b/package-lock.json
@@ -1,0 +1,2953 @@
+{
+  "name": "ethereum-package-e2b",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ethereum-package-e2b",
+      "dependencies": {
+        "e2b": "2.35.0"
+      },
+      "devDependencies": {
+        "@e2b/cli": "2.13.3",
+        "@types/node": "24.1.0",
+        "tsx": "4.20.3",
+        "typescript": "5.8.3"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@e2b/cli": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@e2b/cli/-/cli-2.13.3.tgz",
+      "integrity": "sha512-561oGnJqrh/zECKbBTLeqr8JtEfn5BVWTDTqxU/ojHPL5UksWQ6llpoJuXIWWqzQugOgOsWa3yP1qnLnQrwLaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@inquirer/prompts": "^7.9.0",
+        "@npmcli/package-json": "^5.2.1",
+        "async-listen": "^3.0.1",
+        "boxen": "^7.1.1",
+        "chalk": "^5.3.0",
+        "cli-highlight": "^2.1.11",
+        "commander": "^11.1.0",
+        "console-table-printer": "^2.11.2",
+        "e2b": "^2.33.1",
+        "handlebars": "^4.7.9",
+        "inquirer": "^12.10.0",
+        "simple-update-notifier": "^2.0.0",
+        "statuses": "^2.0.1",
+        "yup": "^1.3.2"
+      },
+      "bin": {
+        "e2b": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.18.1 <21 || >=22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
+      "integrity": "sha512-liASfw5cqhjNW9UFd+ruwwdEf/lbOAQjLL2XY2dFW/bkJheXDYZgOyul/4gVvEV4BWkTXjYGmDqMw9uegdbJNQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/promise-spawn": "^7.0.0",
+        "ini": "^4.1.3",
+        "lru-cache": "^10.0.1",
+        "npm-pick-manifest": "^9.0.0",
+        "proc-log": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.2.1.tgz",
+      "integrity": "sha512-f7zYC6kQautXHvNbLEWgD/uGu1+xCn9izgqBfgItWSx22U0ZDekxN08A1vM8cTxj/cRVe0Q94Ode+tdoYmIOOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^5.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^7.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^6.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@npmcli/package-json/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz",
+      "integrity": "sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-listen": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.1.0.tgz",
+      "integrity": "sha512-TkOhqze98lP+6e7SPbrBpyhTpfvqqX8VYKGn4uckrgPan4WQIHnTaUD2zZzZS18eVVDj4rHPcIZa1PGgvo1DfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
+      "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.1",
+        "chalk": "^5.2.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/console-table-printer": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.16.1.tgz",
+      "integrity": "sha512-Sc9FRJ4O9xKGNrvulNdPfK5SyBcZ6lcaRnDE4AQ/uw6IDtjHhsqyzzqcnMikjyGaiOOF2tNOKoBhbVjRvFy9Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.1.2"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.35.0.tgz",
+      "integrity": "sha512-ZOu2aNbnTtUcMBbLMB6houapLJxACco+PbmybzP42Id3H7ud8Z1HkQAVKj9nXwSH4g8llojwsRx6Ro6asQGJrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.1",
+        "@connectrpc/connect": "^2.1.2",
+        "@connectrpc/connect-web": "^2.1.2",
+        "chalk": "^5.3.0",
+        "compare-versions": "^6.1.0",
+        "dockerfile-ast": "^0.7.1",
+        "glob": "^11.1.0",
+        "openapi-fetch": "^0.14.1",
+        "platform": "^1.3.6",
+        "tar": "^7.5.16",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=20.18.1 <21 || >=22"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/inquirer": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@inquirer/type": "^3.0.10",
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-install-checks": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
+      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
+      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.1.0.tgz",
+      "integrity": "sha512-nkc+3pIIhqHVQr085X9d2JzPzLyjzQS96zbruppqC9aZRm/x8xx6xhI98gHtsfELP2bE+loHq8ZaHFHhe+NauA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    }
+  }
+}

--- a/e2b/package-lock.json
+++ b/e2b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "ethereum-package-e2b",
       "dependencies": {
-        "e2b": "2.35.0"
+        "e2b": "2.35.0",
+        "yaml": "2.8.1"
       },
       "devDependencies": {
         "@e2b/cli": "2.13.3",
@@ -2847,6 +2848,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {

--- a/e2b/package.json
+++ b/e2b/package.json
@@ -6,10 +6,11 @@
     "build": "tsc --noEmit",
     "test": "tsx --test test/*.test.ts",
     "launch": "tsx src/launch.ts",
-    "template:build": "e2b template create ethereum-lighthouse-geth -d e2b.Dockerfile --cpu-count 8 --memory-mb 8192"
+    "template:build": "e2b template create ethereum-client-topology -d e2b.Dockerfile --cpu-count 8 --memory-mb 8192"
   },
   "dependencies": {
-    "e2b": "2.35.0"
+    "e2b": "2.35.0",
+    "yaml": "2.8.1"
   },
   "devDependencies": {
     "@e2b/cli": "2.13.3",

--- a/e2b/package.json
+++ b/e2b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ethereum-package-e2b",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "tsx --test test/*.test.ts",
+    "launch": "tsx src/launch.ts",
+    "template:build": "e2b template create ethereum-lighthouse-geth -d e2b.Dockerfile --cpu-count 8 --memory-mb 8192"
+  },
+  "dependencies": {
+    "e2b": "2.35.0"
+  },
+  "devDependencies": {
+    "@e2b/cli": "2.13.3",
+    "@types/node": "24.1.0",
+    "tsx": "4.20.3",
+    "typescript": "5.8.3"
+  }
+}

--- a/e2b/src/config.ts
+++ b/e2b/src/config.ts
@@ -1,0 +1,104 @@
+export const networks = ["mainnet", "sepolia", "hoodi"] as const;
+export type Network = (typeof networks)[number];
+
+const defaultCheckpointUrls: Record<Network, string> = {
+  mainnet: "https://mainnet.checkpoint.sigp.io",
+  sepolia: "https://checkpoint-sync.sepolia.ethpandaops.io",
+  hoodi: "https://hoodi.checkpoint.sigp.io",
+};
+
+export interface LaunchOptions {
+  network: Network;
+  timeoutMinutes: number;
+  checkpointUrl?: string;
+}
+
+export function gethArgs(network: Network, jwtPath: string): string[] {
+  return [
+    "geth",
+    `--${network}`,
+    "--datadir=/home/user/ethereum/geth",
+    "--syncmode=snap",
+    "--http",
+    "--http.addr=127.0.0.1",
+    "--http.port=8545",
+    "--http.vhosts=*",
+    "--http.corsdomain=*",
+    "--http.api=eth,net,web3",
+    "--authrpc.addr=0.0.0.0",
+    "--authrpc.port=8551",
+    "--authrpc.vhosts=*",
+    `--authrpc.jwtsecret=${jwtPath}`,
+    "--metrics",
+    "--metrics.addr=127.0.0.1",
+    "--metrics.port=9001",
+  ];
+}
+
+export function lighthouseArgs(
+  network: Network,
+  jwtPath: string,
+  executionEndpoint: string,
+  checkpointUrl?: string,
+): string[] {
+  const args = [
+    "lighthouse",
+    "beacon_node",
+    `--network=${network}`,
+    "--datadir=/home/user/ethereum/lighthouse",
+    `--execution-endpoints=${executionEndpoint}`,
+    `--jwt-secrets=${jwtPath}`,
+    "--http",
+    "--http-address=0.0.0.0",
+    "--http-port=4000",
+    "--metrics",
+    "--metrics-address=0.0.0.0",
+    "--metrics-port=5054",
+    "--disable-enr-auto-update",
+  ];
+  if (checkpointUrl) {
+    args.push(`--checkpoint-sync-url=${checkpointUrl}`);
+  } else {
+    args.push("--allow-insecure-genesis-sync", "--ignore-ws-check");
+  }
+  return args;
+}
+
+export function parseOptions(args: string[]): LaunchOptions {
+  let network: Network = "hoodi";
+  let timeoutMinutes = 60;
+  let checkpointUrl: string | undefined;
+
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (!option || !value) {
+      throw new Error(`missing value for ${option ?? "option"}`);
+    }
+    if (option === "--network") {
+      if (!networks.includes(value as Network)) {
+        throw new Error(`network must be one of: ${networks.join(", ")}`);
+      }
+      network = value as Network;
+    } else if (option === "--timeout") {
+      timeoutMinutes = Number(value);
+      if (!Number.isInteger(timeoutMinutes) || timeoutMinutes < 5 || timeoutMinutes > 1440) {
+        throw new Error("timeout must be an integer from 5 to 1440 minutes");
+      }
+    } else if (option === "--checkpoint-url") {
+      const url = new URL(value);
+      if (url.protocol !== "https:" && url.protocol !== "http:") {
+        throw new Error("checkpoint URL must use HTTP or HTTPS");
+      }
+      checkpointUrl = url.toString().replace(/\/$/, "");
+    } else {
+      throw new Error(`unknown option: ${option}`);
+    }
+  }
+
+  return {
+    network,
+    timeoutMinutes,
+    checkpointUrl: checkpointUrl ?? defaultCheckpointUrls[network],
+  };
+}

--- a/e2b/src/config.ts
+++ b/e2b/src/config.ts
@@ -1,14 +1,15 @@
 export const networks = ["mainnet", "sepolia", "hoodi"] as const;
 export type Network = (typeof networks)[number];
 
-const defaultCheckpointUrls: Record<Network, string> = {
+export const defaultCheckpointUrls: Record<Network, string> = {
   mainnet: "https://mainnet.checkpoint.sigp.io",
   sepolia: "https://checkpoint-sync.sepolia.ethpandaops.io",
   hoodi: "https://hoodi.checkpoint.sigp.io",
 };
 
 export interface LaunchOptions {
-  network: Network;
+  network?: Network;
+  configPath?: string;
   timeoutMinutes: number;
   checkpointUrl?: string;
 }
@@ -63,9 +64,41 @@ export function lighthouseArgs(
   }
   return args;
 }
+export function prysmArgs(
+  network: Network,
+  jwtPath: string,
+  executionEndpoint: string,
+  checkpointUrl?: string,
+): string[] {
+  const args = [
+    "beacon-chain",
+    `--${network}`,
+    "--accept-terms-of-use=true",
+    "--datadir=/home/user/ethereum/prysm",
+    `--execution-endpoint=${executionEndpoint}`,
+    `--jwt-secret=${jwtPath}`,
+    "--http-host=0.0.0.0",
+    "--http-cors-domain=*",
+    "--http-port=3500",
+    "--rpc-host=127.0.0.1",
+    "--rpc-port=4000",
+    "--disable-monitoring=false",
+    "--monitoring-host=0.0.0.0",
+    "--monitoring-port=8080",
+  ];
+  if (checkpointUrl) {
+    args.push(
+      `--checkpoint-sync-url=${checkpointUrl}`,
+      `--genesis-beacon-api-url=${checkpointUrl}`,
+    );
+  }
+  return args;
+}
+
 
 export function parseOptions(args: string[]): LaunchOptions {
-  let network: Network = "hoodi";
+  let network: Network | undefined;
+  let configPath: string | undefined;
   let timeoutMinutes = 60;
   let checkpointUrl: string | undefined;
 
@@ -80,6 +113,8 @@ export function parseOptions(args: string[]): LaunchOptions {
         throw new Error(`network must be one of: ${networks.join(", ")}`);
       }
       network = value as Network;
+    } else if (option === "--config") {
+      configPath = value;
     } else if (option === "--timeout") {
       timeoutMinutes = Number(value);
       if (!Number.isInteger(timeoutMinutes) || timeoutMinutes < 5 || timeoutMinutes > 1440) {
@@ -96,9 +131,15 @@ export function parseOptions(args: string[]): LaunchOptions {
     }
   }
 
-  return {
-    network,
-    timeoutMinutes,
-    checkpointUrl: checkpointUrl ?? defaultCheckpointUrls[network],
-  };
+  const options: LaunchOptions = { timeoutMinutes };
+  if (network) {
+    options.network = network;
+    options.checkpointUrl = checkpointUrl ?? defaultCheckpointUrls[network];
+  } else if (checkpointUrl) {
+    options.checkpointUrl = checkpointUrl;
+  }
+  if (configPath) {
+    options.configPath = configPath;
+  }
+  return options;
 }

--- a/e2b/src/config.ts
+++ b/e2b/src/config.ts
@@ -1,7 +1,9 @@
-export const networks = ["mainnet", "sepolia", "hoodi"] as const;
+export const publicNetworks = ["mainnet", "sepolia", "hoodi"] as const;
+export const networks = [...publicNetworks, "kurtosis"] as const;
+export type PublicNetwork = (typeof publicNetworks)[number];
 export type Network = (typeof networks)[number];
 
-export const defaultCheckpointUrls: Record<Network, string> = {
+export const defaultCheckpointUrls: Record<PublicNetwork, string> = {
   mainnet: "https://mainnet.checkpoint.sigp.io",
   sepolia: "https://checkpoint-sync.sepolia.ethpandaops.io",
   hoodi: "https://hoodi.checkpoint.sigp.io",
@@ -14,7 +16,7 @@ export interface LaunchOptions {
   checkpointUrl?: string;
 }
 
-export function gethArgs(network: Network, jwtPath: string): string[] {
+export function gethArgs(network: PublicNetwork, jwtPath: string): string[] {
   return [
     "geth",
     `--${network}`,
@@ -37,7 +39,7 @@ export function gethArgs(network: Network, jwtPath: string): string[] {
 }
 
 export function lighthouseArgs(
-  network: Network,
+  network: PublicNetwork,
   jwtPath: string,
   executionEndpoint: string,
   checkpointUrl?: string,
@@ -65,7 +67,7 @@ export function lighthouseArgs(
   return args;
 }
 export function prysmArgs(
-  network: Network,
+  network: PublicNetwork,
   jwtPath: string,
   executionEndpoint: string,
   checkpointUrl?: string,
@@ -96,6 +98,16 @@ export function prysmArgs(
 }
 
 
+export function resolveCheckpointUrl(network: Network, checkpointUrl?: string): string | undefined {
+  if (network === "kurtosis") {
+    if (checkpointUrl) {
+      throw new Error("checkpoint URL is only valid for public networks");
+    }
+    return undefined;
+  }
+  return checkpointUrl ?? defaultCheckpointUrls[network];
+}
+
 export function parseOptions(args: string[]): LaunchOptions {
   let network: Network | undefined;
   let configPath: string | undefined;
@@ -122,8 +134,8 @@ export function parseOptions(args: string[]): LaunchOptions {
       }
     } else if (option === "--checkpoint-url") {
       const url = new URL(value);
-      if (url.protocol !== "https:" && url.protocol !== "http:") {
-        throw new Error("checkpoint URL must use HTTP or HTTPS");
+      if (url.protocol !== "https:") {
+        throw new Error("checkpoint URL must use HTTPS");
       }
       checkpointUrl = url.toString().replace(/\/$/, "");
     } else {
@@ -134,7 +146,10 @@ export function parseOptions(args: string[]): LaunchOptions {
   const options: LaunchOptions = { timeoutMinutes };
   if (network) {
     options.network = network;
-    options.checkpointUrl = checkpointUrl ?? defaultCheckpointUrls[network];
+    const resolvedCheckpointUrl = resolveCheckpointUrl(network, checkpointUrl);
+    if (resolvedCheckpointUrl) {
+      options.checkpointUrl = resolvedCheckpointUrl;
+    }
   } else if (checkpointUrl) {
     options.checkpointUrl = checkpointUrl;
   }

--- a/e2b/src/devnet.ts
+++ b/e2b/src/devnet.ts
@@ -1,0 +1,241 @@
+import { type Sandbox } from "e2b";
+
+import { type DevnetConfig, type NodePair, type Topology } from "./topology.js";
+
+export const devnetRoot = "/home/user/devnet";
+export const devnetGenesisPath = `${devnetRoot}/metadata/genesis.json`;
+
+const feeRecipient = "0x0000000000000000000000000000000000000000";
+
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function requireDevnet(topology: Topology): DevnetConfig {
+  if (!topology.devnet) {
+    throw new Error("private devnet configuration is missing");
+  }
+  return topology.devnet;
+}
+
+function genesisEnvironment(topology: Topology, genesisTimestamp: number): string {
+  const config = requireDevnet(topology);
+  const participantValidatorCount = topology.pairs.reduce(
+    (total, pair) => total + pair.validatorCount,
+    0,
+  );
+  const validatorCount =
+    config.preregisteredValidatorCount && config.preregisteredValidatorCount > 0
+      ? config.preregisteredValidatorCount
+      : participantValidatorCount;
+  return [
+    `export PRESET_BASE=${shellQuote(config.preset)}`,
+    `export CHAIN_ID=${shellQuote(config.networkId)}`,
+    `export EL_AND_CL_MNEMONIC=${shellQuote(config.mnemonic)}`,
+    `export NUMBER_OF_VALIDATORS=${validatorCount}`,
+    `export GENESIS_TIMESTAMP=${genesisTimestamp}`,
+    `export GENESIS_DELAY=0`,
+    `export SLOT_DURATION_IN_SECONDS=${config.secondsPerSlot}`,
+    `export SLOT_DURATION_MS=${config.secondsPerSlot * 1_000}`,
+    "export ALTAIR_FORK_EPOCH=0",
+    "export BELLATRIX_FORK_EPOCH=0",
+    "export CAPELLA_FORK_EPOCH=0",
+    "export DENEB_FORK_EPOCH=0",
+    "export ELECTRA_FORK_EPOCH=0",
+    "export FULU_FORK_EPOCH=0",
+    "export GLOAS_FORK_EPOCH=18446744073709551615",
+    "export HEZE_FORK_EPOCH=18446744073709551615",
+    "export WITHDRAWAL_TYPE=0x01",
+    `export WITHDRAWAL_ADDRESS=${feeRecipient}`,
+    "",
+  ].join("\n");
+}
+
+export function plannedGenesisTimestamp(topology: Topology): number {
+  const config = requireDevnet(topology);
+  if (config.genesisTime && config.genesisTime > 0) {
+    return config.genesisTime;
+  }
+  const startupAllowance = 60 + topology.pairs.length * 10;
+  return Math.floor(Date.now() / 1_000) + Math.max(config.genesisDelaySeconds, startupAllowance);
+}
+
+export async function generateDevnetArtifacts(
+  sandbox: Sandbox,
+  topology: Topology,
+  genesisTimestamp: number,
+): Promise<Uint8Array> {
+  const config = requireDevnet(topology);
+  await sandbox.files.write("/config/values.env", genesisEnvironment(topology, genesisTimestamp));
+  await sandbox.commands.run("rm -rf /data/* && /work/entrypoint.sh all", {
+    timeoutMs: 120_000,
+  });
+
+  let validatorIndex = 0;
+  const commands: string[] = ["mkdir -p /data/keystores"];
+  for (const pair of topology.pairs) {
+    const start = validatorIndex;
+    const stop = start + pair.validatorCount;
+    validatorIndex = stop;
+    if (pair.validatorCount === 0) {
+      continue;
+    }
+    commands.push(
+      [
+        "eth2-val-tools",
+        "keystores",
+        "--insecure",
+        "--prysm-pass",
+        "password",
+        "--out-loc",
+        `/data/keystores/${pair.id}`,
+        "--source-mnemonic",
+        config.mnemonic,
+        "--source-min",
+        String(start),
+        "--source-max",
+        String(stop),
+      ]
+        .map(shellQuote)
+        .join(" "),
+    );
+  }
+  commands.push(
+    "printf 'password\\n' > /data/prysm-password.txt",
+    "tar -C /data -czf /tmp/e2b-devnet.tar.gz metadata keystores prysm-password.txt",
+  );
+  await sandbox.commands.run(commands.join(" && "), { timeoutMs: 120_000 });
+  return sandbox.files.read("/tmp/e2b-devnet.tar.gz", { format: "bytes" });
+}
+
+export async function installDevnetArtifacts(
+  sandbox: Sandbox,
+  artifacts: Uint8Array,
+): Promise<void> {
+  const buffer =
+    artifacts.byteOffset === 0 && artifacts.byteLength === artifacts.buffer.byteLength
+      ? (artifacts.buffer as ArrayBuffer)
+      : artifacts.slice().buffer;
+  await sandbox.files.write("/tmp/e2b-devnet.tar.gz", buffer);
+  await sandbox.commands.run(
+    `rm -rf ${shellQuote(devnetRoot)} && mkdir -p ${shellQuote(devnetRoot)} && tar -C ${shellQuote(devnetRoot)} -xzf /tmp/e2b-devnet.tar.gz`,
+    { timeoutMs: 30_000 },
+  );
+}
+
+export function gethDevnetArgs(config: DevnetConfig, jwtPath: string): string[] {
+  return [
+    "geth",
+    `--override.genesis=${devnetGenesisPath}`,
+    `--networkid=${config.networkId}`,
+    "--datadir=/home/user/ethereum/geth",
+    "--syncmode=full",
+    "--nodiscover",
+    "--http",
+    "--http.addr=127.0.0.1",
+    "--http.port=8545",
+    "--http.vhosts=*",
+    "--http.corsdomain=*",
+    "--http.api=admin,eth,net,web3",
+    "--authrpc.addr=0.0.0.0",
+    "--authrpc.port=8551",
+    "--authrpc.vhosts=*",
+    `--authrpc.jwtsecret=${jwtPath}`,
+    "--rpc.allow-unprotected-txs",
+    "--miner.gasprice=1",
+    "--metrics",
+    "--metrics.addr=127.0.0.1",
+    "--metrics.port=9001",
+  ];
+}
+
+export function lighthouseDevnetArgs(
+  jwtPath: string,
+  executionEndpoint: string,
+): string[] {
+  return [
+    "lighthouse",
+    "beacon_node",
+    `--testnet-dir=${devnetRoot}/metadata`,
+    "--datadir=/home/user/ethereum/lighthouse",
+    `--execution-endpoints=${executionEndpoint}`,
+    `--jwt-secrets=${jwtPath}`,
+    "--suggested-fee-recipient=" + feeRecipient,
+    "--disable-discovery",
+    "--allow-insecure-genesis-sync",
+    "--http",
+    "--http-address=127.0.0.1",
+    "--http-port=4000",
+    "--metrics",
+    "--metrics-address=127.0.0.1",
+    "--metrics-port=5054",
+  ];
+}
+
+export function prysmDevnetArgs(
+  config: DevnetConfig,
+  jwtPath: string,
+  executionEndpoint: string,
+): string[] {
+  const args = [
+    "beacon-chain",
+    "--accept-terms-of-use=true",
+    "--datadir=/home/user/ethereum/prysm",
+    `--chain-config-file=${devnetRoot}/metadata/config.yaml`,
+    `--genesis-state=${devnetRoot}/metadata/genesis.ssz`,
+    "--contract-deployment-block=0",
+    `--execution-endpoint=${executionEndpoint}`,
+    `--jwt-secret=${jwtPath}`,
+    "--p2p-host-ip=127.0.0.1",
+    "--p2p-tcp-port=13000",
+    "--p2p-udp-port=12000",
+    "--p2p-quic-port=14000",
+    "--p2p-static-id=true",
+    "--min-sync-peers=0",
+    "--http-host=127.0.0.1",
+    "--http-cors-domain=*",
+    "--http-port=3500",
+    "--rpc-host=127.0.0.1",
+    "--rpc-port=4000",
+    "--disable-monitoring=false",
+    "--monitoring-host=127.0.0.1",
+    "--monitoring-port=8080",
+    "--suggested-fee-recipient=" + feeRecipient,
+  ];
+  if (config.preset === "minimal") {
+    args.push("--minimal-config=true");
+  }
+  return args;
+}
+
+export function validatorArgs(pair: NodePair, beaconApiUrl: string): string[] {
+  const keyRoot = `${devnetRoot}/keystores/${pair.id}`;
+  if (pair.vcType === "lighthouse") {
+    return [
+      "lighthouse",
+      "vc",
+      `--testnet-dir=${devnetRoot}/metadata`,
+      `--validators-dir=${keyRoot}/keys`,
+      `--secrets-dir=${keyRoot}/secrets`,
+      "--init-slashing-protection",
+      `--beacon-nodes=${beaconApiUrl}`,
+      "--suggested-fee-recipient=" + feeRecipient,
+      "--metrics",
+      "--metrics-address=127.0.0.1",
+      "--metrics-port=8081",
+    ];
+  }
+  return [
+    "validator",
+    "--accept-terms-of-use=true",
+    `--chain-config-file=${devnetRoot}/metadata/config.yaml`,
+    `--beacon-rest-api-provider=${beaconApiUrl}`,
+    "--enable-beacon-rest-api",
+    `--wallet-dir=${keyRoot}/prysm`,
+    `--wallet-password-file=${devnetRoot}/prysm-password.txt`,
+    "--suggested-fee-recipient=" + feeRecipient,
+    "--disable-monitoring=false",
+    "--monitoring-host=127.0.0.1",
+    "--monitoring-port=8081",
+  ];
+}

--- a/e2b/src/launch.ts
+++ b/e2b/src/launch.ts
@@ -1,0 +1,278 @@
+import { randomBytes } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { Sandbox, type CommandHandle } from "e2b";
+
+import { gethArgs, lighthouseArgs, parseOptions } from "./config.js";
+
+const template = process.env.E2B_TEMPLATE ?? "ethereum-lighthouse-geth";
+const jwtPath = "/home/user/ethereum/jwt.hex";
+
+type ClientRole = "geth" | "lighthouse";
+type InterruptSignal = "SIGINT" | "SIGTERM";
+
+interface ManagedSandbox {
+  role: ClientRole;
+  sandbox: Sandbox;
+  logPath: string;
+}
+
+function command(args: string[], logPath: string): string {
+  const quoted = args.map((arg) => `'${arg.replaceAll("'", `'\"'\"'`)}'`).join(" ");
+  return `${quoted} > '${logPath}' 2>&1`;
+}
+
+async function waitForHttp(sandbox: Sandbox, url: string, label: string): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  while (true) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+
+    try {
+      await sandbox.commands.run(`curl --fail --silent '${url}' >/dev/null`, {
+        timeoutMs: Math.min(5_000, remainingMs),
+      });
+      return;
+    } catch {
+      const updatedRemainingMs = deadline - Date.now();
+      if (updatedRemainingMs <= 0) {
+        break;
+      }
+      await delay(Math.min(2_000, updatedRemainingMs));
+    }
+  }
+  throw new Error(`${label} did not become ready within 120 seconds`);
+}
+
+function failWhenProcessExits(handle: CommandHandle, label: string): Promise<never> {
+  return handle.wait().then(
+    ({ exitCode }) => {
+      throw new Error(`${label} exited before startup completed (exit code ${exitCode})`);
+    },
+    (error: unknown) => {
+      const exitCode =
+        handle.exitCode === undefined ? "" : ` (exit code ${handle.exitCode})`;
+      throw new Error(`${label} exited before startup completed${exitCode}`, { cause: error });
+    },
+  );
+}
+
+function assertProcessRunning(handle: CommandHandle, label: string): void {
+  if (handle.exitCode !== undefined) {
+    throw new Error(
+      `${label} exited before startup completed (exit code ${handle.exitCode})`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const jwt = randomBytes(32).toString("hex");
+  const managedSandboxes: ManagedSandbox[] = [];
+  let cleanupPromise: Promise<void> | undefined;
+  let cleanupFailureReported = false;
+  let interruptedSignal: InterruptSignal | undefined;
+  const { promise: interruption, resolve: resolveInterruption } =
+    Promise.withResolvers<InterruptSignal>();
+
+  const cleanupSandboxes = (): Promise<void> => {
+    cleanupPromise ??= Promise.all(
+      managedSandboxes.map(async ({ role, sandbox }) => {
+        const killed = await Sandbox.kill(sandbox.sandboxId);
+        if (!killed) {
+          throw new Error(`${role} sandbox ${sandbox.sandboxId} was not running`);
+        }
+      }),
+    ).then(() => undefined);
+    return cleanupPromise;
+  };
+
+  const reportCleanupFailure = (context: string, cleanupError: unknown): void => {
+    if (cleanupFailureReported) {
+      return;
+    }
+    cleanupFailureReported = true;
+    const sandboxIds = managedSandboxes
+      .map(({ role, sandbox }) => `${role}=${sandbox.sandboxId}`)
+      .join(", ");
+    console.error(`Failed to clean up sandboxes (${sandboxIds}) ${context}:`, cleanupError);
+  };
+
+  function removeSignalHandlers(): void {
+    process.off("SIGINT", handleSigint);
+    process.off("SIGTERM", handleSigterm);
+  }
+  function throwIfInterrupted(): void {
+    if (interruptedSignal !== undefined) {
+      throw new Error(`Startup interrupted by ${interruptedSignal}`);
+    }
+  }
+
+  function failOnInterruption(): Promise<never> {
+    return interruption.then((signal) => {
+      throw new Error(`Startup interrupted by ${signal}`);
+    });
+  }
+
+
+  function handleSignal(signal: InterruptSignal): void {
+    if (interruptedSignal !== undefined) {
+      return;
+    }
+    interruptedSignal = signal;
+    resolveInterruption(signal);
+  }
+
+  function handleSigint(): void {
+    handleSignal("SIGINT");
+  }
+
+  function handleSigterm(): void {
+    handleSignal("SIGTERM");
+  }
+
+  process.once("SIGINT", handleSigint);
+  process.once("SIGTERM", handleSigterm);
+
+  try {
+    const gethSandbox = await Sandbox.create(template, {
+      timeoutMs: options.timeoutMinutes * 60_000,
+      allowInternetAccess: true,
+      network: { allowPublicTraffic: true },
+      metadata: {
+        application: "ethereum-package",
+        client: "geth",
+        network: options.network,
+      },
+    });
+    managedSandboxes.push({
+      role: "geth",
+      sandbox: gethSandbox,
+      logPath: "/home/user/geth.log",
+    });
+    throwIfInterrupted();
+
+    await gethSandbox.files.write(jwtPath, jwt);
+    throwIfInterrupted();
+    const gethHandle = await gethSandbox.commands.run(
+      command(gethArgs(options.network, jwtPath), "/home/user/geth.log"),
+      { background: true, timeoutMs: 0 },
+    );
+    const gethExit = failWhenProcessExits(gethHandle, "Geth");
+    await Promise.race([
+      waitForHttp(gethSandbox, "http://127.0.0.1:8545", "geth RPC"),
+      gethExit,
+      failOnInterruption(),
+    ]);
+
+    throwIfInterrupted();
+    const executionEndpoint = `https://${gethSandbox.getHost(8551)}`;
+    const lighthouseSandbox = await Sandbox.create(template, {
+      timeoutMs: options.timeoutMinutes * 60_000,
+      allowInternetAccess: true,
+      network: { allowPublicTraffic: false },
+      metadata: {
+        application: "ethereum-package",
+        client: "lighthouse",
+        network: options.network,
+      },
+    });
+    managedSandboxes.push({
+      role: "lighthouse",
+      sandbox: lighthouseSandbox,
+      logPath: "/home/user/lighthouse.log",
+    });
+    throwIfInterrupted();
+
+    await lighthouseSandbox.files.write(jwtPath, jwt);
+    throwIfInterrupted();
+    const lighthouseHandle = await lighthouseSandbox.commands.run(
+      command(
+        lighthouseArgs(
+          options.network,
+          jwtPath,
+          executionEndpoint,
+          options.checkpointUrl,
+        ),
+        "/home/user/lighthouse.log",
+      ),
+      { background: true, timeoutMs: 0 },
+    );
+    const lighthouseExit = failWhenProcessExits(lighthouseHandle, "Lighthouse");
+    await Promise.race([
+      waitForHttp(
+        lighthouseSandbox,
+        "http://127.0.0.1:4000/eth/v1/node/health",
+        "Lighthouse HTTP API",
+      ),
+      gethExit,
+      lighthouseExit,
+      failOnInterruption(),
+    ]);
+
+    throwIfInterrupted();
+    assertProcessRunning(gethHandle, "Geth");
+    assertProcessRunning(lighthouseHandle, "Lighthouse");
+    await Promise.all([gethHandle.disconnect(), lighthouseHandle.disconnect()]);
+    throwIfInterrupted();
+    removeSignalHandlers();
+
+    console.log(
+      JSON.stringify(
+        {
+          network: options.network,
+          configuredTimeoutMinutes: options.timeoutMinutes,
+          geth: {
+            sandboxId: gethSandbox.sandboxId,
+            rpcUrl: "http://127.0.0.1:8545",
+            access: "sandbox-local via the E2B SDK",
+            log: "/home/user/geth.log",
+          },
+          lighthouse: {
+            sandboxId: lighthouseSandbox.sandboxId,
+            trafficAccessToken: lighthouseSandbox.trafficAccessToken,
+            apiUrl: `https://${lighthouseSandbox.getHost(4000)}`,
+            metricsUrl: `https://${lighthouseSandbox.getHost(5054)}/metrics`,
+            log: "/home/user/lighthouse.log",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    removeSignalHandlers();
+    if (interruptedSignal !== undefined) {
+      try {
+        await cleanupSandboxes();
+      } catch (cleanupError) {
+        reportCleanupFailure(`after ${interruptedSignal}`, cleanupError);
+      }
+      process.exitCode = interruptedSignal === "SIGINT" ? 130 : 143;
+      return;
+    }
+
+    const logTails = await Promise.all(
+      managedSandboxes.map(async ({ role, sandbox, logPath }) => {
+        const log = await sandbox.commands
+          .run(`tail -c 4000 '${logPath}'`)
+          .then(({ stdout }) => stdout)
+          .catch(() => "");
+        return { role, log };
+      }),
+    );
+    try {
+      await cleanupSandboxes();
+    } catch (cleanupError) {
+      reportCleanupFailure("after startup failure", cleanupError);
+    }
+    for (const { role, log } of logTails) {
+      console.error(`${role} log:\n${log}`);
+    }
+    throw error;
+  }
+}
+
+await main();

--- a/e2b/src/launch.ts
+++ b/e2b/src/launch.ts
@@ -5,24 +5,37 @@ import { setTimeout as delay } from "node:timers/promises";
 import { Sandbox, type CommandHandle } from "e2b";
 
 import {
-  defaultCheckpointUrls,
+  resolveCheckpointUrl,
   gethArgs,
   lighthouseArgs,
   parseOptions,
   prysmArgs,
+  type PublicNetwork,
 } from "./config.js";
+import {
+  devnetGenesisPath,
+  generateDevnetArtifacts,
+  gethDevnetArgs,
+  installDevnetArtifacts,
+  lighthouseDevnetArgs,
+  plannedGenesisTimestamp,
+  prysmDevnetArgs,
+  shellQuote,
+  validatorArgs,
+} from "./devnet.js";
 import { parseTopology, type ConsensusClient, type NodePair } from "./topology.js";
 
 const template = process.env.E2B_TEMPLATE ?? "ethereum-client-topology";
 const jwtPath = "/home/user/ethereum/jwt.hex";
 
 type InterruptSignal = "SIGINT" | "SIGTERM";
-type ClientLayer = "el" | "cl";
+type ClientLayer = "el" | "cl" | "generator";
+type ClientName = "geth" | ConsensusClient | "genesis";
 
 interface ManagedSandbox {
   pairId: string;
   layer: ClientLayer;
-  client: "geth" | ConsensusClient;
+  client: ClientName;
   sandbox: Sandbox;
   logPath: string;
 }
@@ -34,36 +47,111 @@ interface PairRuntime {
   consensus?: ManagedSandbox;
   gethHandle?: CommandHandle;
   consensusHandle?: CommandHandle;
+  validatorHandle?: CommandHandle;
+  validatorLogPath?: string;
 }
 
 function command(args: string[], logPath: string): string {
-  const quoted = args.map((arg) => `'${arg.replaceAll("'", `'\"'\"'`)}'`).join(" ");
-  return `${quoted} > '${logPath}' 2>&1`;
+  return `${args.map(shellQuote).join(" ")} > ${shellQuote(logPath)} 2>&1`;
 }
 
-async function waitForHttp(sandbox: Sandbox, url: string, label: string): Promise<void> {
-  const deadline = Date.now() + 120_000;
-  while (true) {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      break;
-    }
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : new Error("startup readiness cancelled");
+}
 
+async function waitForCommand(
+  sandbox: Sandbox,
+  commandText: string,
+  label: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    throwIfAborted(signal);
+    const remainingMs = deadline - Date.now();
     try {
-      await sandbox.commands.run(`curl --fail --silent '${url}' >/dev/null`, {
+      await sandbox.commands.run(commandText, {
         timeoutMs: Math.min(5_000, remainingMs),
+        ...(signal ? { signal } : {}),
       });
       return;
     } catch {
-      const updatedRemainingMs = deadline - Date.now();
-      if (updatedRemainingMs <= 0) {
+      throwIfAborted(signal);
+      if (Date.now() >= deadline) {
         break;
       }
-      await delay(Math.min(2_000, updatedRemainingMs));
+      await delay(
+        Math.min(2_000, deadline - Date.now()),
+        undefined,
+        signal ? { signal } : undefined,
+      );
     }
   }
-  throw new Error(`${label} did not become ready within 120 seconds`);
+  throw new Error(`${label} did not become ready within ${timeoutMs / 1_000} seconds`);
 }
+
+function waitForHttp(
+  sandbox: Sandbox,
+  url: string,
+  label: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  return waitForCommand(
+    sandbox,
+    `curl --fail --silent ${shellQuote(url)} >/dev/null`,
+    label,
+    120_000,
+    signal,
+  );
+}
+
+function waitForConsensusExecution(
+  sandbox: Sandbox,
+  apiPort: number,
+  label: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  return waitForCommand(
+    sandbox,
+    `curl --fail --silent http://127.0.0.1:${apiPort}/eth/v1/node/syncing | jq --exit-status '.data.el_offline == false' >/dev/null`,
+    label,
+    120_000,
+    signal,
+  );
+}
+
+function waitForExecutionBlock(sandbox: Sandbox, signal?: AbortSignal): Promise<void> {
+  const payload = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "eth_blockNumber",
+    params: [],
+    id: 1,
+  });
+  return waitForCommand(
+    sandbox,
+    `curl --fail --silent -H 'Content-Type: application/json' --data ${shellQuote(payload)} http://127.0.0.1:8545 | jq --exit-status '.result != "0x0" and .result != null' >/dev/null`,
+    "private testnet execution block",
+    240_000,
+    signal,
+  );
+}
+
+async function raceStartup(
+  readiness: (signal: AbortSignal) => Promise<void>,
+  failures: Promise<never>[],
+): Promise<void> {
+  const controller = new AbortController();
+  try {
+    await Promise.race([readiness(controller.signal), ...failures]);
+  } finally {
+    controller.abort(new Error("startup readiness settled"));
+  }
+}
+
 
 function failWhenProcessExits(handle: CommandHandle, label: string): Promise<never> {
   return handle.wait().then(
@@ -71,8 +159,7 @@ function failWhenProcessExits(handle: CommandHandle, label: string): Promise<nev
       throw new Error(`${label} exited before startup completed (exit code ${exitCode})`);
     },
     (error: unknown) => {
-      const exitCode =
-        handle.exitCode === undefined ? "" : ` (exit code ${handle.exitCode})`;
+      const exitCode = handle.exitCode === undefined ? "" : ` (exit code ${handle.exitCode})`;
       throw new Error(`${label} exited before startup completed${exitCode}`, { cause: error });
     },
   );
@@ -95,6 +182,18 @@ async function settleAll(tasks: Promise<void>[], label: string): Promise<void> {
   }
 }
 
+function requireSandbox(
+  runtime: PairRuntime,
+  layer: "geth" | "consensus",
+): ManagedSandbox {
+  const managed = runtime[layer];
+  if (!managed) {
+    throw new Error(`${runtime.plan.id} has no ${layer} sandbox`);
+  }
+  return managed;
+}
+
+
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   const source = options.configPath ? await readFile(options.configPath, "utf8") : undefined;
@@ -104,7 +203,9 @@ async function main(): Promise<void> {
     : parseTopology(
         `network_params:\n  network: ${defaultNetwork}\nparticipants:\n  - el_type: geth\n    cl_type: lighthouse\n`,
       );
-  const checkpointUrl = options.checkpointUrl ?? defaultCheckpointUrls[topology.network];
+  const isDevnet = topology.network === "kurtosis";
+  const checkpointUrl = resolveCheckpointUrl(topology.network, options.checkpointUrl);
+  const launchId = `${Date.now().toString(36)}-${randomBytes(8).toString("hex")}`;
   const runtimes: PairRuntime[] = topology.pairs.map((plan) => ({
     plan,
     jwt: randomBytes(32).toString("hex"),
@@ -113,18 +214,72 @@ async function main(): Promise<void> {
   let cleanupPromise: Promise<void> | undefined;
   let cleanupFailureReported = false;
   let interruptedSignal: InterruptSignal | undefined;
+  let genesisTimestamp: number | undefined;
   const { promise: interruption, resolve: resolveInterruption } =
     Promise.withResolvers<InterruptSignal>();
 
-  const cleanupSandboxes = (): Promise<void> => {
-    cleanupPromise ??= Promise.all(
-      managedSandboxes.map(async ({ pairId, layer, sandbox }) => {
-        const killed = await Sandbox.kill(sandbox.sandboxId);
-        if (!killed) {
-          throw new Error(`${pairId} ${layer} sandbox ${sandbox.sandboxId} was not running`);
+  async function killSandbox(sandboxId: string): Promise<void> {
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        await Sandbox.kill(sandboxId);
+        return;
+      } catch (error) {
+        if (attempt === 3) {
+          throw error;
         }
-      }),
-    ).then(() => undefined);
+        await delay(attempt * 500);
+      }
+    }
+  }
+
+  async function discoverLaunchSandboxIds(): Promise<string[]> {
+    const paginator = Sandbox.list({
+      query: {
+        metadata: {
+          application: "ethereum-package",
+          launch_id: launchId,
+        },
+      },
+    });
+    const sandboxIds: string[] = [];
+    while (paginator.hasNext) {
+      const sandboxes = await paginator.nextItems();
+      sandboxIds.push(...sandboxes.map(({ sandboxId }) => sandboxId));
+    }
+    return sandboxIds;
+  }
+
+  const cleanupSandboxes = (): Promise<void> => {
+    cleanupPromise ??= (async () => {
+      const sandboxIds = new Set(
+        managedSandboxes.map(({ sandbox }) => sandbox.sandboxId),
+      );
+      let discovered = false;
+      let discoveryError: unknown;
+      for (let scan = 0; scan < 3; scan += 1) {
+        try {
+          for (const sandboxId of await discoverLaunchSandboxIds()) {
+            sandboxIds.add(sandboxId);
+          }
+          discovered = true;
+          discoveryError = undefined;
+        } catch (error) {
+          discoveryError = error;
+        }
+        await settleAll(
+          [...sandboxIds].map((sandboxId) => killSandbox(sandboxId)),
+          "sandbox cleanup",
+        );
+        if (scan < 2) {
+          await delay(1_000);
+        }
+      }
+      if (!discovered) {
+        throw new Error("could not reconcile launch sandboxes during cleanup", {
+          cause: discoveryError,
+        });
+      }
+    })();
     return cleanupPromise;
   };
 
@@ -173,9 +328,9 @@ async function main(): Promise<void> {
   }
 
   async function createSandbox(
-    runtime: PairRuntime,
+    pairId: string,
     layer: ClientLayer,
-    client: "geth" | ConsensusClient,
+    client: ClientName,
     allowPublicTraffic: boolean,
   ): Promise<ManagedSandbox> {
     const sandbox = await Sandbox.create(template, {
@@ -184,110 +339,239 @@ async function main(): Promise<void> {
       network: { allowPublicTraffic },
       metadata: {
         application: "ethereum-package",
+        launch_id: launchId,
         network: topology.network,
-        participant: runtime.plan.id,
+        participant: pairId,
         layer,
         client,
       },
     });
     const managed = {
-      pairId: runtime.plan.id,
+      pairId,
       layer,
       client,
       sandbox,
-      logPath: `/home/user/${runtime.plan.id}-${client}.log`,
+      logPath: `/home/user/${pairId}-${client}.log`,
     } satisfies ManagedSandbox;
     managedSandboxes.push(managed);
     return managed;
   }
 
-  process.once("SIGINT", handleSigint);
-  process.once("SIGTERM", handleSigterm);
+  async function releaseSandbox(managed: ManagedSandbox): Promise<void> {
+    await killSandbox(managed.sandbox.sandboxId);
+    const index = managedSandboxes.indexOf(managed);
+    if (index >= 0) {
+      managedSandboxes.splice(index, 1);
+    }
+  }
+
+  async function startConsensus(runtime: PairRuntime): Promise<void> {
+    const geth = requireSandbox(runtime, "geth");
+    const consensus = requireSandbox(runtime, "consensus");
+    const executionEndpoint = `https://${geth.sandbox.getHost(8551)}`;
+    const args = isDevnet
+      ? runtime.plan.clType === "lighthouse"
+        ? lighthouseDevnetArgs(jwtPath, executionEndpoint)
+        : prysmDevnetArgs(topology.devnet!, jwtPath, executionEndpoint)
+      : runtime.plan.clType === "lighthouse"
+        ? lighthouseArgs(
+            topology.network as PublicNetwork,
+            jwtPath,
+            executionEndpoint,
+            checkpointUrl,
+          )
+        : prysmArgs(
+            topology.network as PublicNetwork,
+            jwtPath,
+            executionEndpoint,
+            checkpointUrl,
+          );
+    const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
+    runtime.consensusHandle = await consensus.sandbox.commands.run(
+      command(args, consensus.logPath),
+      { background: true, timeoutMs: 0 },
+    );
+    await raceStartup(
+      (signal) =>
+        waitForConsensusExecution(
+          consensus.sandbox,
+          apiPort,
+          `${runtime.plan.id} ${runtime.plan.clType} execution connection`,
+          signal,
+        ),
+      [
+        failWhenProcessExits(runtime.gethHandle!, `${runtime.plan.id} Geth`),
+        failWhenProcessExits(
+          runtime.consensusHandle,
+          `${runtime.plan.id} ${runtime.plan.clType}`,
+        ),
+        failOnInterruption(),
+      ],
+    );
+  }
+
+  process.on("SIGINT", handleSigint);
+  process.on("SIGTERM", handleSigterm);
 
   try {
+    let devnetArtifacts: Uint8Array | undefined;
+    if (isDevnet) {
+      genesisTimestamp = plannedGenesisTimestamp(topology);
+      const generator = await createSandbox("devnet", "generator", "genesis", false);
+      try {
+        devnetArtifacts = await generateDevnetArtifacts(
+          generator.sandbox,
+          topology,
+          genesisTimestamp,
+        );
+      } finally {
+        await releaseSandbox(generator);
+      }
+      throwIfInterrupted();
+    }
+
+    await settleAll(
+      runtimes.flatMap((runtime) => [
+        (async () => {
+          runtime.geth = await createSandbox(
+            runtime.plan.id,
+            "el",
+            "geth",
+            true,
+          );
+        })(),
+        (async () => {
+          runtime.consensus = await createSandbox(
+            runtime.plan.id,
+            "cl",
+            runtime.plan.clType,
+            false,
+          );
+        })(),
+      ]),
+      "client sandbox creation",
+    );
+    throwIfInterrupted();
+
+
     await settleAll(
       runtimes.map(async (runtime) => {
-        runtime.geth = await createSandbox(runtime, "el", "geth", true);
+        const geth = requireSandbox(runtime, "geth");
+        const consensus = requireSandbox(runtime, "consensus");
+        await Promise.all([
+          geth.sandbox.files.write(jwtPath, runtime.jwt),
+          consensus.sandbox.files.write(jwtPath, runtime.jwt),
+          ...(devnetArtifacts
+            ? [
+                installDevnetArtifacts(geth.sandbox, devnetArtifacts),
+                installDevnetArtifacts(consensus.sandbox, devnetArtifacts),
+              ]
+            : []),
+        ]);
       }),
-      "execution sandbox creation",
+      "client configuration",
     );
     throwIfInterrupted();
 
     await settleAll(
       runtimes.map(async (runtime) => {
-        const geth = runtime.geth;
-        if (!geth) {
-          throw new Error(`${runtime.plan.id} has no execution sandbox`);
+        const geth = requireSandbox(runtime, "geth");
+        if (isDevnet) {
+          await geth.sandbox.commands.run(
+            `geth init --datadir=/home/user/ethereum/geth ${shellQuote(devnetGenesisPath)}`,
+            { timeoutMs: 30_000 },
+          );
         }
-        await geth.sandbox.files.write(jwtPath, runtime.jwt);
-        throwIfInterrupted();
-        runtime.gethHandle = await geth.sandbox.commands.run(
-          command(gethArgs(topology.network, jwtPath), geth.logPath),
-          { background: true, timeoutMs: 0 },
+        const args = isDevnet
+          ? gethDevnetArgs(topology.devnet!, jwtPath)
+          : gethArgs(topology.network as PublicNetwork, jwtPath);
+        runtime.gethHandle = await geth.sandbox.commands.run(command(args, geth.logPath), {
+          background: true,
+          timeoutMs: 0,
+        });
+        await raceStartup(
+          (signal) =>
+            waitForHttp(
+              geth.sandbox,
+              "http://127.0.0.1:8545",
+              `${runtime.plan.id} geth RPC`,
+              signal,
+            ),
+          [
+            failWhenProcessExits(runtime.gethHandle, `${runtime.plan.id} Geth`),
+            failOnInterruption(),
+          ],
         );
-        await Promise.race([
-          waitForHttp(
-            geth.sandbox,
-            "http://127.0.0.1:8545",
-            `${runtime.plan.id} geth RPC`,
-          ),
-          failWhenProcessExits(runtime.gethHandle, `${runtime.plan.id} Geth`),
-          failOnInterruption(),
-        ]);
       }),
       "execution client startup",
     );
     throwIfInterrupted();
 
-    await settleAll(
-      runtimes.map(async (runtime) => {
-        runtime.consensus = await createSandbox(
-          runtime,
-          "cl",
-          runtime.plan.clType,
-          false,
-        );
-      }),
-      "consensus sandbox creation",
-    );
+    await settleAll(runtimes.map((runtime) => startConsensus(runtime)), "consensus client startup");
     throwIfInterrupted();
 
-    await settleAll(
-      runtimes.map(async (runtime) => {
-        const geth = runtime.geth;
-        const consensus = runtime.consensus;
-        if (!geth || !consensus) {
-          throw new Error(`${runtime.plan.id} is missing a client sandbox`);
-        }
-        const executionEndpoint = `https://${geth.sandbox.getHost(8551)}`;
-        const args =
-          runtime.plan.clType === "lighthouse"
-            ? lighthouseArgs(topology.network, jwtPath, executionEndpoint, checkpointUrl)
-            : prysmArgs(topology.network, jwtPath, executionEndpoint, checkpointUrl);
-        const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
-        await consensus.sandbox.files.write(jwtPath, runtime.jwt);
-        throwIfInterrupted();
-        runtime.consensusHandle = await consensus.sandbox.commands.run(
-          command(args, consensus.logPath),
-          { background: true, timeoutMs: 0 },
-        );
-        await Promise.race([
-          waitForHttp(
-            consensus.sandbox,
-            `http://127.0.0.1:${apiPort}/eth/v1/node/health`,
-            `${runtime.plan.id} ${runtime.plan.clType} HTTP API`,
-          ),
-          failWhenProcessExits(runtime.gethHandle!, `${runtime.plan.id} Geth`),
-          failWhenProcessExits(
-            runtime.consensusHandle,
-            `${runtime.plan.id} ${runtime.plan.clType}`,
-          ),
+    if (isDevnet) {
+      await settleAll(
+        runtimes
+          .filter(({ plan }) => plan.validatorCount > 0)
+          .map(async (runtime) => {
+            const consensus = requireSandbox(runtime, "consensus");
+            const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
+            runtime.validatorLogPath = `/home/user/${runtime.plan.id}-${runtime.plan.vcType}-vc.log`;
+            runtime.validatorHandle = await consensus.sandbox.commands.run(
+              command(
+                validatorArgs(runtime.plan, `http://127.0.0.1:${apiPort}`),
+                runtime.validatorLogPath,
+              ),
+              { background: true, timeoutMs: 0 },
+            );
+            await raceStartup(
+              (signal) =>
+                waitForHttp(
+                  consensus.sandbox,
+                  "http://127.0.0.1:8081/metrics",
+                  `${runtime.plan.id} ${runtime.plan.vcType} validator metrics`,
+                  signal,
+                ),
+              [
+                failWhenProcessExits(runtime.gethHandle!, `${runtime.plan.id} Geth`),
+                failWhenProcessExits(
+                  runtime.consensusHandle!,
+                  `${runtime.plan.id} ${runtime.plan.clType}`,
+                ),
+                failWhenProcessExits(
+                  runtime.validatorHandle,
+                  `${runtime.plan.id} ${runtime.plan.vcType} validator`,
+                ),
+                failOnInterruption(),
+              ],
+            );
+          }),
+        "validator client startup",
+      );
+      await raceStartup(
+        (signal) =>
+          waitForExecutionBlock(requireSandbox(runtimes[0]!, "geth").sandbox, signal),
+        [
+          ...runtimes.flatMap((runtime) => [
+            failWhenProcessExits(runtime.gethHandle!, `${runtime.plan.id} Geth`),
+            failWhenProcessExits(
+              runtime.consensusHandle!,
+              `${runtime.plan.id} ${runtime.plan.clType}`,
+            ),
+            ...(runtime.validatorHandle
+              ? [
+                  failWhenProcessExits(
+                    runtime.validatorHandle,
+                    `${runtime.plan.id} ${runtime.plan.vcType} validator`,
+                  ),
+                ]
+              : []),
+          ]),
           failOnInterruption(),
-        ]);
-      }),
-      "consensus client startup",
-    );
-    throwIfInterrupted();
+        ],
+      );
+    }
 
     for (const runtime of runtimes) {
       assertProcessRunning(runtime.gethHandle, `${runtime.plan.id} Geth`);
@@ -295,11 +579,18 @@ async function main(): Promise<void> {
         runtime.consensusHandle,
         `${runtime.plan.id} ${runtime.plan.clType}`,
       );
+      if (runtime.plan.validatorCount > 0 && isDevnet) {
+        assertProcessRunning(
+          runtime.validatorHandle,
+          `${runtime.plan.id} ${runtime.plan.vcType} validator`,
+        );
+      }
     }
     await Promise.all(
       runtimes.flatMap((runtime) => [
         runtime.gethHandle!.disconnect(),
         runtime.consensusHandle!.disconnect(),
+        ...(runtime.validatorHandle ? [runtime.validatorHandle.disconnect()] : []),
       ]),
     );
     throwIfInterrupted();
@@ -312,9 +603,10 @@ async function main(): Promise<void> {
           configuredTimeoutMinutes: options.timeoutMinutes,
           participantCount: topology.pairs.length,
           sandboxCount: topology.sandboxCount,
+          ...(genesisTimestamp === undefined ? {} : { genesisTimestamp }),
           nodes: runtimes.map((runtime) => {
-            const geth = runtime.geth!;
-            const consensus = runtime.consensus!;
+            const geth = requireSandbox(runtime, "geth");
+            const consensus = requireSandbox(runtime, "consensus");
             const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
             const metricsPort = runtime.plan.clType === "lighthouse" ? 5054 : 8080;
             return {
@@ -331,11 +623,28 @@ async function main(): Promise<void> {
               consensus: {
                 client: runtime.plan.clType,
                 sandboxId: consensus.sandbox.sandboxId,
-                trafficAccessToken: consensus.sandbox.trafficAccessToken,
-                apiUrl: `https://${consensus.sandbox.getHost(apiPort)}`,
-                metricsUrl: `https://${consensus.sandbox.getHost(metricsPort)}/metrics`,
+                ...(isDevnet
+                  ? {
+                      apiUrl: `http://127.0.0.1:${apiPort}`,
+                      metricsUrl: `http://127.0.0.1:${metricsPort}/metrics`,
+                      access: "sandbox-local via the E2B SDK",
+                    }
+                  : {
+                      trafficAccessToken: consensus.sandbox.trafficAccessToken,
+                      apiUrl: `https://${consensus.sandbox.getHost(apiPort)}`,
+                      metricsUrl: `https://${consensus.sandbox.getHost(metricsPort)}/metrics`,
+                    }),
                 log: consensus.logPath,
               },
+              ...(runtime.validatorHandle
+                ? {
+                    validator: {
+                      client: runtime.plan.vcType,
+                      count: runtime.plan.validatorCount,
+                      log: runtime.validatorLogPath,
+                    },
+                  }
+                : {}),
             };
           }),
         },
@@ -344,35 +653,42 @@ async function main(): Promise<void> {
       ),
     );
   } catch (error) {
-    removeSignalHandlers();
-    if (interruptedSignal !== undefined) {
+    try {
+      if (interruptedSignal !== undefined) {
+        try {
+          await cleanupSandboxes();
+        } catch (cleanupError) {
+          reportCleanupFailure(`after ${interruptedSignal}`, cleanupError);
+        }
+        process.exitCode = interruptedSignal === "SIGINT" ? 130 : 143;
+        return;
+      }
+
+      const logTails = await Promise.all(
+        managedSandboxes.map(async ({ pairId, client, sandbox, logPath }) => {
+          const log = await sandbox.commands
+            .run(`tail -c 4000 ${shellQuote(logPath)}`)
+            .then(({ stdout }) => stdout)
+            .catch(() => "");
+          return { label: `${pairId} ${client}`, log };
+        }),
+      );
       try {
         await cleanupSandboxes();
       } catch (cleanupError) {
-        reportCleanupFailure(`after ${interruptedSignal}`, cleanupError);
+        reportCleanupFailure("after startup failure", cleanupError);
       }
-      process.exitCode = interruptedSignal === "SIGINT" ? 130 : 143;
-      return;
+      if (interruptedSignal !== undefined) {
+        process.exitCode = interruptedSignal === "SIGINT" ? 130 : 143;
+        return;
+      }
+      for (const { label, log } of logTails) {
+        console.error(`${label} log:\n${log}`);
+      }
+      throw error;
+    } finally {
+      removeSignalHandlers();
     }
-
-    const logTails = await Promise.all(
-      managedSandboxes.map(async ({ pairId, client, sandbox, logPath }) => {
-        const log = await sandbox.commands
-          .run(`tail -c 4000 '${logPath}'`)
-          .then(({ stdout }) => stdout)
-          .catch(() => "");
-        return { label: `${pairId} ${client}`, log };
-      }),
-    );
-    try {
-      await cleanupSandboxes();
-    } catch (cleanupError) {
-      reportCleanupFailure("after startup failure", cleanupError);
-    }
-    for (const { label, log } of logTails) {
-      console.error(`${label} log:\n${log}`);
-    }
-    throw error;
   }
 }
 

--- a/e2b/src/launch.ts
+++ b/e2b/src/launch.ts
@@ -1,20 +1,39 @@
 import { randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { Sandbox, type CommandHandle } from "e2b";
 
-import { gethArgs, lighthouseArgs, parseOptions } from "./config.js";
+import {
+  defaultCheckpointUrls,
+  gethArgs,
+  lighthouseArgs,
+  parseOptions,
+  prysmArgs,
+} from "./config.js";
+import { parseTopology, type ConsensusClient, type NodePair } from "./topology.js";
 
-const template = process.env.E2B_TEMPLATE ?? "ethereum-lighthouse-geth";
+const template = process.env.E2B_TEMPLATE ?? "ethereum-client-topology";
 const jwtPath = "/home/user/ethereum/jwt.hex";
 
-type ClientRole = "geth" | "lighthouse";
 type InterruptSignal = "SIGINT" | "SIGTERM";
+type ClientLayer = "el" | "cl";
 
 interface ManagedSandbox {
-  role: ClientRole;
+  pairId: string;
+  layer: ClientLayer;
+  client: "geth" | ConsensusClient;
   sandbox: Sandbox;
   logPath: string;
+}
+
+interface PairRuntime {
+  plan: NodePair;
+  jwt: string;
+  geth?: ManagedSandbox;
+  consensus?: ManagedSandbox;
+  gethHandle?: CommandHandle;
+  consensusHandle?: CommandHandle;
 }
 
 function command(args: string[], logPath: string): string {
@@ -59,17 +78,37 @@ function failWhenProcessExits(handle: CommandHandle, label: string): Promise<nev
   );
 }
 
-function assertProcessRunning(handle: CommandHandle, label: string): void {
-  if (handle.exitCode !== undefined) {
-    throw new Error(
-      `${label} exited before startup completed (exit code ${handle.exitCode})`,
-    );
+function assertProcessRunning(handle: CommandHandle | undefined, label: string): void {
+  if (!handle || handle.exitCode !== undefined) {
+    const exitCode = handle?.exitCode === undefined ? "" : ` (exit code ${handle.exitCode})`;
+    throw new Error(`${label} exited before startup completed${exitCode}`);
+  }
+}
+
+async function settleAll(tasks: Promise<void>[], label: string): Promise<void> {
+  const results = await Promise.allSettled(tasks);
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map(({ reason }) => reason);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${label} failed`);
   }
 }
 
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
-  const jwt = randomBytes(32).toString("hex");
+  const source = options.configPath ? await readFile(options.configPath, "utf8") : undefined;
+  const defaultNetwork = options.network ?? "hoodi";
+  const topology = source
+    ? parseTopology(source, options.network)
+    : parseTopology(
+        `network_params:\n  network: ${defaultNetwork}\nparticipants:\n  - el_type: geth\n    cl_type: lighthouse\n`,
+      );
+  const checkpointUrl = options.checkpointUrl ?? defaultCheckpointUrls[topology.network];
+  const runtimes: PairRuntime[] = topology.pairs.map((plan) => ({
+    plan,
+    jwt: randomBytes(32).toString("hex"),
+  }));
   const managedSandboxes: ManagedSandbox[] = [];
   let cleanupPromise: Promise<void> | undefined;
   let cleanupFailureReported = false;
@@ -79,10 +118,10 @@ async function main(): Promise<void> {
 
   const cleanupSandboxes = (): Promise<void> => {
     cleanupPromise ??= Promise.all(
-      managedSandboxes.map(async ({ role, sandbox }) => {
+      managedSandboxes.map(async ({ pairId, layer, sandbox }) => {
         const killed = await Sandbox.kill(sandbox.sandboxId);
         if (!killed) {
-          throw new Error(`${role} sandbox ${sandbox.sandboxId} was not running`);
+          throw new Error(`${pairId} ${layer} sandbox ${sandbox.sandboxId} was not running`);
         }
       }),
     ).then(() => undefined);
@@ -95,7 +134,7 @@ async function main(): Promise<void> {
     }
     cleanupFailureReported = true;
     const sandboxIds = managedSandboxes
-      .map(({ role, sandbox }) => `${role}=${sandbox.sandboxId}`)
+      .map(({ pairId, layer, sandbox }) => `${pairId}/${layer}=${sandbox.sandboxId}`)
       .join(", ");
     console.error(`Failed to clean up sandboxes (${sandboxIds}) ${context}:`, cleanupError);
   };
@@ -104,6 +143,7 @@ async function main(): Promise<void> {
     process.off("SIGINT", handleSigint);
     process.off("SIGTERM", handleSigterm);
   }
+
   function throwIfInterrupted(): void {
     if (interruptedSignal !== undefined) {
       throw new Error(`Startup interrupted by ${interruptedSignal}`);
@@ -115,7 +155,6 @@ async function main(): Promise<void> {
       throw new Error(`Startup interrupted by ${signal}`);
     });
   }
-
 
   function handleSignal(signal: InterruptSignal): void {
     if (interruptedSignal !== undefined) {
@@ -133,110 +172,172 @@ async function main(): Promise<void> {
     handleSignal("SIGTERM");
   }
 
+  async function createSandbox(
+    runtime: PairRuntime,
+    layer: ClientLayer,
+    client: "geth" | ConsensusClient,
+    allowPublicTraffic: boolean,
+  ): Promise<ManagedSandbox> {
+    const sandbox = await Sandbox.create(template, {
+      timeoutMs: options.timeoutMinutes * 60_000,
+      allowInternetAccess: true,
+      network: { allowPublicTraffic },
+      metadata: {
+        application: "ethereum-package",
+        network: topology.network,
+        participant: runtime.plan.id,
+        layer,
+        client,
+      },
+    });
+    const managed = {
+      pairId: runtime.plan.id,
+      layer,
+      client,
+      sandbox,
+      logPath: `/home/user/${runtime.plan.id}-${client}.log`,
+    } satisfies ManagedSandbox;
+    managedSandboxes.push(managed);
+    return managed;
+  }
+
   process.once("SIGINT", handleSigint);
   process.once("SIGTERM", handleSigterm);
 
   try {
-    const gethSandbox = await Sandbox.create(template, {
-      timeoutMs: options.timeoutMinutes * 60_000,
-      allowInternetAccess: true,
-      network: { allowPublicTraffic: true },
-      metadata: {
-        application: "ethereum-package",
-        client: "geth",
-        network: options.network,
-      },
-    });
-    managedSandboxes.push({
-      role: "geth",
-      sandbox: gethSandbox,
-      logPath: "/home/user/geth.log",
-    });
-    throwIfInterrupted();
-
-    await gethSandbox.files.write(jwtPath, jwt);
-    throwIfInterrupted();
-    const gethHandle = await gethSandbox.commands.run(
-      command(gethArgs(options.network, jwtPath), "/home/user/geth.log"),
-      { background: true, timeoutMs: 0 },
+    await settleAll(
+      runtimes.map(async (runtime) => {
+        runtime.geth = await createSandbox(runtime, "el", "geth", true);
+      }),
+      "execution sandbox creation",
     );
-    const gethExit = failWhenProcessExits(gethHandle, "Geth");
-    await Promise.race([
-      waitForHttp(gethSandbox, "http://127.0.0.1:8545", "geth RPC"),
-      gethExit,
-      failOnInterruption(),
-    ]);
-
-    throwIfInterrupted();
-    const executionEndpoint = `https://${gethSandbox.getHost(8551)}`;
-    const lighthouseSandbox = await Sandbox.create(template, {
-      timeoutMs: options.timeoutMinutes * 60_000,
-      allowInternetAccess: true,
-      network: { allowPublicTraffic: false },
-      metadata: {
-        application: "ethereum-package",
-        client: "lighthouse",
-        network: options.network,
-      },
-    });
-    managedSandboxes.push({
-      role: "lighthouse",
-      sandbox: lighthouseSandbox,
-      logPath: "/home/user/lighthouse.log",
-    });
     throwIfInterrupted();
 
-    await lighthouseSandbox.files.write(jwtPath, jwt);
-    throwIfInterrupted();
-    const lighthouseHandle = await lighthouseSandbox.commands.run(
-      command(
-        lighthouseArgs(
-          options.network,
-          jwtPath,
-          executionEndpoint,
-          options.checkpointUrl,
-        ),
-        "/home/user/lighthouse.log",
-      ),
-      { background: true, timeoutMs: 0 },
+    await settleAll(
+      runtimes.map(async (runtime) => {
+        const geth = runtime.geth;
+        if (!geth) {
+          throw new Error(`${runtime.plan.id} has no execution sandbox`);
+        }
+        await geth.sandbox.files.write(jwtPath, runtime.jwt);
+        throwIfInterrupted();
+        runtime.gethHandle = await geth.sandbox.commands.run(
+          command(gethArgs(topology.network, jwtPath), geth.logPath),
+          { background: true, timeoutMs: 0 },
+        );
+        await Promise.race([
+          waitForHttp(
+            geth.sandbox,
+            "http://127.0.0.1:8545",
+            `${runtime.plan.id} geth RPC`,
+          ),
+          failWhenProcessExits(runtime.gethHandle, `${runtime.plan.id} Geth`),
+          failOnInterruption(),
+        ]);
+      }),
+      "execution client startup",
     );
-    const lighthouseExit = failWhenProcessExits(lighthouseHandle, "Lighthouse");
-    await Promise.race([
-      waitForHttp(
-        lighthouseSandbox,
-        "http://127.0.0.1:4000/eth/v1/node/health",
-        "Lighthouse HTTP API",
-      ),
-      gethExit,
-      lighthouseExit,
-      failOnInterruption(),
-    ]);
-
     throwIfInterrupted();
-    assertProcessRunning(gethHandle, "Geth");
-    assertProcessRunning(lighthouseHandle, "Lighthouse");
-    await Promise.all([gethHandle.disconnect(), lighthouseHandle.disconnect()]);
+
+    await settleAll(
+      runtimes.map(async (runtime) => {
+        runtime.consensus = await createSandbox(
+          runtime,
+          "cl",
+          runtime.plan.clType,
+          false,
+        );
+      }),
+      "consensus sandbox creation",
+    );
+    throwIfInterrupted();
+
+    await settleAll(
+      runtimes.map(async (runtime) => {
+        const geth = runtime.geth;
+        const consensus = runtime.consensus;
+        if (!geth || !consensus) {
+          throw new Error(`${runtime.plan.id} is missing a client sandbox`);
+        }
+        const executionEndpoint = `https://${geth.sandbox.getHost(8551)}`;
+        const args =
+          runtime.plan.clType === "lighthouse"
+            ? lighthouseArgs(topology.network, jwtPath, executionEndpoint, checkpointUrl)
+            : prysmArgs(topology.network, jwtPath, executionEndpoint, checkpointUrl);
+        const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
+        await consensus.sandbox.files.write(jwtPath, runtime.jwt);
+        throwIfInterrupted();
+        runtime.consensusHandle = await consensus.sandbox.commands.run(
+          command(args, consensus.logPath),
+          { background: true, timeoutMs: 0 },
+        );
+        await Promise.race([
+          waitForHttp(
+            consensus.sandbox,
+            `http://127.0.0.1:${apiPort}/eth/v1/node/health`,
+            `${runtime.plan.id} ${runtime.plan.clType} HTTP API`,
+          ),
+          failWhenProcessExits(runtime.gethHandle!, `${runtime.plan.id} Geth`),
+          failWhenProcessExits(
+            runtime.consensusHandle,
+            `${runtime.plan.id} ${runtime.plan.clType}`,
+          ),
+          failOnInterruption(),
+        ]);
+      }),
+      "consensus client startup",
+    );
+    throwIfInterrupted();
+
+    for (const runtime of runtimes) {
+      assertProcessRunning(runtime.gethHandle, `${runtime.plan.id} Geth`);
+      assertProcessRunning(
+        runtime.consensusHandle,
+        `${runtime.plan.id} ${runtime.plan.clType}`,
+      );
+    }
+    await Promise.all(
+      runtimes.flatMap((runtime) => [
+        runtime.gethHandle!.disconnect(),
+        runtime.consensusHandle!.disconnect(),
+      ]),
+    );
     throwIfInterrupted();
     removeSignalHandlers();
 
     console.log(
       JSON.stringify(
         {
-          network: options.network,
+          network: topology.network,
           configuredTimeoutMinutes: options.timeoutMinutes,
-          geth: {
-            sandboxId: gethSandbox.sandboxId,
-            rpcUrl: "http://127.0.0.1:8545",
-            access: "sandbox-local via the E2B SDK",
-            log: "/home/user/geth.log",
-          },
-          lighthouse: {
-            sandboxId: lighthouseSandbox.sandboxId,
-            trafficAccessToken: lighthouseSandbox.trafficAccessToken,
-            apiUrl: `https://${lighthouseSandbox.getHost(4000)}`,
-            metricsUrl: `https://${lighthouseSandbox.getHost(5054)}/metrics`,
-            log: "/home/user/lighthouse.log",
-          },
+          participantCount: topology.pairs.length,
+          sandboxCount: topology.sandboxCount,
+          nodes: runtimes.map((runtime) => {
+            const geth = runtime.geth!;
+            const consensus = runtime.consensus!;
+            const apiPort = runtime.plan.clType === "lighthouse" ? 4000 : 3500;
+            const metricsPort = runtime.plan.clType === "lighthouse" ? 5054 : 8080;
+            return {
+              id: runtime.plan.id,
+              participantIndex: runtime.plan.participantIndex,
+              instance: runtime.plan.instance,
+              execution: {
+                client: "geth",
+                sandboxId: geth.sandbox.sandboxId,
+                rpcUrl: "http://127.0.0.1:8545",
+                access: "sandbox-local via the E2B SDK",
+                log: geth.logPath,
+              },
+              consensus: {
+                client: runtime.plan.clType,
+                sandboxId: consensus.sandbox.sandboxId,
+                trafficAccessToken: consensus.sandbox.trafficAccessToken,
+                apiUrl: `https://${consensus.sandbox.getHost(apiPort)}`,
+                metricsUrl: `https://${consensus.sandbox.getHost(metricsPort)}/metrics`,
+                log: consensus.logPath,
+              },
+            };
+          }),
         },
         null,
         2,
@@ -255,12 +356,12 @@ async function main(): Promise<void> {
     }
 
     const logTails = await Promise.all(
-      managedSandboxes.map(async ({ role, sandbox, logPath }) => {
+      managedSandboxes.map(async ({ pairId, client, sandbox, logPath }) => {
         const log = await sandbox.commands
           .run(`tail -c 4000 '${logPath}'`)
           .then(({ stdout }) => stdout)
           .catch(() => "");
-        return { role, log };
+        return { label: `${pairId} ${client}`, log };
       }),
     );
     try {
@@ -268,8 +369,8 @@ async function main(): Promise<void> {
     } catch (cleanupError) {
       reportCleanupFailure("after startup failure", cleanupError);
     }
-    for (const { role, log } of logTails) {
-      console.error(`${role} log:\n${log}`);
+    for (const { label, log } of logTails) {
+      console.error(`${label} log:\n${log}`);
     }
     throw error;
   }

--- a/e2b/src/topology.ts
+++ b/e2b/src/topology.ts
@@ -4,6 +4,7 @@ import { networks, type Network } from "./config.js";
 
 export type ExecutionClient = "geth";
 export type ConsensusClient = "lighthouse" | "prysm";
+export type ValidatorClient = ConsensusClient;
 
 export interface NodePair {
   id: string;
@@ -11,17 +12,32 @@ export interface NodePair {
   instance: number;
   elType: ExecutionClient;
   clType: ConsensusClient;
+  vcType: ValidatorClient;
+  validatorCount: number;
+}
+
+export interface DevnetConfig {
+  networkId: string;
+  preset: "mainnet" | "minimal";
+  secondsPerSlot: number;
+  genesisDelaySeconds: number;
+  genesisTime?: number;
+  preregisteredValidatorCount?: number;
+  mnemonic: string;
 }
 
 export interface Topology {
   network: Network;
   pairs: NodePair[];
   sandboxCount: number;
+  devnet?: DevnetConfig;
 }
 
 interface ParticipantInput {
   el_type?: unknown;
   cl_type?: unknown;
+  vc_type?: unknown;
+  validator_count?: unknown;
   count?: unknown;
   [key: string]: unknown;
 }
@@ -43,6 +59,8 @@ interface ConfigInput {
 const participantKeys: Record<string, true> = {
   el_type: true,
   cl_type: true,
+  vc_type: true,
+  validator_count: true,
   count: true,
 };
 const matrixKeys: Record<string, true> = { el: true, cl: true, count: true };
@@ -52,50 +70,20 @@ const rootKeys: Record<string, true> = {
   participants: true,
   participants_matrix: true,
   network_params: true,
-  port_publisher: true,
   additional_services: true,
-  extra_files: true,
-  blockscout_params: true,
-  dora_params: true,
-  checkpointz_params: true,
-  docker_cache_params: true,
-  tx_fuzz_params: true,
-  rakoon_params: true,
-  custom_flood_params: true,
-  prometheus_params: true,
-  grafana_params: true,
-  tempo_params: true,
-  assertoor_params: true,
-  mev_params: true,
-  xatu_sentry_params: true,
-  snooper_params: true,
-  spamoor_params: true,
-  disruptoor_params: true,
-  slashoor_params: true,
-  mempool_bridge_params: true,
-  ethereum_genesis_generator_params: true,
-  bootnodoor_params: true,
-  zkboost_params: true,
-  buildoor_params: true,
-  trueblocks_params: true,
-  wait_for_finalization: true,
-  global_log_level: true,
-  snooper_enabled: true,
-  ethereum_metrics_exporter_enabled: true,
-  parallel_keystore_generation: true,
-  disable_peer_scoring: true,
-  persistent: true,
-  mev_type: true,
-  xatu_sentry_enabled: true,
-  apache_port: true,
-  nginx_port: true,
-  global_tolerations: true,
-  global_node_selectors: true,
-  use_remote_signer: true,
-  keymanager_enabled: true,
-  checkpoint_sync_enabled: true,
-  checkpoint_sync_url: true,
 };
+const devnetNetworkParameterKeys: Record<string, true> = {
+  network: true,
+  network_id: true,
+  preset: true,
+  seconds_per_slot: true,
+  genesis_delay: true,
+  genesis_time: true,
+  num_validator_keys_per_node: true,
+  preregistered_validator_count: true,
+  preregistered_validator_keys_mnemonic: true,
+};
+const publicNetworkParameterKeys: Record<string, true> = { network: true };
 const maxPairs = 32;
 
 function asRecord(value: unknown, label: string): Record<string, unknown> {
@@ -135,26 +123,37 @@ function parseParticipant(
   input: ParticipantInput,
   participantIndex: number,
   instance: number,
+  defaultValidatorCount: number,
 ): NodePair {
   rejectUnknownKeys(input, participantKeys, `participant ${participantIndex}`);
   const elType = input.el_type ?? "geth";
   const clType = input.cl_type ?? "lighthouse";
+  const vcType = input.vc_type ?? clType;
   if (elType !== "geth") {
     throw new Error(`unsupported EL client in participant ${participantIndex}: ${String(elType)}`);
   }
   if (clType !== "lighthouse" && clType !== "prysm") {
     throw new Error(`unsupported CL client in participant ${participantIndex}: ${String(clType)}`);
   }
+  if (vcType !== "lighthouse" && vcType !== "prysm") {
+    throw new Error(`unsupported VC client in participant ${participantIndex}: ${String(vcType)}`);
+  }
+  const validatorCount =
+    input.validator_count == null
+      ? defaultValidatorCount
+      : countOf(input.validator_count, `participant ${participantIndex}.validator_count`);
   return {
     id: `participant-${participantIndex}-${instance}`,
     participantIndex,
     instance,
     elType,
     clType,
+    vcType,
+    validatorCount,
   };
 }
 
-function expandParticipants(value: unknown): NodePair[] {
+function expandParticipants(value: unknown, defaultValidatorCount: number): NodePair[] {
   if (value === undefined) {
     return [];
   }
@@ -167,13 +166,17 @@ function expandParticipants(value: unknown): NodePair[] {
       throw new Error(`E2B topology is limited to ${maxPairs} participant pairs`);
     }
     for (let instance = 1; instance <= count; instance += 1) {
-      pairs.push(parseParticipant(participant, offset + 1, instance));
+      pairs.push(parseParticipant(participant, offset + 1, instance, defaultValidatorCount));
     }
   }
   return pairs;
 }
 
-function expandMatrix(value: unknown, participantOffset: number): NodePair[] {
+function expandMatrix(
+  value: unknown,
+  participantOffset: number,
+  defaultValidatorCount: number,
+): NodePair[] {
   if (value === undefined) {
     return [];
   }
@@ -208,6 +211,7 @@ function expandMatrix(value: unknown, participantOffset: number): NodePair[] {
             { el_type: el.el_type, cl_type: cl.cl_type },
             participantIndex,
             instance,
+            defaultValidatorCount,
           ),
         );
       }
@@ -226,19 +230,75 @@ function resolveNetwork(config: ConfigInput, override?: Network): Network {
       : asRecord(config.network_params, "network_params");
   const configured = networkParams?.network;
   if (configured === undefined) {
-    throw new Error(
-      "E2B topology requires a public network in network_params.network or --network",
-    );
-  }
-  if (configured === "kurtosis") {
-    throw new Error(
-      "custom Kurtosis networks require inbound P2P and genesis services that E2B does not provide",
-    );
+    throw new Error("E2B topology requires network_params.network or --network");
   }
   if (!networks.includes(configured as Network)) {
     throw new Error(`network must be one of: ${networks.join(", ")}`);
   }
   return configured as Network;
+}
+
+const defaultMnemonic =
+  "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete";
+
+function integerParameter(
+  value: unknown,
+  fallback: number,
+  label: string,
+  minimum: number,
+): number {
+  const result = value ?? fallback;
+  if (!Number.isInteger(result) || (result as number) < minimum) {
+    throw new Error(`${label} must be an integer greater than or equal to ${minimum}`);
+  }
+  return result as number;
+}
+
+function devnetConfig(networkParams: Record<string, unknown>): DevnetConfig {
+  const networkIdValue = networkParams.network_id ?? "3151908";
+  if (
+    (typeof networkIdValue !== "string" && typeof networkIdValue !== "number") ||
+    String(networkIdValue).length === 0
+  ) {
+    throw new Error("network_params.network_id must be a string or number");
+  }
+  const preset = networkParams.preset ?? "mainnet";
+  if (preset !== "mainnet" && preset !== "minimal") {
+    throw new Error("network_params.preset must be mainnet or minimal");
+  }
+  const mnemonic = networkParams.preregistered_validator_keys_mnemonic ?? defaultMnemonic;
+  if (typeof mnemonic !== "string" || mnemonic.trim().length === 0) {
+    throw new Error("network_params.preregistered_validator_keys_mnemonic must be a string");
+  }
+  return {
+    networkId: String(networkIdValue),
+    preset,
+    secondsPerSlot: integerParameter(
+      networkParams.seconds_per_slot,
+      preset === "minimal" ? 6 : 12,
+      "network_params.seconds_per_slot",
+      1,
+    ),
+    genesisDelaySeconds: integerParameter(
+      networkParams.genesis_delay,
+      20,
+      "network_params.genesis_delay",
+      0,
+    ),
+    genesisTime: integerParameter(
+      networkParams.genesis_time,
+      0,
+      "network_params.genesis_time",
+      0,
+    ),
+    preregisteredValidatorCount: integerParameter(
+      networkParams.preregistered_validator_count,
+      0,
+      "network_params.preregistered_validator_count",
+      0,
+    ),
+    mnemonic: mnemonic.trim().replaceAll(/\s+/g, " "),
+  };
 }
 
 export function parseTopology(source: string, networkOverride?: Network): Topology {
@@ -253,26 +313,61 @@ export function parseTopology(source: string, networkOverride?: Network): Topolo
     throw new Error("additional_services are not supported by the E2B topology adapter");
   }
 
+  const network = resolveNetwork(config, networkOverride);
+  const networkParams =
+    config.network_params === undefined
+      ? {}
+      : asRecord(config.network_params, "network_params");
+  rejectUnknownKeys(
+    networkParams,
+    network === "kurtosis" ? devnetNetworkParameterKeys : publicNetworkParameterKeys,
+    "network_params",
+  );
+  const defaultValidatorCount =
+    network === "kurtosis"
+      ? integerParameter(
+          networkParams.num_validator_keys_per_node,
+          128,
+          "network_params.num_validator_keys_per_node",
+          0,
+        )
+      : 0;
   const hasConfiguredParticipants =
     config.participants !== undefined || config.participants_matrix !== undefined;
-  const explicit = expandParticipants(config.participants);
-  const matrix = expandMatrix(config.participants_matrix, explicit.length);
+  const explicit = expandParticipants(config.participants, defaultValidatorCount);
+  const matrix = expandMatrix(
+    config.participants_matrix,
+    explicit.length,
+    defaultValidatorCount,
+  );
   const expandedPairs = [...explicit, ...matrix];
   if (expandedPairs.length === 0 && hasConfiguredParticipants) {
     throw new Error("configuration expands to zero participants");
   }
   if (expandedPairs.length === 0) {
-    expandedPairs.push(parseParticipant({}, 1, 1));
+    expandedPairs.push(parseParticipant({}, 1, 1, defaultValidatorCount));
   }
   const pairs = expandedPairs.map((pair, index) => ({
     ...pair,
     id: `participant-${index + 1}`,
     participantIndex: index + 1,
   }));
-
-  return {
-    network: resolveNetwork(config, networkOverride),
+  const topology: Topology = {
+    network,
     pairs,
     sandboxCount: pairs.length * 2,
   };
+  if (network !== "kurtosis" && pairs.some(({ validatorCount }) => validatorCount > 0)) {
+    throw new Error("validator clients are only supported on private E2B devnets");
+  }
+  if (network === "kurtosis") {
+    if (pairs.length !== 1) {
+      throw new Error("a private E2B devnet supports exactly one EL-CL participant pair");
+    }
+    if (pairs.every(({ validatorCount }) => validatorCount === 0)) {
+      throw new Error("a private devnet requires at least one validator");
+    }
+    topology.devnet = devnetConfig(networkParams);
+  }
+  return topology;
 }

--- a/e2b/src/topology.ts
+++ b/e2b/src/topology.ts
@@ -1,0 +1,278 @@
+import { parse } from "yaml";
+
+import { networks, type Network } from "./config.js";
+
+export type ExecutionClient = "geth";
+export type ConsensusClient = "lighthouse" | "prysm";
+
+export interface NodePair {
+  id: string;
+  participantIndex: number;
+  instance: number;
+  elType: ExecutionClient;
+  clType: ConsensusClient;
+}
+
+export interface Topology {
+  network: Network;
+  pairs: NodePair[];
+  sandboxCount: number;
+}
+
+interface ParticipantInput {
+  el_type?: unknown;
+  cl_type?: unknown;
+  count?: unknown;
+  [key: string]: unknown;
+}
+
+interface MatrixInput {
+  el?: unknown;
+  cl?: unknown;
+  count?: unknown;
+  [key: string]: unknown;
+}
+
+interface ConfigInput {
+  participants?: unknown;
+  participants_matrix?: unknown;
+  network_params?: unknown;
+  additional_services?: unknown;
+}
+
+const participantKeys: Record<string, true> = {
+  el_type: true,
+  cl_type: true,
+  count: true,
+};
+const matrixKeys: Record<string, true> = { el: true, cl: true, count: true };
+const elMatrixKeys: Record<string, true> = { el_type: true };
+const clMatrixKeys: Record<string, true> = { cl_type: true, count: true };
+const rootKeys: Record<string, true> = {
+  participants: true,
+  participants_matrix: true,
+  network_params: true,
+  port_publisher: true,
+  additional_services: true,
+  extra_files: true,
+  blockscout_params: true,
+  dora_params: true,
+  checkpointz_params: true,
+  docker_cache_params: true,
+  tx_fuzz_params: true,
+  rakoon_params: true,
+  custom_flood_params: true,
+  prometheus_params: true,
+  grafana_params: true,
+  tempo_params: true,
+  assertoor_params: true,
+  mev_params: true,
+  xatu_sentry_params: true,
+  snooper_params: true,
+  spamoor_params: true,
+  disruptoor_params: true,
+  slashoor_params: true,
+  mempool_bridge_params: true,
+  ethereum_genesis_generator_params: true,
+  bootnodoor_params: true,
+  zkboost_params: true,
+  buildoor_params: true,
+  trueblocks_params: true,
+  wait_for_finalization: true,
+  global_log_level: true,
+  snooper_enabled: true,
+  ethereum_metrics_exporter_enabled: true,
+  parallel_keystore_generation: true,
+  disable_peer_scoring: true,
+  persistent: true,
+  mev_type: true,
+  xatu_sentry_enabled: true,
+  apache_port: true,
+  nginx_port: true,
+  global_tolerations: true,
+  global_node_selectors: true,
+  use_remote_signer: true,
+  keymanager_enabled: true,
+  checkpoint_sync_enabled: true,
+  checkpoint_sync_url: true,
+};
+const maxPairs = 32;
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a mapping`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be a list`);
+  }
+  return value;
+}
+
+function countOf(value: unknown, label: string): number {
+  const count = value ?? 1;
+  if (!Number.isInteger(count) || (count as number) < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return count as number;
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: Readonly<Record<string, true>>,
+  label: string,
+): void {
+  const unsupported = Object.keys(value).find((key) => !allowed[key]);
+  if (unsupported) {
+    throw new Error(`unsupported ${label} option: ${unsupported}`);
+  }
+}
+
+function parseParticipant(
+  input: ParticipantInput,
+  participantIndex: number,
+  instance: number,
+): NodePair {
+  rejectUnknownKeys(input, participantKeys, `participant ${participantIndex}`);
+  const elType = input.el_type ?? "geth";
+  const clType = input.cl_type ?? "lighthouse";
+  if (elType !== "geth") {
+    throw new Error(`unsupported EL client in participant ${participantIndex}: ${String(elType)}`);
+  }
+  if (clType !== "lighthouse" && clType !== "prysm") {
+    throw new Error(`unsupported CL client in participant ${participantIndex}: ${String(clType)}`);
+  }
+  return {
+    id: `participant-${participantIndex}-${instance}`,
+    participantIndex,
+    instance,
+    elType,
+    clType,
+  };
+}
+
+function expandParticipants(value: unknown): NodePair[] {
+  if (value === undefined) {
+    return [];
+  }
+  const participants = asArray(value, "participants");
+  const pairs: NodePair[] = [];
+  for (const [offset, entry] of participants.entries()) {
+    const participant = asRecord(entry, `participants[${offset}]`) as ParticipantInput;
+    const count = countOf(participant.count, `participants[${offset}].count`);
+    if (count > maxPairs - pairs.length) {
+      throw new Error(`E2B topology is limited to ${maxPairs} participant pairs`);
+    }
+    for (let instance = 1; instance <= count; instance += 1) {
+      pairs.push(parseParticipant(participant, offset + 1, instance));
+    }
+  }
+  return pairs;
+}
+
+function expandMatrix(value: unknown, participantOffset: number): NodePair[] {
+  if (value === undefined) {
+    return [];
+  }
+  const matrix = asRecord(value, "participants_matrix") as MatrixInput;
+  rejectUnknownKeys(matrix, matrixKeys, "participants_matrix");
+  const executionClients = asArray(matrix.el ?? [], "participants_matrix.el");
+  const consensusClients = asArray(matrix.cl ?? [], "participants_matrix.cl");
+  if (executionClients.length === 0 || consensusClients.length === 0) {
+    throw new Error("participants_matrix requires non-empty el and cl lists");
+  }
+  const matrixCount = countOf(matrix.count, "participants_matrix.count");
+  const pairs: NodePair[] = [];
+  let participantIndex = participantOffset;
+  for (const [elOffset, elValue] of executionClients.entries()) {
+    const el = asRecord(elValue, `participants_matrix.el[${elOffset}]`);
+    rejectUnknownKeys(el, elMatrixKeys, `participants_matrix.el[${elOffset}]`);
+    for (const [clOffset, clValue] of consensusClients.entries()) {
+      const cl = asRecord(clValue, `participants_matrix.cl[${clOffset}]`);
+      rejectUnknownKeys(cl, clMatrixKeys, `participants_matrix.cl[${clOffset}]`);
+      const clientCount = countOf(cl.count, `participants_matrix.cl[${clOffset}].count`);
+      if (
+        clientCount > 0 &&
+        matrixCount > Math.floor((maxPairs - participantOffset - pairs.length) / clientCount)
+      ) {
+        throw new Error(`E2B topology is limited to ${maxPairs} participant pairs`);
+      }
+      participantIndex += 1;
+      const count = matrixCount * clientCount;
+      for (let instance = 1; instance <= count; instance += 1) {
+        pairs.push(
+          parseParticipant(
+            { el_type: el.el_type, cl_type: cl.cl_type },
+            participantIndex,
+            instance,
+          ),
+        );
+      }
+    }
+  }
+  return pairs;
+}
+
+function resolveNetwork(config: ConfigInput, override?: Network): Network {
+  if (override) {
+    return override;
+  }
+  const networkParams =
+    config.network_params === undefined
+      ? undefined
+      : asRecord(config.network_params, "network_params");
+  const configured = networkParams?.network;
+  if (configured === undefined) {
+    throw new Error(
+      "E2B topology requires a public network in network_params.network or --network",
+    );
+  }
+  if (configured === "kurtosis") {
+    throw new Error(
+      "custom Kurtosis networks require inbound P2P and genesis services that E2B does not provide",
+    );
+  }
+  if (!networks.includes(configured as Network)) {
+    throw new Error(`network must be one of: ${networks.join(", ")}`);
+  }
+  return configured as Network;
+}
+
+export function parseTopology(source: string, networkOverride?: Network): Topology {
+  const parsed: unknown = parse(source);
+  const configRecord = asRecord(parsed, "configuration");
+  rejectUnknownKeys(configRecord, rootKeys, "root");
+  const config = configRecord as ConfigInput;
+  if (
+    config.additional_services !== undefined &&
+    asArray(config.additional_services, "additional_services").length > 0
+  ) {
+    throw new Error("additional_services are not supported by the E2B topology adapter");
+  }
+
+  const hasConfiguredParticipants =
+    config.participants !== undefined || config.participants_matrix !== undefined;
+  const explicit = expandParticipants(config.participants);
+  const matrix = expandMatrix(config.participants_matrix, explicit.length);
+  const expandedPairs = [...explicit, ...matrix];
+  if (expandedPairs.length === 0 && hasConfiguredParticipants) {
+    throw new Error("configuration expands to zero participants");
+  }
+  if (expandedPairs.length === 0) {
+    expandedPairs.push(parseParticipant({}, 1, 1));
+  }
+  const pairs = expandedPairs.map((pair, index) => ({
+    ...pair,
+    id: `participant-${index + 1}`,
+    participantIndex: index + 1,
+  }));
+
+  return {
+    network: resolveNetwork(config, networkOverride),
+    pairs,
+    sandboxCount: pairs.length * 2,
+  };
+}

--- a/e2b/test/commands.test.ts
+++ b/e2b/test/commands.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { gethArgs, lighthouseArgs, parseOptions } from "../src/config.js";
+
+test("pairs separate sandboxes over the authenticated public Engine API", () => {
+  const geth = gethArgs("hoodi", "/home/user/ethereum/jwt.hex");
+  const lighthouse = lighthouseArgs(
+    "hoodi",
+    "/home/user/ethereum/jwt.hex",
+    "https://engine.example",
+  );
+
+  assert.ok(geth.includes("--hoodi"));
+  assert.ok(geth.includes("--http.addr=127.0.0.1"));
+  assert.ok(geth.includes("--authrpc.addr=0.0.0.0"));
+  assert.ok(geth.includes("--authrpc.jwtsecret=/home/user/ethereum/jwt.hex"));
+  assert.ok(lighthouse.includes("--network=hoodi"));
+  assert.ok(lighthouse.includes("--execution-endpoints=https://engine.example"));
+  assert.ok(lighthouse.includes("--jwt-secrets=/home/user/ethereum/jwt.hex"));
+});
+
+test("only accepts public networks and bounded sandbox lifetimes", () => {
+  assert.deepEqual(parseOptions(["--network", "sepolia", "--timeout", "5"]), {
+    network: "sepolia",
+    timeoutMinutes: 5,
+    checkpointUrl: "https://checkpoint-sync.sepolia.ethpandaops.io",
+  });
+  assert.throws(() => parseOptions(["--network", "kurtosis"]), /network/);
+  assert.throws(
+    () => parseOptions(["--timeout", "4"]),
+    /timeout must be an integer from 5 to 1440 minutes/,
+  );
+  assert.throws(() => parseOptions(["--timeout", "1441"]), /timeout/);
+});
+
+test("uses checkpoint sync when configured and insecure genesis sync otherwise", () => {
+  assert.ok(
+    lighthouseArgs("mainnet", "/jwt", "https://engine.example", "https://checkpoint.example").includes(
+      "--checkpoint-sync-url=https://checkpoint.example",
+    ),
+  );
+  assert.ok(
+    lighthouseArgs("mainnet", "/jwt", "https://engine.example").includes(
+      "--allow-insecure-genesis-sync",
+    ),
+  );
+  assert.ok(lighthouseArgs("mainnet", "/jwt", "https://engine.example").includes("--ignore-ws-check"));
+});

--- a/e2b/test/commands.test.ts
+++ b/e2b/test/commands.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { gethArgs, lighthouseArgs, parseOptions } from "../src/config.js";
+import { gethArgs, lighthouseArgs, parseOptions, prysmArgs } from "../src/config.js";
 
 test("pairs separate sandboxes over the authenticated public Engine API", () => {
   const geth = gethArgs("hoodi", "/home/user/ethereum/jwt.hex");
@@ -18,6 +18,14 @@ test("pairs separate sandboxes over the authenticated public Engine API", () => 
   assert.ok(lighthouse.includes("--network=hoodi"));
   assert.ok(lighthouse.includes("--execution-endpoints=https://engine.example"));
   assert.ok(lighthouse.includes("--jwt-secrets=/home/user/ethereum/jwt.hex"));
+  const prysm = prysmArgs(
+    "hoodi",
+    "/home/user/ethereum/jwt.hex",
+    "https://engine.example",
+  );
+  assert.ok(prysm.includes("--hoodi"));
+  assert.ok(prysm.includes("--execution-endpoint=https://engine.example"));
+  assert.ok(prysm.includes("--jwt-secret=/home/user/ethereum/jwt.hex"));
 });
 
 test("only accepts public networks and bounded sandbox lifetimes", () => {
@@ -25,6 +33,10 @@ test("only accepts public networks and bounded sandbox lifetimes", () => {
     network: "sepolia",
     timeoutMinutes: 5,
     checkpointUrl: "https://checkpoint-sync.sepolia.ethpandaops.io",
+  });
+  assert.deepEqual(parseOptions(["--config", "network_params.yaml", "--timeout", "10"]), {
+    configPath: "network_params.yaml",
+    timeoutMinutes: 10,
   });
   assert.throws(() => parseOptions(["--network", "kurtosis"]), /network/);
   assert.throws(
@@ -40,6 +52,14 @@ test("uses checkpoint sync when configured and insecure genesis sync otherwise",
       "--checkpoint-sync-url=https://checkpoint.example",
     ),
   );
+  const prysm = prysmArgs(
+    "sepolia",
+    "/jwt",
+    "https://engine.example",
+    "https://checkpoint.example",
+  );
+  assert.ok(prysm.includes("--checkpoint-sync-url=https://checkpoint.example"));
+  assert.ok(prysm.includes("--genesis-beacon-api-url=https://checkpoint.example"));
   assert.ok(
     lighthouseArgs("mainnet", "/jwt", "https://engine.example").includes(
       "--allow-insecure-genesis-sync",

--- a/e2b/test/commands.test.ts
+++ b/e2b/test/commands.test.ts
@@ -1,7 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { gethArgs, lighthouseArgs, parseOptions, prysmArgs } from "../src/config.js";
+import { type Sandbox } from "e2b";
+
+import {
+  gethArgs,
+  lighthouseArgs,
+  parseOptions,
+  prysmArgs,
+  resolveCheckpointUrl,
+} from "../src/config.js";
+import {
+  generateDevnetArtifacts,
+  gethDevnetArgs,
+  lighthouseDevnetArgs,
+  prysmDevnetArgs,
+  plannedGenesisTimestamp,
+  validatorArgs,
+} from "../src/devnet.js";
 
 test("pairs separate sandboxes over the authenticated public Engine API", () => {
   const geth = gethArgs("hoodi", "/home/user/ethereum/jwt.hex");
@@ -28,7 +44,7 @@ test("pairs separate sandboxes over the authenticated public Engine API", () => 
   assert.ok(prysm.includes("--jwt-secret=/home/user/ethereum/jwt.hex"));
 });
 
-test("only accepts public networks and bounded sandbox lifetimes", () => {
+test("accepts public and private networks with bounded sandbox lifetimes", () => {
   assert.deepEqual(parseOptions(["--network", "sepolia", "--timeout", "5"]), {
     network: "sepolia",
     timeoutMinutes: 5,
@@ -38,12 +54,28 @@ test("only accepts public networks and bounded sandbox lifetimes", () => {
     configPath: "network_params.yaml",
     timeoutMinutes: 10,
   });
-  assert.throws(() => parseOptions(["--network", "kurtosis"]), /network/);
+  assert.deepEqual(parseOptions(["--network", "kurtosis"]), {
+    network: "kurtosis",
+    timeoutMinutes: 60,
+  });
   assert.throws(
     () => parseOptions(["--timeout", "4"]),
     /timeout must be an integer from 5 to 1440 minutes/,
   );
   assert.throws(() => parseOptions(["--timeout", "1441"]), /timeout/);
+});
+test("rejects plaintext checkpoint URLs", () => {
+  assert.throws(
+    () => parseOptions(["--checkpoint-url", "http://checkpoint.example"]),
+    /checkpoint URL must use HTTPS/,
+  );
+});
+
+test("rejects checkpoint sync after a config resolves to a private network", () => {
+  assert.throws(
+    () => resolveCheckpointUrl("kurtosis", "https://checkpoint.example"),
+    /checkpoint URL is only valid for public networks/,
+  );
 });
 
 test("uses checkpoint sync when configured and insecure genesis sync otherwise", () => {
@@ -66,4 +98,112 @@ test("uses checkpoint sync when configured and insecure genesis sync otherwise",
     ),
   );
   assert.ok(lighthouseArgs("mainnet", "/jwt", "https://engine.example").includes("--ignore-ws-check"));
+});
+
+test("honors an explicit private genesis timestamp", () => {
+  assert.equal(
+    plannedGenesisTimestamp({
+      network: "kurtosis",
+      pairs: [],
+      sandboxCount: 0,
+      devnet: {
+        networkId: "424242",
+        preset: "mainnet",
+        secondsPerSlot: 12,
+        genesisDelaySeconds: 20,
+        genesisTime: 1234567890,
+        preregisteredValidatorCount: 64,
+        mnemonic: "test mnemonic",
+      },
+    }),
+    1234567890,
+  );
+});
+
+test("uses the preregistered validator count in generated genesis", async () => {
+  let valuesEnvironment = "";
+  const sandbox = {
+    files: {
+      write: async (path: string, value: unknown) => {
+        if (path === "/config/values.env") {
+          valuesEnvironment = String(value);
+        }
+      },
+      read: async () => new Uint8Array(),
+    },
+    commands: {
+      run: async () => ({}),
+    },
+  } as unknown as Sandbox;
+  await generateDevnetArtifacts(
+    sandbox,
+    {
+      network: "kurtosis",
+      sandboxCount: 2,
+      pairs: [
+        {
+          id: "participant-1",
+          participantIndex: 1,
+          instance: 1,
+          elType: "geth",
+          clType: "lighthouse",
+          vcType: "lighthouse",
+          validatorCount: 32,
+        },
+      ],
+      devnet: {
+        networkId: "424242",
+        preset: "mainnet",
+        secondsPerSlot: 12,
+        genesisDelaySeconds: 20,
+        preregisteredValidatorCount: 64,
+        mnemonic: "test mnemonic",
+      },
+    },
+    1234567890,
+  );
+
+  assert.match(valuesEnvironment, /export NUMBER_OF_VALIDATORS=64\n/);
+});
+
+test("configures native private clients over the E2B HTTPS Engine bridge", () => {
+  const config = {
+    networkId: "424242",
+    preset: "mainnet" as const,
+    secondsPerSlot: 12,
+    genesisDelaySeconds: 20,
+    mnemonic: "test mnemonic",
+  };
+  const geth = gethDevnetArgs(config, "/jwt");
+  assert.ok(geth.includes("--networkid=424242"));
+  assert.ok(geth.includes("--http.addr=127.0.0.1"));
+  assert.ok(geth.includes("--nodiscover"));
+  assert.ok(geth.includes("--authrpc.addr=0.0.0.0"));
+
+  const lighthouse = lighthouseDevnetArgs("/jwt", "https://engine.example");
+  assert.ok(lighthouse.includes("--testnet-dir=/home/user/devnet/metadata"));
+  assert.ok(lighthouse.includes("--execution-endpoints=https://engine.example"));
+  assert.ok(lighthouse.includes("--disable-discovery"));
+
+  const prysm = prysmDevnetArgs(config, "/jwt", "https://engine.example");
+  assert.ok(prysm.includes("--chain-config-file=/home/user/devnet/metadata/config.yaml"));
+  assert.ok(prysm.includes("--p2p-host-ip=127.0.0.1"));
+  assert.ok(prysm.includes("--execution-endpoint=https://engine.example"));
+
+  const validator = validatorArgs(
+    {
+      id: "participant-1",
+      participantIndex: 1,
+      instance: 1,
+      elType: "geth",
+      clType: "lighthouse",
+      vcType: "lighthouse",
+      validatorCount: 128,
+    },
+    "http://127.0.0.1:4000",
+  );
+  assert.ok(
+    validator.includes("--validators-dir=/home/user/devnet/keystores/participant-1/keys"),
+  );
+  assert.ok(validator.includes("--beacon-nodes=http://127.0.0.1:4000"));
 });

--- a/e2b/test/topology.test.ts
+++ b/e2b/test/topology.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseTopology } from "../src/topology.js";
+
+test("expands ethereum-package participant counts into EL-CL sandbox pairs", () => {
+  const topology = parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: prysm
+    count: 2
+  - el_type: geth
+    cl_type: lighthouse
+    count: 2
+`);
+
+  assert.equal(topology.network, "hoodi");
+  assert.equal(topology.pairs.length, 4);
+  assert.equal(topology.sandboxCount, 8);
+  assert.deepEqual(
+    topology.pairs.map(({ elType, clType }) => [elType, clType]),
+    [
+      ["geth", "prysm"],
+      ["geth", "prysm"],
+      ["geth", "lighthouse"],
+      ["geth", "lighthouse"],
+    ],
+  );
+});
+
+test("matches ethereum-package participants_matrix cartesian expansion", () => {
+  const topology = parseTopology(`
+network_params:
+  network: sepolia
+participants_matrix:
+  el:
+    - el_type: geth
+  cl:
+    - cl_type: lighthouse
+    - cl_type: prysm
+  count: 2
+`);
+
+  assert.equal(topology.pairs.length, 4);
+  assert.deepEqual(
+    topology.pairs.map(({ clType }) => clType),
+    ["lighthouse", "lighthouse", "prysm", "prysm"],
+  );
+});
+
+test("preserves ethereum-package count and participant numbering semantics", () => {
+  const topology = parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    count: 0
+  - el_type: geth
+    cl_type: prysm
+    count: 2
+participants_matrix:
+  el:
+    - el_type: geth
+  cl:
+    - cl_type: lighthouse
+      count: 2
+  count: 2
+`);
+
+  assert.equal(topology.pairs.length, 6);
+  assert.deepEqual(
+    topology.pairs.map(({ participantIndex }) => participantIndex),
+    [1, 2, 3, 4, 5, 6],
+  );
+  assert.deepEqual(
+    topology.pairs.map(({ id }) => id),
+    [
+      "participant-1",
+      "participant-2",
+      "participant-3",
+      "participant-4",
+      "participant-5",
+      "participant-6",
+    ],
+  );
+});
+
+test("rejects topology that E2B cannot reproduce safely", () => {
+  assert.throws(
+    () =>
+      parseTopology(`
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+`),
+    /public network.*--network/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: kurtosis
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+`),
+    /custom Kurtosis networks/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: nethermind
+    cl_type: lighthouse
+`),
+    /unsupported EL client/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    cl_image: custom/lighthouse:latest
+`),
+    /unsupported participant 1 option.*cl_image/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+additional_services:
+  - dora
+`),
+    /additional_services/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: prysm
+    count: 1000000000
+`),
+    /limited to 32 participant pairs/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants: []
+`),
+    /zero participants/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participant:
+  - el_type: geth
+    cl_type: lighthouse
+`),
+    /unsupported root option.*participant/,
+  );
+});

--- a/e2b/test/topology.test.ts
+++ b/e2b/test/topology.test.ts
@@ -88,6 +88,59 @@ participants_matrix:
   );
 });
 
+test("parses private devnet and validator settings", () => {
+  const topology = parseTopology(`
+network_params:
+  network: kurtosis
+  network_id: "424242"
+  preset: minimal
+  seconds_per_slot: 6
+  genesis_delay: 30
+  num_validator_keys_per_node: 32
+  genesis_time: 1234567890
+  preregistered_validator_count: 64
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    vc_type: prysm
+    validator_count: 48
+`);
+
+  assert.equal(topology.network, "kurtosis");
+  assert.deepEqual(topology.devnet, {
+    networkId: "424242",
+    preset: "minimal",
+    secondsPerSlot: 6,
+    genesisDelaySeconds: 30,
+    genesisTime: 1234567890,
+    preregisteredValidatorCount: 64,
+    mnemonic:
+      "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete",
+  });
+  assert.deepEqual(
+    topology.pairs.map(({ clType, vcType, validatorCount }) => ({
+      clType,
+      vcType,
+      validatorCount,
+    })),
+    [{ clType: "lighthouse", vcType: "prysm", validatorCount: 48 }],
+  );
+});
+
+test("uses ethereum-package null validator defaults", () => {
+  const topology = parseTopology(`
+network_params:
+  network: kurtosis
+  num_validator_keys_per_node: 32
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    validator_count: null
+`);
+
+  assert.equal(topology.pairs[0]?.validatorCount, 32);
+});
+
 test("rejects topology that E2B cannot reproduce safely", () => {
   assert.throws(
     () =>
@@ -96,18 +149,21 @@ participants:
   - el_type: geth
     cl_type: lighthouse
 `),
-    /public network.*--network/,
+    /network_params.*--network/,
   );
   assert.throws(
     () =>
       parseTopology(`
 network_params:
   network: kurtosis
+  num_validator_keys_per_node: 32
 participants:
   - el_type: geth
     cl_type: lighthouse
+  - el_type: geth
+    cl_type: prysm
 `),
-    /custom Kurtosis networks/,
+    /exactly one EL-CL participant pair/,
   );
   assert.throws(
     () =>
@@ -176,5 +232,46 @@ participant:
     cl_type: lighthouse
 `),
     /unsupported root option.*participant/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    validator_count: 1
+`),
+    /validator clients are only supported on private/,
+  );
+  for (const unsupported of ["mev_params", "persistent"]) {
+    assert.throws(
+      () =>
+        parseTopology(`
+network_params:
+  network: hoodi
+${unsupported}: {}
+`),
+      new RegExp(`unsupported root option.*${unsupported}`),
+    );
+  }
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: hoodi
+  network_id: "424242"
+`),
+    /unsupported network_params option.*network_id/,
+  );
+  assert.throws(
+    () =>
+      parseTopology(`
+network_params:
+  network: kurtosis
+  terminal_total_difficulty: "0"
+`),
+    /unsupported network_params option.*terminal_total_difficulty/,
   );
 });

--- a/e2b/testnet.yaml
+++ b/e2b/testnet.yaml
@@ -1,0 +1,13 @@
+network_params:
+  network: kurtosis
+  network_id: "3151908"
+  preset: mainnet
+  seconds_per_slot: 6
+  genesis_delay: 90
+  num_validator_keys_per_node: 32
+
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    vc_type: lighthouse
+    validator_count: 64

--- a/e2b/tsconfig.json
+++ b/e2b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Run supported ethereum-package participant topologies directly in E2B without requiring Docker or Kubernetes. With no configuration, the adapter bootstraps a self-contained Geth + Lighthouse post-merge devnet with validators; explicit public-network selection launches supervised Geth + Lighthouse/Prysm sandbox pairs instead.

## Design decisions

- **Fail closed on topology fidelity.** Participant counts and matrices expand with ethereum-package numbering semantics; unsupported clients, unimplemented YAML options, public validators, and multi-pair private networks are rejected instead of silently producing a different network.
- **Keep the Engine bridge narrow.** Each EL/CL pair uses a unique JWT, only Geth's Engine API binds externally, consensus APIs retain E2B traffic-token protection, and ordinary EL RPC and metrics remain sandbox-local.
- **Generate private networks from the canonical tooling.** An ephemeral generator sandbox creates execution genesis, consensus genesis/config, and validator key material from the pinned `ethereum-genesis-generator`; both client sandboxes receive the same artifacts before startup.
- **Make runtime ownership explicit.** Startup checks client processes and readiness concurrently, signal handling interrupts pending probes, and cleanup reconciles every sandbox tagged with the launch ID before returning.
- **Pin the executable supply chain.** The E2B base image and genesis-generator image use immutable digests; downloaded Geth, Lighthouse, Prysm, and helper artifacts are checksum-verified with bounded transfer times.

Public-network pairs independently join the selected canonical network because E2B does not expose the private UDP ports required for an ad-hoc multi-node Ethereum P2P network. Private devnets are therefore intentionally limited to one EL/CL pair.

## Validation

- `npm test` — 15/15 focused command and topology cases passed, including private-by-default resolution, explicit public selection, fail-closed YAML handling, private genesis timing, validator defaults, and client command construction.
- `npm run build` — strict TypeScript compilation passed.
- `npm run template:build` — the pinned `ethereum-client-topology` E2B template built successfully.
- `npm run launch -- --config testnet.yaml --timeout 10` — a live Geth + Lighthouse private devnet reached execution block 3 and beacon head slot 3 with 64 active validators; both sandboxes were then cleaned up.
