### PR TITLE
chore: bump ethereum-genesis-generator to 6.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1806,7 +1806,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.1.3
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -270,7 +270,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.3
+  image: ethpandaops/ethereum-genesis-generator:6.1.4
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -111,7 +111,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.1.3"
+    "ethpandaops/ethereum-genesis-generator:6.1.4"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
Bumps the pinned `ethereum-genesis-generator` image from `6.1.3` to [`6.1.4`](https://github.com/ethpandaops/ethereum-genesis-generator/releases/tag/v6.1.4).

All three pin sites updated:

- `src/package_io/constants.star` — `DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE`
- `network_params.yaml`
- `README.md` — `ethereum_genesis_generator_params` example

The `README.md` note at line 874 ("requires ethereum-genesis-generator >= 6.1.3") is intentionally left alone — it states a minimum version for Gloas scheduling, not a pin, and remains accurate.