### PR TITLE
feat: Add standalone discv5 'bootnode' service

### DIFF
--- a/src/bootnode/bootnode_launcher.star
+++ b/src/bootnode/bootnode_launcher.star
@@ -11,6 +11,70 @@ shared_utils = import_module("../shared_utils/shared_utils.star")
 
 SERVICE_NAME = "bootnode"
 
+# Fixed identity for the devp2p bootnode (deterministic ENR across runs; devnet-only).
+DEVP2P_NODEKEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+DEVP2P_DISCOVERY_PORT = 30303
+
+
+# Launch a pure discv5 bootnode using go-ethereum's `devp2p discv5 listen` (no chain,
+# RLPx, RPC or txpool — just discv5). Needs an alltools image (e.g.
+# ethereum/client-go:alltools-latest) set as bootnode_params.image. It has no RPC to
+# query, so its ENR/enode are COMPUTED in-container with `devp2p key to-enr/to-enode`
+# from the fixed nodekey + the container's own IP. Returns (enode, enr).
+def _launch_devp2p_bootnode(plan, bootnode_params, node_selectors, tolerations):
+    config = ServiceConfig(
+        image=bootnode_params.image,
+        ports={
+            constants.UDP_DISCOVERY_PORT_ID: shared_utils.new_port_spec(
+                DEVP2P_DISCOVERY_PORT,
+                shared_utils.UDP_PROTOCOL,
+            ),
+        },
+        entrypoint=["devp2p"],
+        cmd=[
+            "discv5",
+            "listen",
+            "--nodekey",
+            DEVP2P_NODEKEY,
+            # Explicit empty bootnodes: suppress devp2p's DEFAULT (public mainnet)
+            # bootnodes, so the table isn't polluted with public nodes.
+            "--bootnodes",
+            "",
+            "--addr",
+            "0.0.0.0:{0}".format(DEVP2P_DISCOVERY_PORT),
+            "--extaddr",
+            "{0}:{1}".format(
+                constants.PRIVATE_IP_ADDRESS_PLACEHOLDER, DEVP2P_DISCOVERY_PORT
+            ),
+        ],
+        private_ip_address_placeholder=constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        node_selectors=node_selectors,
+        tolerations=tolerations,
+    )
+    plan.add_service(SERVICE_NAME, config)
+
+    enr = _devp2p_record(plan, "to-enr")
+    enode = _devp2p_record(plan, "to-enode")
+    plan.print("Bootnode (devp2p) ENR: {0}".format(enr))
+    return enode, enr
+
+
+def _devp2p_record(plan, subcmd):
+    # Compute the running node's enode/ENR from the same nodekey + its own IP.
+    result = plan.exec(
+        service_name=SERVICE_NAME,
+        recipe=ExecRecipe(
+            command=[
+                "sh",
+                "-c",
+                "echo -n {key} > /tmp/nk && devp2p key {sub} --ip $(hostname -i | cut -d' ' -f1) --udp {port} --tcp 0 /tmp/nk | tr -d '\\n'".format(
+                    key=DEVP2P_NODEKEY, sub=subcmd, port=DEVP2P_DISCOVERY_PORT
+                ),
+            ],
+        ),
+    )
+    return result["output"]
+
 
 # Launch a standalone EL node whose ONLY job is to be the network's discv5 bootnode.
 # It has no CL (nothing drives it past genesis) and no validators. With a discovery-only
@@ -34,6 +98,17 @@ def launch_bootnode(
     global_node_selectors,
     global_tolerations,
 ):
+    node_selectors = input_parser.get_client_node_selectors(
+        {}, global_node_selectors
+    )
+    tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
+
+    # Pure discv5 bootnode via go-ethereum's devp2p tool (no chain/RLPx/RPC).
+    if bootnode_params.backend == "devp2p":
+        return _launch_devp2p_bootnode(
+            plan, bootnode_params, node_selectors, tolerations
+        )
+
     el_bootnode_launchers = {
         constants.EL_TYPE.geth: {
             "launcher": geth.new_geth_launcher(el_cl_genesis_data, jwt_file, network_id),

--- a/src/bootnode/bootnode_launcher.star
+++ b/src/bootnode/bootnode_launcher.star
@@ -1,0 +1,120 @@
+geth = import_module("../el/geth/geth_launcher.star")
+besu = import_module("../el/besu/besu_launcher.star")
+erigon = import_module("../el/erigon/erigon_launcher.star")
+nethermind = import_module("../el/nethermind/nethermind_launcher.star")
+reth = import_module("../el/reth/reth_launcher.star")
+nimbus_eth1 = import_module("../el/nimbus-eth1/nimbus_launcher.star")
+ethrex = import_module("../el/ethrex/ethrex_launcher.star")
+input_parser = import_module("../package_io/input_parser.star")
+constants = import_module("../package_io/constants.star")
+shared_utils = import_module("../shared_utils/shared_utils.star")
+
+SERVICE_NAME = "bootnode"
+
+
+# Launch a standalone EL node whose ONLY job is to be the network's discv5 bootnode.
+# It has no CL (nothing drives it past genesis) and no validators. With a discovery-only
+# flag set (e.g. geth --maxpeers=0) it holds zero RLPx peers and is a pure rendezvous:
+# it still bonds via discv5 and serves FINDNODE. Because discv5 is application-agnostic,
+# this one node seeds BOTH overlays — its enode/ENR feed the EL clients and its ENR the
+# CL clients via the same override plumbing bootnodoor uses. Returns (enode, enr).
+#
+# The bootnode backend is selectable via bootnode_params.backend (default geth). Note the
+# discovery-only / disable-discv4 flags in extra_params are backend-specific.
+def launch_bootnode(
+    plan,
+    bootnode_params,
+    el_cl_genesis_data,
+    jwt_file,
+    network_id,
+    network_params,
+    global_log_level,
+    persistent,
+    port_publisher,
+    global_node_selectors,
+    global_tolerations,
+):
+    el_bootnode_launchers = {
+        constants.EL_TYPE.geth: {
+            "launcher": geth.new_geth_launcher(el_cl_genesis_data, jwt_file, network_id),
+            "get_config": geth.get_config,
+            "get_el_context": geth.get_el_context,
+        },
+        constants.EL_TYPE.nethermind: {
+            "launcher": nethermind.new_nethermind_launcher(el_cl_genesis_data, jwt_file),
+            "get_config": nethermind.get_config,
+            "get_el_context": nethermind.get_el_context,
+        },
+        constants.EL_TYPE.reth: {
+            "launcher": reth.new_reth_launcher(el_cl_genesis_data, jwt_file),
+            "get_config": reth.get_config,
+            "get_el_context": reth.get_el_context,
+        },
+        constants.EL_TYPE.erigon: {
+            "launcher": erigon.new_erigon_launcher(
+                el_cl_genesis_data, jwt_file, network_id
+            ),
+            "get_config": erigon.get_config,
+            "get_el_context": erigon.get_el_context,
+        },
+        constants.EL_TYPE.ethrex: {
+            "launcher": ethrex.new_ethrex_launcher(el_cl_genesis_data, jwt_file),
+            "get_config": ethrex.get_config,
+            "get_el_context": ethrex.get_el_context,
+        },
+        constants.EL_TYPE.besu: {
+            "launcher": besu.new_besu_launcher(el_cl_genesis_data, jwt_file),
+            "get_config": besu.get_config,
+            "get_el_context": besu.get_el_context,
+        },
+        constants.EL_TYPE.nimbus: {
+            "launcher": nimbus_eth1.new_nimbus_launcher(el_cl_genesis_data, jwt_file),
+            "get_config": nimbus_eth1.get_config,
+            "get_el_context": nimbus_eth1.get_el_context,
+        },
+    }
+
+    backend = bootnode_params.backend
+    if backend not in el_bootnode_launchers:
+        fail(
+            "Unsupported bootnode backend '{0}', need one of '{1}'".format(
+                backend, ",".join(el_bootnode_launchers.keys())
+            )
+        )
+    entry = el_bootnode_launchers[backend]
+
+    # Synthetic single-EL-node config (reuses the client's tested launcher).
+    p = input_parser.default_participant()
+    p["el_type"] = backend
+    p["el_image"] = bootnode_params.image
+    p["el_extra_params"] = bootnode_params.extra_params
+    p["validator_count"] = 0
+    participant = struct(**p)
+
+    node_selectors = input_parser.get_client_node_selectors(
+        participant.node_selectors, global_node_selectors
+    )
+    tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
+
+    config = entry["get_config"](
+        plan,
+        entry["launcher"],
+        participant,
+        SERVICE_NAME,
+        [],  # existing_el_clients: none -> this node is the bootstrap anchor
+        "none",  # cl_client_name (label only)
+        global_log_level,
+        persistent,
+        tolerations,
+        node_selectors,
+        port_publisher,
+        0,  # participant_index (label/port slot; bootnode is not a participant)
+        network_params,
+        {},  # extra_files_artifacts
+    )
+    service = plan.add_service(SERVICE_NAME, config)
+
+    el_context = entry["get_el_context"](plan, SERVICE_NAME, service, entry["launcher"])
+    plan.print("Bootnode ({0}) ENODE: {1}".format(backend, el_context.enode))
+    plan.print("Bootnode ({0}) ENR: {1}".format(backend, el_context.enr))
+    return el_context.enode, el_context.enr

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -34,7 +34,15 @@ def launch(
     bootnodoor_enode=None,
     binary_artifacts={},
     otel_otlp_grpc_url=None,
+    bootnodoor_enr=None,
+    bootnode_record="enode",
 ):
+    # Global bootnode record format (NOT per-client): "enode" or "enr". Controls the
+    # form in which the single bootnode is handed to every EL client. Clients whose
+    # discv5 can't seed from a bare enode (e.g. erigon) need "enr"; geth/nethermind/
+    # ethrex accept either. reth only accepts "enode" (and can't discv5-bootstrap from
+    # it) so it has no working option here.
+    use_enr = bootnode_record == "enr"
     el_launchers = {
         constants.EL_TYPE.geth: {
             "launcher": geth.new_geth_launcher(
@@ -175,6 +183,23 @@ def launch(
         el_service_name = "el-{0}-{1}-{2}".format(index_str, el_type, cl_type)
         el_binary_artifact = binary_artifacts.get(index, {}).get("el", None)
 
+        # Choose this client's single bootnode, in the form it needs (ENR for clients
+        # whose discv5 can't seed from a bare enode, enode otherwise):
+        #  - bootnodoor enabled -> point at bootnodoor.
+        #  - bootnodoor absent  -> "geth-as-bootnode" strict star: every client except
+        #    participant #0 points ONLY at #0 (which the package treats as the network
+        #    bootnode). #0 itself gets no bootnode. This reuses each launcher's override
+        #    branch, so no per-client launcher changes are needed.
+        if bootnodoor_enode != None:
+            bootnode_override = (
+                bootnodoor_enr if (use_enr and bootnodoor_enr != None) else bootnodoor_enode
+            )
+        elif index > 0 and len(all_el_contexts) > 0:
+            anchor = all_el_contexts[0]
+            bootnode_override = anchor.enr if use_enr else anchor.enode
+        else:
+            bootnode_override = None
+
         if index == 0:
             el_context = launch_method(
                 plan,
@@ -190,7 +215,7 @@ def launch(
                 index,
                 network_params,
                 extra_files_artifacts,
-                bootnodoor_enode,
+                bootnode_override,
                 el_binary_artifact,
                 otel_otlp_grpc_url,
             )
@@ -217,7 +242,7 @@ def launch(
                 index,
                 network_params,
                 extra_files_artifacts,
-                bootnodoor_enode,
+                bootnode_override,
                 el_binary_artifact,
                 otel_otlp_grpc_url,
             )

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -97,6 +97,7 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "buildoor_params",
     "ethereum_genesis_generator_params",
     "trueblocks_params",
+    "bootnode_params",
 )
 
 
@@ -120,6 +121,7 @@ def input_parser(plan, input_args):
     # add default eth2 input params
     result["blockscout_params"] = get_default_blockscout_params()
     result["dora_params"] = get_default_dora_params()
+    result["bootnode_params"] = get_default_bootnode_params()
     result["checkpointz_params"] = get_default_checkpointz_params()
     result["docker_cache_params"] = get_default_docker_cache_params()
     result["mev_params"] = get_default_mev_params(
@@ -181,6 +183,10 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["dora_params"]:
                 sub_value = input_args["dora_params"][sub_attr]
                 result["dora_params"][sub_attr] = sub_value
+        elif attr == "bootnode_params":
+            for sub_attr in input_args["bootnode_params"]:
+                sub_value = input_args["bootnode_params"][sub_attr]
+                result["bootnode_params"][sub_attr] = sub_value
         elif attr == "docker_cache_params":
             for sub_attr in input_args["docker_cache_params"]:
                 sub_value = input_args["docker_cache_params"][sub_attr]
@@ -1074,6 +1080,12 @@ def input_parser(plan, input_args):
         dora_params=struct(
             image=result["dora_params"]["image"],
             env=result["dora_params"]["env"],
+        ),
+        bootnode_params=struct(
+            backend=result["bootnode_params"]["backend"],
+            image=result["bootnode_params"]["image"],
+            extra_params=result["bootnode_params"]["extra_params"],
+            record=result["bootnode_params"]["record"],
         ),
         docker_cache_params=struct(
             enabled=result["docker_cache_params"]["enabled"],
@@ -2166,6 +2178,21 @@ def get_default_dora_params():
     return {
         "image": constants.DEFAULT_DORA_IMAGE,
         "env": {},
+    }
+
+
+def get_default_bootnode_params():
+    # Config for the standalone discv5 bootnode (enabled via
+    # `additional_services: [bootnode]`). It seeds both the EL and CL overlays.
+    # `backend` selects the implementation (default geth; an EL client type or a tool).
+    # `extra_params` are backend-specific — the defaults below make geth discovery-only
+    # (no RLPx peers, discv4 off, discv5 on). `record` is the GLOBAL form handed to EL
+    # clients: "enr" (works for geth/nethermind/ethrex/erigon) or "enode" (all but erigon).
+    return {
+        "backend": "geth",
+        "image": "",
+        "extra_params": ["--discovery.v4=false", "--maxpeers=0"],
+        "record": "enr",
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -484,6 +484,7 @@ SUBCATEGORY_PARAMS = {
 
 ADDITIONAL_SERVICES_PARAMS = [
     "bootnodoor",
+    "bootnode",
     "assertoor",
     "broadcaster",
     "tx_fuzz",
@@ -670,6 +671,7 @@ def sanity_check(plan, input_args):
         )
         combined_root_params.append("additional_services")
         combined_root_params.append("extra_files")
+        combined_root_params.append("bootnode_params")
 
         if param not in combined_root_params:
             fail(

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -34,6 +34,7 @@ snooper_el_launcher = import_module("./snooper/snooper_el_launcher.star")
 blobber_launcher = import_module("./blobber/blobber_launcher.star")
 cl_context_module = import_module("./cl/cl_context.star")
 bootnodoor_launcher = import_module("./bootnodoor/bootnodoor_launcher.star")
+bootnode_launcher = import_module("./bootnode/bootnode_launcher.star")
 
 
 def launch_participant_network(
@@ -176,6 +177,26 @@ def launch_participant_network(
         plan.print("Bootnodoor launched with ENR: {0}".format(bootnodoor_enr))
         plan.print("Bootnodoor launched with ENODE: {0}".format(bootnodoor_enode))
 
+    # Launch a standalone geth-backed discv5 bootnode if configured. It seeds BOTH
+    # overlays: its enode/ENR feed the EL override and its ENR the CL override (the
+    # same variables bootnodoor uses), so no separate wiring is needed downstream.
+    if "bootnode" in args_with_right_defaults.additional_services:
+        plan.print("Launching standalone geth discv5 bootnode")
+        args_with_right_defaults.additional_services.remove("bootnode")
+        bootnodoor_enode, bootnodoor_enr = bootnode_launcher.launch_bootnode(
+            plan,
+            args_with_right_defaults.bootnode_params,
+            el_cl_data,
+            jwt_file,
+            network_id,
+            network_params,
+            args_with_right_defaults.global_log_level,
+            persistent,
+            args_with_right_defaults.port_publisher,
+            global_node_selectors,
+            global_tolerations,
+        )
+
     # Upload binary artifacts when both binary_path and force_restart are enabled
     binary_artifacts = {}
     for index, participant in enumerate(args_with_right_defaults.participants):
@@ -216,6 +237,8 @@ def launch_participant_network(
         bootnodoor_enode,
         binary_artifacts,
         otel_otlp_grpc_url,
+        bootnodoor_enr=bootnodoor_enr,
+        bootnode_record=args_with_right_defaults.bootnode_params.record,
     )
 
     # Launch all consensus layer clients


### PR DESCRIPTION
Adds a dedicated discv5 bootnode enabled via additional_services: [bootnode]. It launches one EL node (geth by default, selectable via bootnode_params.el_type) whose sole job is discv5 discovery; with --maxpeers=0 it holds no RLPx peers and is a pure rendezvous. Its enode/ENR are fed into the existing bootnodoor override plumbing, so a single node seeds BOTH the EL and CL discovery overlays (discv5 is application-agnostic). A global bootnode_params.record switch selects the form (enr|enode) handed to EL clients.

Files:
- src/bootnode/bootnode_launcher.star (new): launches the bootnode, reuses geth.get_config
- src/participant_network.star: launch when enabled, feed EL+CL overrides
- src/package_io/input_parser.star: bootnode_params (el_type, el_image, el_extra_params, record)
- src/package_io/sanity_check.star: allow 'bootnode' service + bootnode_params
- src/el/el_launcher.star: global bootnode_record (enr|enode) selection