### PR TITLE
revert: restore tx_fuzz

### DIFF
--- a/.github/tests/examples/bal-devnet-0.yaml
+++ b/.github/tests/examples/bal-devnet-0.yaml
@@ -22,4 +22,5 @@ dora_params:
   image: ethpandaops/dora:eip7928-support
 additional_services:
   - dora
+  - tx_fuzz
   - spamoor

--- a/.github/tests/examples/mainnet-split.yaml
+++ b/.github/tests/examples/mainnet-split.yaml
@@ -49,6 +49,7 @@ mev_type: flashbots
 additional_services:
   - dora
   - spamoor
+  - tx_fuzz
   - assertoor
 
 global_log_level: debug

--- a/.github/tests/mev-commit-boost.yaml
+++ b/.github/tests/mev-commit-boost.yaml
@@ -3,6 +3,7 @@ participants:
     cl_type: lighthouse
 mev_type: commit-boost
 additional_services:
+  - tx_fuzz
   - spamoor
   - forkmon
   - dora

--- a/.github/tests/mev-mock.yaml
+++ b/.github/tests/mev-mock.yaml
@@ -6,5 +6,6 @@ mev_type: mock
 additional_services:
   - dora
   - spamoor
+  - tx_fuzz
 mev_params:
   mock_mev_image: "ethpandaops/rustic-builder:main"

--- a/.github/tests/mev.yaml
+++ b/.github/tests/mev.yaml
@@ -10,6 +10,7 @@ mev_params:
   mev_boost_image: ethpandaops/mev-boost:develop
 
 additional_services:
+  - tx_fuzz
   - spamoor
   - dora
   - prometheus

--- a/.github/tests/minimal-fulu.yaml
+++ b/.github/tests/minimal-fulu.yaml
@@ -37,6 +37,7 @@ participants:
     cl_image: ethpandaops/grandine:develop-minimal
 additional_services:
   - dora
+  - tx_fuzz
   - spamoor
   - assertoor
 

--- a/.github/tests/mix-public.yaml
+++ b/.github/tests/mix-public.yaml
@@ -35,6 +35,7 @@ port_publisher:
     enabled: true
     public_port_start: 46000
 additional_services:
+  - tx_fuzz
   - forkmon
   - dora
   - checkpointz

--- a/.github/tests/mix-with-tools-mev.yaml
+++ b/.github/tests/mix-with-tools-mev.yaml
@@ -12,6 +12,7 @@ participants:
   - el_type: ethrex
     cl_type: teku
 additional_services:
+  - tx_fuzz
   - forkmon
   - dora
   - checkpointz

--- a/.github/tests/mix-with-tools-minimal.yaml
+++ b/.github/tests/mix-with-tools-minimal.yaml
@@ -20,6 +20,7 @@ participants:
 network_params:
   preset: minimal
 additional_services:
+  - tx_fuzz
   - forkmon
   - dora
   - checkpointz

--- a/.github/tests/mix-with-tools.yaml
+++ b/.github/tests/mix-with-tools.yaml
@@ -20,6 +20,7 @@ participants:
     use_separate_vc: true
     vc_type: lighthouse
 additional_services:
+  - tx_fuzz
   - forkmon
   - dora
   - checkpointz

--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,7 @@ additional_services:
   - tempo
   - tracoor
   - trueblocks
+  - tx_fuzz
 
 # Configuration place for blockscout explorer - https://github.com/blockscout/blockscout
 blockscout_params:
@@ -1155,6 +1156,14 @@ extra_files: {}
   # my_script.sh: |
   #   #!/bin/bash
   #   echo "Custom script"
+
+# Configuration place for transaction spammer - https://github.com/MariusVanDerWijden/tx-fuzz
+tx_fuzz_params:
+  # TX Spammer docker image to use
+  # Defaults to the latest master image
+  image: "ethpandaops/tx-fuzz:master"
+  # A list of optional extra params that will be passed to the TX Spammer container for modifying its behaviour
+  tx_fuzz_extra_args: []
 
 # Configuration place for rakoon transaction fuzzer - https://github.com/protocol-security/fuzztools
 rakoon_params:
@@ -2287,6 +2296,7 @@ Here's a table of where the keys are used
 | Account Index | Component Used In   | Private Key Used | Public Key Used | Comment                     |
 |---------------|---------------------|------------------|-----------------|-----------------------------|
 | 0             | Builder             | ✅                |                 | As coinbase                |
+| 3             | tx_fuzz | ✅                |                 | To spam transactions with  |
 | 8             | assertoor           | ✅                | ✅              | As the funding for tests   |
 | 12            | l2_contracts        | ✅                |                 | Contract deployer address  |
 | 13            | spamoor             | ✅                |                 | Spams transactions         |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,7 @@ After the Ethereum network is up and running, this package starts several auxili
 - [Prometheus](https://github.com/ethpandaops/ethereum-package/tree/main/src/prometheus) for collecting client node metrics
 - [Grafana](https://github.com/ethpandaops/ethereum-package/tree/main/src/grafana) for visualizing client node metrics
 - [An ETH transaction spammer](https://github.com/ethpandaops/spamoor) ([spamoor](https://github.com/ethpandaops/ethereum-package/tree/main/src/spamoor)) for generating transaction load on the network
+- [tx-fuzz](https://github.com/ethpandaops/ethereum-package/tree/main/src/tx_fuzz), a transaction fuzzer based on [Marius' transaction spammer code](https://github.com/MariusVanDerWijden/tx-fuzz)
 
 ## [Testnet Verifier][testnet-verifier]
 

--- a/main.star
+++ b/main.star
@@ -11,6 +11,7 @@ validator_ranges = import_module(
     "./src/prelaunch_data_generator/validator_keystores/validator_ranges_generator.star"
 )
 
+tx_fuzz = import_module("./src/tx_fuzz/tx_fuzz.star")
 rakoon = import_module("./src/rakoon/rakoon.star")
 forkmon = import_module("./src/forkmon/forkmon_launcher.star")
 
@@ -1009,7 +1010,19 @@ def run(plan, args={}):
     for index, additional_service in enumerate(
         args_with_right_defaults.additional_services
     ):
-        if additional_service == "rakoon":
+        if additional_service == "tx_fuzz":
+            plan.print("Launching tx-fuzz")
+            tx_fuzz_params = args_with_right_defaults.tx_fuzz_params
+            tx_fuzz.launch_tx_fuzz(
+                plan,
+                prefunded_accounts,
+                fuzz_target,
+                tx_fuzz_params,
+                global_node_selectors,
+                global_tolerations,
+            )
+            plan.print("Successfully launched tx-fuzz")
+        elif additional_service == "rakoon":
             plan.print("Launching rakoon transaction fuzzer")
             rakoon_params = args_with_right_defaults.rakoon_params
             rakoon.launch_rakoon(

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -154,6 +154,8 @@ network_params:
 additional_services: []
 dora_params:
   image: "ethpandaops/dora:latest"
+tx_fuzz_params:
+  tx_fuzz_extra_args: []
 spamoor_params:
   min_cpu: 100
   max_cpu: 1000

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -82,6 +82,7 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "prometheus_params",
     "grafana_params",
     "tempo_params",
+    "tx_fuzz_params",
     "rakoon_params",
     "xatu_sentry_params",
     "port_publisher",
@@ -130,6 +131,7 @@ def input_parser(plan, input_args):
         result["additional_services"] = DEFAULT_ADDITIONAL_SERVICES
     else:
         result["additional_services"] = []
+    result["tx_fuzz_params"] = get_default_tx_fuzz_params()
     result["rakoon_params"] = get_default_rakoon_params()
     result["disable_peer_scoring"] = False
     result["grafana_params"] = get_default_grafana_params()
@@ -185,6 +187,10 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["mev_params"]:
                 sub_value = input_args["mev_params"][sub_attr]
                 result["mev_params"][sub_attr] = sub_value
+        elif attr == "tx_fuzz_params":
+            for sub_attr in input_args["tx_fuzz_params"]:
+                sub_value = input_args["tx_fuzz_params"][sub_attr]
+                result["tx_fuzz_params"][sub_attr] = sub_value
         elif attr == "rakoon_params":
             for sub_attr in input_args["rakoon_params"]:
                 sub_value = input_args["rakoon_params"][sub_attr]
@@ -1071,6 +1077,10 @@ def input_parser(plan, input_args):
             dockerhub_prefix=result["docker_cache_params"]["dockerhub_prefix"],
             github_prefix=result["docker_cache_params"]["github_prefix"],
             google_prefix=result["docker_cache_params"]["google_prefix"],
+        ),
+        tx_fuzz_params=struct(
+            image=result["tx_fuzz_params"]["image"],
+            tx_fuzz_extra_args=result["tx_fuzz_params"]["tx_fuzz_extra_args"],
         ),
         rakoon_params=struct(
             image=result["rakoon_params"]["image"],
@@ -2279,6 +2289,13 @@ def get_default_mev_params(mev_type, preset):
     }
 
 
+def get_default_tx_fuzz_params():
+    return {
+        "image": "ethpandaops/tx-fuzz:master",
+        "tx_fuzz_extra_args": [],
+    }
+
+
 def get_default_rakoon_params():
     return {
         "image": "ethpandaops/fuzztools:main",
@@ -2820,6 +2837,7 @@ def docker_cache_image_override(plan, result):
         "mev_params.mev_boost_image",
         "mev_params.mock_mev_image",
         "xatu_sentry_params.xatu_sentry_image",
+        "tx_fuzz_params.image",
         "rakoon_params.image",
         "prometheus_params.image",
         "grafana_params.image",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -312,6 +312,10 @@ SUBCATEGORY_PARAMS = {
         "github_prefix",
         "google_prefix",
     ],
+    "tx_fuzz_params": [
+        "image",
+        "tx_fuzz_extra_args",
+    ],
     "rakoon_params": [
         "image",
         "tx_type",
@@ -481,6 +485,7 @@ ADDITIONAL_SERVICES_PARAMS = [
     "bootnodoor",
     "assertoor",
     "broadcaster",
+    "tx_fuzz",
     "forkmon",
     "blockscout",
     "dora",

--- a/src/tx_fuzz/tx_fuzz.star
+++ b/src/tx_fuzz/tx_fuzz.star
@@ -1,0 +1,57 @@
+shared_utils = import_module("../shared_utils/shared_utils.star")
+input_parser = import_module("../package_io/input_parser.star")
+SERVICE_NAME = "tx-fuzz"
+
+# The min/max CPU/memory that tx-fuzz can use
+MIN_CPU = 100
+MAX_CPU = 1000
+MIN_MEMORY = 20
+MAX_MEMORY = 300
+
+
+def launch_tx_fuzz(
+    plan,
+    prefunded_addresses,
+    el_uri,
+    tx_fuzz_params,
+    global_node_selectors,
+    global_tolerations,
+):
+    tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
+
+    config = get_config(
+        prefunded_addresses,
+        el_uri,
+        tx_fuzz_params,
+        global_node_selectors,
+        tolerations,
+    )
+    plan.add_service(SERVICE_NAME, config)
+
+
+def get_config(
+    prefunded_addresses,
+    el_uri,
+    tx_fuzz_params,
+    node_selectors,
+    tolerations,
+):
+    cmd = [
+        "spam",
+        "--rpc={}".format(el_uri),
+        "--sk={0}".format(prefunded_addresses[3].private_key),
+    ]
+
+    if len(tx_fuzz_params.tx_fuzz_extra_args) > 0:
+        cmd.extend([param for param in tx_fuzz_params.tx_fuzz_extra_args])
+
+    return ServiceConfig(
+        image=tx_fuzz_params.image,
+        cmd=cmd,
+        min_cpu=MIN_CPU,
+        max_cpu=MAX_CPU,
+        min_memory=MIN_MEMORY,
+        max_memory=MAX_MEMORY,
+        node_selectors=node_selectors,
+        tolerations=tolerations,
+    )


### PR DESCRIPTION
## What

Restores `tx_fuzz`, which was removed in #1427. The other three tools removed in that PR — `custom_flood`, `full_beaconchain_explorer`, `blutgang` — stay removed.

#1427's description said tx_fuzz would be kept, but the branch was merged before the re-add landed. This is that re-add.

## Changes

- Restored `src/tx_fuzz/tx_fuzz.star` (unchanged from before the removal)
- `main.star` — import and the `tx_fuzz` branch in the additional-services dispatch
- `input_parser.star` — `tx_fuzz_params` skip-list entry, defaults, sub-attr merge, output struct, `get_default_tx_fuzz_params()`, docker-cache image override
- `sanity_check.star` — `tx_fuzz_params` subcategory and `tx_fuzz` in `ADDITIONAL_SERVICES_PARAMS`
- `network_params.yaml` — `tx_fuzz_params.tx_fuzz_extra_args`
- `README.md` — service-list entry, `tx_fuzz_params` config block, prefunded-key table row (account 3)
- `docs/architecture.md` — tx-fuzz bullet, alongside the spamoor one
- Re-added `- tx_fuzz` to the 10 CI fixtures that previously ran it

The prose lines that #1427 *rewrote* rather than deleted (README's "Spin up a transaction spammer" bullet, and the 2-node example's `additional_services`) still point at spamoor — both tools exist, and spamoor is the sensible thing to name there.
