### PR TITLE
fix(bootnodoor): hand discv5-only EL clients the EL ENR instead of the enode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1233,6 +1233,9 @@ bootnodoor_params:
   max_cpu: 1000
   min_mem: 128
   max_mem: 512
+  # Use separate randomly-generated EL (discv4) and CL (discv5) identity keys
+  # instead of one shared key
+  separate_keys: false
   # A list of optional extra args the bootnodoor container should spin up with
   extra_args: []
 

--- a/main.star
+++ b/main.star
@@ -55,6 +55,7 @@ buildoor = import_module("./src/mev/buildoor/buildoor_launcher.star")
 mev_custom_flood = import_module(
     "./src/mev/flashbots/mev_custom_flood/mev_custom_flood_launcher.star"
 )
+bootnodoor = import_module("./src/bootnodoor/bootnodoor_launcher.star")
 broadcaster = import_module("./src/broadcaster/broadcaster.star")
 mempool_bridge = import_module("./src/mempool_bridge/mempool_bridge_launcher.star")
 assertoor = import_module("./src/assertoor/assertoor_launcher.star")
@@ -522,6 +523,8 @@ def run(plan, args={}):
             num_participants, network_params
         )
     )
+    # launch_participant_network removes bootnodoor from additional_services, so check first
+    bootnodoor_enabled = "bootnodoor" in args_with_right_defaults.additional_services
     (
         all_participants,
         final_genesis_timestamp,
@@ -548,6 +551,9 @@ def run(plan, args={}):
         otel_otlp_http_traces_url,
         detected_backend,
     )
+
+    if bootnodoor_enabled:
+        prometheus_additional_metrics_jobs.append(bootnodoor.get_metrics_job())
 
     for p in all_participants:
         if p.el_context != None:

--- a/src/bootnodoor/bootnodoor_launcher.star
+++ b/src/bootnodoor/bootnodoor_launcher.star
@@ -44,7 +44,8 @@ def launch_bootnodoor(
 
     # Fetch external bootnodes for non-kurtosis networks
     # For kurtosis/shadowfork: bootnodoor is the primary bootnode, no external bootnodes needed
-    # For ephemery/devnets: read bootstrap_nodes.txt (CL ENRs) and enodes.txt (EL) from genesis data
+    # For ephemery/devnets: read bootstrap_nodes.txt (CL ENRs) plus el_enrs.txt and
+    # enodes.txt (EL discv5 + discv4) from genesis data
     external_cl_bootnodes = None
     external_el_bootnodes = None
     if network_params.network == constants.NETWORK_NAME.ephemery or (
@@ -60,7 +61,7 @@ def launch_bootnodoor(
         external_cl_bootnodes = shared_utils.get_devnet_enrs_list(
             plan, el_cl_genesis_data.files_artifact_uuid
         )
-        external_el_bootnodes = shared_utils.get_devnet_enodes(
+        external_el_bootnodes = shared_utils.get_devnet_el_bootnodes(
             plan, el_cl_genesis_data.files_artifact_uuid
         )
 

--- a/src/bootnodoor/bootnodoor_launcher.star
+++ b/src/bootnodoor/bootnodoor_launcher.star
@@ -5,18 +5,6 @@ SERVICE_NAME = "bootnodoor"
 HTTP_PORT_NUMBER = 8080
 DISCOVERY_PORT_NUMBER = 9000
 
-USED_PORTS = {
-    constants.HTTP_PORT_ID: shared_utils.new_port_spec(
-        HTTP_PORT_NUMBER,
-        shared_utils.TCP_PROTOCOL,
-        shared_utils.HTTP_APPLICATION_PROTOCOL,
-    ),
-    constants.UDP_DISCOVERY_PORT_ID: shared_utils.new_port_spec(
-        DISCOVERY_PORT_NUMBER,
-        shared_utils.UDP_PROTOCOL,
-    ),
-}
-
 
 def launch_bootnodoor(
     plan,
@@ -26,11 +14,27 @@ def launch_bootnodoor(
     global_node_selectors,
     global_tolerations,
     docker_cache_params,
+    port_publisher,
+    additional_service_index,
+    backend,
 ):
     tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
 
-    # Generate a random 32-byte (64 hex char) private key
-    private_key = generate_random_private_key(plan)
+    # Generate random 32-byte (64 hex char) private keys
+    private_key = None
+    el_private_key = None
+    cl_private_key = None
+    if bootnodoor_params.separate_keys:
+        el_private_key = generate_random_private_key(
+            plan, "generate-bootnodoor-el-private-key"
+        )
+        cl_private_key = generate_random_private_key(
+            plan, "generate-bootnodoor-cl-private-key"
+        )
+    else:
+        private_key = generate_random_private_key(
+            plan, "generate-bootnodoor-private-key"
+        )
 
     # Get the genesis validators root from the genesis data
     genesis_validators_root = el_cl_genesis_data.genesis_validators_root
@@ -40,8 +44,9 @@ def launch_bootnodoor(
 
     # Fetch external bootnodes for non-kurtosis networks
     # For kurtosis/shadowfork: bootnodoor is the primary bootnode, no external bootnodes needed
-    # For ephemery/devnets: read bootstrap_nodes.txt from genesis data
-    external_bootnodes = None
+    # For ephemery/devnets: read bootstrap_nodes.txt (CL ENRs) and enodes.txt (EL) from genesis data
+    external_cl_bootnodes = None
+    external_el_bootnodes = None
     if network_params.network == constants.NETWORK_NAME.ephemery or (
         network_params.network not in constants.PUBLIC_NETWORKS
         and network_params.network != constants.NETWORK_NAME.kurtosis
@@ -52,7 +57,10 @@ def launch_bootnodoor(
                 network_params.network
             )
         )
-        external_bootnodes = shared_utils.get_devnet_enrs_list(
+        external_cl_bootnodes = shared_utils.get_devnet_enrs_list(
+            plan, el_cl_genesis_data.files_artifact_uuid
+        )
+        external_el_bootnodes = shared_utils.get_devnet_enodes(
             plan, el_cl_genesis_data.files_artifact_uuid
         )
 
@@ -60,20 +68,26 @@ def launch_bootnodoor(
         bootnodoor_params,
         el_cl_genesis_data,
         private_key,
+        el_private_key,
+        cl_private_key,
         genesis_validators_root,
         el_genesis_hash,
-        external_bootnodes,
+        external_cl_bootnodes,
+        external_el_bootnodes,
         global_node_selectors,
         tolerations,
         docker_cache_params,
+        port_publisher,
+        additional_service_index,
+        backend,
     )
 
     plan.add_service(SERVICE_NAME, config)
 
     # Request ENR from the running bootnodoor service
-    # The /enr endpoint returns a plain string (not JSON)
+    # /cl-enr strips the EL-only "eth" field, which some CL clients reject
     enr_recipe = GetHttpRequestRecipe(
-        endpoint="/enr",
+        endpoint="/cl-enr",
         port_id=constants.HTTP_PORT_ID,
     )
 
@@ -104,13 +118,42 @@ def get_config(
     bootnodoor_params,
     el_cl_genesis_data,
     private_key,
+    el_private_key,
+    cl_private_key,
     genesis_validators_root,
     el_genesis_hash,
-    external_bootnodes,
+    external_cl_bootnodes,
+    external_el_bootnodes,
     node_selectors,
     tolerations,
     docker_cache_params,
+    port_publisher,
+    additional_service_index,
+    backend,
 ):
+    # Bind the published port number itself so the ENR (ip, port) is valid both
+    # in-enclave (private IP) and externally (nat_exit_ip)
+    discovery_port = DISCOVERY_PORT_NUMBER
+    public_ports = {}
+    if port_publisher.additional_services_enabled:
+        public_ports_for_component = shared_utils.get_public_ports_for_component(
+            "additional_services", port_publisher, additional_service_index
+        )
+        discovery_port = public_ports_for_component[1]
+        public_ports = shared_utils.get_port_specs(
+            {
+                constants.HTTP_PORT_ID: public_ports_for_component[0],
+                constants.UDP_DISCOVERY_PORT_ID: discovery_port,
+            }
+        )
+
+    used_ports = shared_utils.get_port_specs(
+        {
+            constants.HTTP_PORT_ID: HTTP_PORT_NUMBER,
+            constants.UDP_DISCOVERY_PORT_ID: discovery_port,
+        }
+    )
+
     cmd = [
         "--cl-config",
         "{0}/config.yaml".format(constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS),
@@ -120,34 +163,57 @@ def get_config(
         "{0}/genesis.json".format(constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS),
         "--el-genesis-hash",
         el_genesis_hash,
-        "--private-key",
-        private_key,
         "--bind-addr",
         "0.0.0.0",
+        "--bind-port",
+        str(discovery_port),
+        # Without a pinned IP, bootnodoor rewrites its ENR to the WAN address learned from PONGs
+        "--enr-ip",
+        "${K8S_POD_IP}"
+        if backend == "kubernetes"
+        else port_publisher.additional_services_nat_exit_ip,
         "--web-ui",
         "--nodedb",
         "/nodes.db",
     ]
 
+    if private_key != None:
+        cmd.append("--private-key")
+        cmd.append(private_key)
+    if el_private_key != None:
+        cmd.append("--el-private-key")
+        cmd.append(el_private_key)
+    if cl_private_key != None:
+        cmd.append("--cl-private-key")
+        cmd.append(cl_private_key)
+
     # Add external bootnodes for non-kurtosis networks (ephemery, devnets)
-    if external_bootnodes != None:
-        cmd.append("--bootnodes")
-        cmd.append(external_bootnodes)
+    if external_cl_bootnodes != None:
+        cmd.append("--cl-bootnodes")
+        cmd.append(external_cl_bootnodes)
+    if external_el_bootnodes != None:
+        cmd.append("--el-bootnodes")
+        cmd.append(external_el_bootnodes)
 
     # Add any extra args from the params
     if len(bootnodoor_params.extra_args) > 0:
         cmd.extend(bootnodoor_params.extra_args)
+
+    cmd_str = "exec /app/bootnodoor " + " ".join(cmd)
 
     return ServiceConfig(
         image=shared_utils.docker_cache_image_calc(
             docker_cache_params,
             bootnodoor_params.image,
         ),
-        ports=USED_PORTS,
+        ports=used_ports,
+        public_ports=public_ports,
         files={
             constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: el_cl_genesis_data.files_artifact_uuid,
         },
-        cmd=cmd,
+        entrypoint=["sh", "-c"],
+        cmd=[cmd_str],
+        private_ip_address_placeholder=constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         min_cpu=bootnodoor_params.min_cpu,
         max_cpu=bootnodoor_params.max_cpu,
         min_memory=bootnodoor_params.min_mem,
@@ -177,12 +243,24 @@ def get_el_genesis_hash(plan, network_params, el_cl_genesis_data):
     return result.output
 
 
-def generate_random_private_key(plan):
+def generate_random_private_key(plan, name):
     # Generate a random 32-byte (64 hex char) private key using /dev/urandom
     result = plan.run_sh(
-        name="generate-bootnodoor-private-key",
+        name=name,
         description="Generating random private key for bootnodoor",
         run="head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \\n'",
         wait=None,
     )
     return result.output
+
+
+def get_metrics_job():
+    return {
+        "Name": SERVICE_NAME,
+        "Endpoint": "{0}:{1}".format(SERVICE_NAME, HTTP_PORT_NUMBER),
+        "MetricsPath": "/metrics",
+        "Labels": {
+            "service": SERVICE_NAME,
+        },
+        "ScrapeInterval": "15s",
+    }

--- a/src/bootnodoor/bootnodoor_launcher.star
+++ b/src/bootnodoor/bootnodoor_launcher.star
@@ -111,7 +111,22 @@ def launch_bootnodoor(
 
     bootnodoor_enode = enode_response["body"]
 
-    return bootnodoor_enr, bootnodoor_enode
+    # Request the EL ENR for discv5-only EL clients
+    # /el-enr strips the CL-only "eth2" field, which some EL clients reject; with
+    # separate_keys it is a different identity than the CL ENR altogether
+    el_enr_recipe = GetHttpRequestRecipe(
+        endpoint="/el-enr",
+        port_id=constants.HTTP_PORT_ID,
+    )
+
+    el_enr_response = plan.request(
+        recipe=el_enr_recipe,
+        service_name=SERVICE_NAME,
+    )
+
+    bootnodoor_el_enr = el_enr_response["body"]
+
+    return bootnodoor_enr, bootnodoor_enode, bootnodoor_el_enr
 
 
 def get_config(

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -45,7 +45,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -66,7 +66,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -98,7 +98,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -200,9 +200,9 @@ def get_config(
     else:
         cmd.append("--network=" + network_params.network)
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootnodes=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/el/el_launcher.star
+++ b/src/el/el_launcher.star
@@ -32,6 +32,7 @@ def launch(
     mev_params,
     extra_files_artifacts={},
     bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     binary_artifacts={},
     otel_otlp_grpc_url=None,
 ):
@@ -128,11 +129,12 @@ def launch(
     el_service_configs = {}
     el_participant_info = {}
 
-    # Generic bootnode ENODE override - can be set from bootnodoor or any other bootnode service
-    if bootnodoor_enode != None:
+    # Generic bootnode override - can be set from bootnodoor or any other bootnode service.
+    # Discv5-only clients get the EL ENR; discv4-only ethereumjs keeps the enode.
+    if bootnodoor_el_enr != None or bootnodoor_enode != None:
         plan.print(
-            "Using bootnode ENODE override for all EL clients: {0}".format(
-                bootnodoor_enode
+            "Using bootnode override for all EL clients: ENR {0} / ENODE {1}".format(
+                bootnodoor_el_enr, bootnodoor_enode
             )
         )
 
@@ -175,6 +177,14 @@ def launch(
         el_service_name = "el-{0}-{1}-{2}".format(index_str, el_type, cl_type)
         el_binary_artifact = binary_artifacts.get(index, {}).get("el", None)
 
+        # ethereumjs is discv4-only and needs the enode; every other client is
+        # discv5-only and needs the EL ENR
+        el_bootnode_override = (
+            bootnodoor_enode
+            if el_type == constants.EL_TYPE.ethereumjs
+            else bootnodoor_el_enr
+        )
+
         if index == 0:
             el_context = launch_method(
                 plan,
@@ -190,7 +200,7 @@ def launch(
                 index,
                 network_params,
                 extra_files_artifacts,
-                bootnodoor_enode,
+                el_bootnode_override,
                 el_binary_artifact,
                 otel_otlp_grpc_url,
             )
@@ -217,7 +227,7 @@ def launch(
                 index,
                 network_params,
                 extra_files_artifacts,
-                bootnodoor_enode,
+                el_bootnode_override,
                 el_binary_artifact,
                 otel_otlp_grpc_url,
             )

--- a/src/el/erigon/erigon_launcher.star
+++ b/src/el/erigon/erigon_launcher.star
@@ -42,7 +42,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -63,7 +63,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -95,7 +95,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -223,9 +223,9 @@ def get_config(
     for mount_path, artifact in processed_mounts.items():
         files[mount_path] = artifact
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootnodes=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -59,7 +59,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -80,7 +80,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -112,7 +112,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -178,9 +178,9 @@ def get_config(
         "--metrics.port={0}".format(METRICS_PORT_NUM),
         "--nat.extip=" + port_publisher.el_nat_exit_ip,
     ]
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootnodes=" + bootnodoor_el_enr)
     elif network_params.network == constants.NETWORK_NAME.kurtosis:
         el_bootnode_enrs = [
             ctx.enr

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -51,7 +51,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -72,7 +72,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -104,7 +104,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -232,9 +232,9 @@ def get_config(
             if "--ws.api" in arg:
                 cmd[index] = "--ws.api=admin,engine,net,eth,web3,debug,suavex"
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootnodes=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -40,7 +40,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -61,7 +61,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -93,7 +93,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -191,9 +191,9 @@ def get_config(
     else:
         cmd.append("--config=" + network_params.network)
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--Discovery.Bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--Discovery.Bootnodes=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/el/nimbus-eth1/nimbus_launcher.star
+++ b/src/el/nimbus-eth1/nimbus_launcher.star
@@ -40,7 +40,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -61,7 +61,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -93,7 +93,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -172,9 +172,9 @@ def get_config(
     else:
         cmd.append("--network=" + network_params.network)
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootstrap-node=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootstrap-node=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/el/reth/reth_launcher.star
+++ b/src/el/reth/reth_launcher.star
@@ -49,7 +49,7 @@ def launch(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -70,7 +70,7 @@ def launch(
         participant_index,
         network_params,
         extra_files_artifacts,
-        bootnodoor_enode,
+        bootnodoor_el_enr,
         el_binary_artifact,
         otel_otlp_grpc_url,
     )
@@ -102,7 +102,7 @@ def get_config(
     participant_index,
     network_params,
     extra_files_artifacts,
-    bootnodoor_enode=None,
+    bootnodoor_el_enr=None,
     el_binary_artifact=None,
     otel_otlp_grpc_url=None,
 ):
@@ -220,9 +220,9 @@ def get_config(
     if network_params.gas_limit > 0:
         cmd.append("--builder.gaslimit={0}".format(network_params.gas_limit))
 
-    # Handle bootnode configuration with bootnodoor_enode override
-    if bootnodoor_enode != None:
-        cmd.append("--bootnodes=" + bootnodoor_enode)
+    # Handle bootnode configuration with bootnodoor_el_enr override
+    if bootnodoor_el_enr != None:
+        cmd.append("--bootnodes=" + bootnodoor_el_enr)
     elif (
         network_params.network == constants.NETWORK_NAME.kurtosis
         or constants.NETWORK_NAME.shadowfork in network_params.network

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -1271,6 +1271,7 @@ def input_parser(plan, input_args):
             max_cpu=result["bootnodoor_params"]["max_cpu"],
             min_mem=result["bootnodoor_params"]["min_mem"],
             max_mem=result["bootnodoor_params"]["max_mem"],
+            separate_keys=result["bootnodoor_params"]["separate_keys"],
             extra_args=result["bootnodoor_params"]["extra_args"],
         ),
         zkboost_params=struct(
@@ -2495,6 +2496,7 @@ def get_default_bootnodoor_params():
         "max_cpu": 1000,
         "min_mem": 128,
         "max_mem": 512,
+        "separate_keys": False,
         "extra_args": [],
     }
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -456,6 +456,7 @@ SUBCATEGORY_PARAMS = {
         "max_cpu",
         "min_mem",
         "max_mem",
+        "separate_keys",
         "extra_args",
     ],
     "zkboost_params": [

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -161,10 +161,15 @@ def launch_participant_network(
     # Launch bootnodoor if configured
     bootnodoor_enr = None
     bootnodoor_enode = None
+    bootnodoor_el_enr = None
     if "bootnodoor" in args_with_right_defaults.additional_services:
         plan.print("Launching bootnodoor as bootnode service")
         args_with_right_defaults.additional_services.remove("bootnodoor")
-        bootnodoor_enr, bootnodoor_enode = bootnodoor_launcher.launch_bootnodoor(
+        (
+            bootnodoor_enr,
+            bootnodoor_enode,
+            bootnodoor_el_enr,
+        ) = bootnodoor_launcher.launch_bootnodoor(
             plan,
             args_with_right_defaults.bootnodoor_params,
             el_cl_data,
@@ -177,8 +182,9 @@ def launch_participant_network(
             len(args_with_right_defaults.additional_services),
             backend,
         )
-        plan.print("Bootnodoor launched with ENR: {0}".format(bootnodoor_enr))
+        plan.print("Bootnodoor launched with CL ENR: {0}".format(bootnodoor_enr))
         plan.print("Bootnodoor launched with ENODE: {0}".format(bootnodoor_enode))
+        plan.print("Bootnodoor launched with EL ENR: {0}".format(bootnodoor_el_enr))
 
     # Upload binary artifacts when both binary_path and force_restart are enabled
     binary_artifacts = {}
@@ -218,6 +224,7 @@ def launch_participant_network(
         args_with_right_defaults.mev_params,
         extra_files_artifacts,
         bootnodoor_enode,
+        bootnodoor_el_enr,
         binary_artifacts,
         otel_otlp_grpc_url,
     )

--- a/src/participant_network.star
+++ b/src/participant_network.star
@@ -172,6 +172,10 @@ def launch_participant_network(
             global_node_selectors,
             global_tolerations,
             args_with_right_defaults.docker_cache_params,
+            args_with_right_defaults.port_publisher,
+            # Index past the remaining additional services so public ports don't collide
+            len(args_with_right_defaults.additional_services),
+            backend,
         )
         plan.print("Bootnodoor launched with ENR: {0}".format(bootnodoor_enr))
         plan.print("Bootnodoor launched with ENODE: {0}".format(bootnodoor_enode))

--- a/src/shared_utils/shared_utils.star
+++ b/src/shared_utils/shared_utils.star
@@ -164,6 +164,18 @@ def get_devnet_el_enrs(plan, filename):
     return enr_list.output
 
 
+def get_devnet_el_bootnodes(plan, filename):
+    # EL ENRs (discv5) plus enodes (discv4) in one list, for consumers like
+    # bootnodoor that bridge both protocols; either file may be absent
+    bootnode_list = plan.run_sh(
+        description="Getting devnet EL bootnodes (enrs + enodes)",
+        files={constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: filename},
+        wait=None,
+        run="cat /network-configs/el_enrs.txt /network-configs/enodes.txt 2>/dev/null | grep -v '^[[:space:]]*$' | tr -d ' ' | tr '\n' ',' | sed 's/,$//'",
+    )
+    return bootnode_list.output
+
+
 def get_devnet_enrs_list(plan, filename):
     enr_list = plan.run_sh(
         description="Creating devnet enrs list",


### PR DESCRIPTION
Targets #1461. Merges #1451 and closes the gap between the two: with ELs defaulting to discv5-only, the bootnodoor override still handed every EL client an `enode://` URL, which feeds a disabled protocol — and besu in V5 mode rejects non-ENR bootnodes outright, so a discv5-only enclave with bootnodoor enabled had no working EL bootstrap at all.

## What

- **`launch_bootnodoor` also fetches `/el-enr`** and returns `(cl_enr, enode, el_enr)`. `/el-enr` is the EL identity's record with the CL-only `eth2` field stripped (mirroring why #1451 switched the CL side to `/cl-enr`), and stays correct with `separate_keys: true`, where the CL ENR is a different node identity altogether.
- **`el_launcher.launch` selects the override per client**: the seven discv5-only launchers (geth, besu, erigon, nethermind, reth, nimbus-eth1, ethrex) get the EL ENR — their `bootnodoor_enode` parameter is renamed to `bootnodoor_el_enr` — while discv4-only ethereumjs keeps the enode (bootnodoor still answers discv4 on the EL identity, so that pairing keeps working).

## Testing

`kurtosis lint` clean. Two live enclaves on this branch, all images freshly pulled:

**geth + besu + bootnodoor** — both ELs received `--bootnodes=enr:…` matching bootnodoor's `/el-enr`, peered within 10s (besu is the strict case: it hard-rejects enode bootnodes in V5 mode), both imported blocks.

**7-EL matrix + bootnodoor** (geth, besu, erigon, reth, nethermind, nimbus-eth1, ethrex — bootnodoor as sole bootnode, no static peer bootnodes):

```
el-1-geth        peers=5
el-2-besu        peers=5
el-3-erigon      peers=0   <- see below
el-4-reth        peers=5
el-5-nethermind  peers=5
el-6-nimbus      peers=5
el-7-ethrex      peers=5
```

Six clients registered in bootnodoor's EL table and formed a full mesh through it (peers=5 = everyone except erigon); all seven lighthouses registered in the CL table and peered. Chain progressed on all nodes.

### ⚠️ erigon's discv5 is non-functional

Erigon parses the ENR bootnode, logs `Setup P2P discovery v4=false v5=true`, and binds UDP 30303 — but never sends a single discv5 packet: after 15+ min it is absent even from bootnodoor's inactive-node DB, and it logs `[p2p] No GoodPeers` forever. **#1461's own 7-EL test masked this**: erigon showed `peers=1` there only because other clients had erigon's ENR in their *static* bootnode lists and dialed it inbound. Behind bootnodoor — where discovery is the only way to be found — erigon is fully isolated (it still follows the chain via its CL / engine API). Needs an upstream erigon fix; nothing this package can do.

### Stale-image traps (relevant to CI on both parent PRs)

- A cached `ethpandaops/bootnodoor:latest` still on v0.0.2 404s on `/cl-enr`, hard-failing #1451's fetch.
- A cached `ethpandaops/besu:main` predating besu#10800 doesn't know `--discovery-mode`.
- `ethpandaops/ethereumjs:master` (2026-05-19) crashes at startup with `crypto.getRandomValues must be defined` — unrelated to these PRs (dies generating its node key), but it means the ethereumjs+bootnodoor enode path can't be live-tested until that image is rebuilt on a newer Node.

## Devnet EL seeding

#1451 seeded bootnodoor's devnet EL side from `enodes.txt` only. `--el-bootnodes` accepts ENRs and enode URLs alike, so the new `get_devnet_el_bootnodes` merges `el_enrs.txt` (discv5) with `enodes.txt` (discv4) into one list and tolerates either file being absent — `el_enrs.txt` only appears once ethpandaops/ansible-collection-general#568 lands and devnet metadata is regenerated, and discv4-only stragglers stay reachable through the enodes. The merge snippet was verified for all four file-presence combinations (exit 0, clean comma list); the devnet path itself has no live devnet with `el_enrs.txt` to test against yet.
