### PR TITLE
feat: default EL clients to snap sync when checkpoint sync is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ participants:
     keymanager_enabled: null
 
     # Per-participant override for checkpoint sync. If set, this will override the global checkpoint_sync_enabled flag for this participant.
+    # When enabled, EL clients that support it (geth, besu, nethermind, ethrex) default to snap sync instead of full sync.
     # Defaults to null (uses global checkpoint_sync_enabled setting)
     checkpoint_sync_enabled: null
 
@@ -1687,6 +1688,7 @@ global_node_selectors: {}
 keymanager_enabled: false
 
 # Global flag to enable checkpoint sync across the network
+# When enabled, EL clients that support it (geth, besu, nethermind, ethrex) default to snap sync instead of full sync
 # Default to false
 checkpoint_sync_enabled: false
 

--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -222,10 +222,7 @@ def launch(
                 )
             )
         checkpoint_sync_url = args_with_right_defaults.checkpoint_sync_url
-        # Use participant-level checkpoint_sync_enabled if set, otherwise use global
-        checkpoint_sync_enabled = args_with_right_defaults.checkpoint_sync_enabled
-        if participant.checkpoint_sync_enabled != None:
-            checkpoint_sync_enabled = participant.checkpoint_sync_enabled
+        checkpoint_sync_enabled = participant.checkpoint_sync_enabled
         if checkpoint_sync_enabled:
             if args_with_right_defaults.checkpoint_sync_url == "":
                 if network_params.network == constants.NETWORK_NAME.kurtosis:

--- a/src/el/besu/besu_launcher.star
+++ b/src/el/besu/besu_launcher.star
@@ -173,7 +173,10 @@ def get_config(
         "--engine-rpc-port={0}".format(ENGINE_HTTP_RPC_PORT_NUM),
         "{0}".format(
             "--sync-mode=FULL"
-            if network_params.network in constants.NETWORK_NAME.kurtosis
+            if (
+                network_params.network in constants.NETWORK_NAME.kurtosis
+                and not participant.checkpoint_sync_enabled
+            )
             or participant.el_storage_type == "archive"
             else "--sync-mode=SNAP"
         ),

--- a/src/el/ethrex/ethrex_launcher.star
+++ b/src/el/ethrex/ethrex_launcher.star
@@ -161,7 +161,7 @@ def get_config(
             if network_params.network in constants.PUBLIC_NETWORKS
             else constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER + "/genesis.json"
         ),
-        "--syncmode=full",
+        "--syncmode=snap" if participant.checkpoint_sync_enabled else "--syncmode=full",
         "--log.level={0}".format(VERBOSITY_LEVELS[global_log_level]),
         "--http.port={0}".format(RPC_PORT_NUM),
         "--http.addr=0.0.0.0",

--- a/src/el/geth/geth_launcher.star
+++ b/src/el/geth/geth_launcher.star
@@ -196,6 +196,7 @@ def get_config(
         "--authrpc.jwtsecret=" + constants.JWT_MOUNT_PATH_ON_CONTAINER,
         "--syncmode=full"
         if network_params.network == constants.NETWORK_NAME.kurtosis
+        and not participant.checkpoint_sync_enabled
         and not gcmode_archive
         else "--syncmode=snap"
         if not gcmode_archive

--- a/src/el/nethermind/nethermind_launcher.star
+++ b/src/el/nethermind/nethermind_launcher.star
@@ -162,6 +162,8 @@ def get_config(
     # Configure storage type - nethermind defaults to hybrid pruning, use None mode for archive
     if participant.el_storage_type == "archive":
         cmd.append("--Pruning.Mode=None")
+    elif participant.checkpoint_sync_enabled:
+        cmd.append("--Sync.SnapSync=true")
 
     if network_params.gas_limit > 0:
         cmd.append("--Blocks.TargetBlockGasLimit={0}".format(network_params.gas_limit))

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -873,7 +873,9 @@ def input_parser(plan, input_args):
                 blobber_image=participant["blobber_image"],
                 keymanager_enabled=participant["keymanager_enabled"],
                 vc_beacon_node_indices=participant["vc_beacon_node_indices"],
-                checkpoint_sync_enabled=participant["checkpoint_sync_enabled"],
+                checkpoint_sync_enabled=participant["checkpoint_sync_enabled"]
+                if participant["checkpoint_sync_enabled"] != None
+                else result["checkpoint_sync_enabled"],
                 skip_start=participant["skip_start"],
             )
             for participant in result["participants"]


### PR DESCRIPTION
## Summary

When `checkpoint_sync_enabled` is set (globally or per-participant), EL clients that support snap sync now default to it instead of full sync:

- **geth**: `--syncmode=snap` instead of `--syncmode=full` on kurtosis networks (archive mode still uses `--gcmode=archive`)
- **besu**: `--sync-mode=SNAP` instead of `--sync-mode=FULL` on kurtosis networks (archive still forces FULL)
- **nethermind**: appends `--Sync.SnapSync=true` (skipped for archive nodes)
- **ethrex**: `--syncmode=snap` instead of `--syncmode=full`

reth, erigon and nimbus-eth1 have no snap sync mode; ethereumjs snap sync is still experimental — all left unchanged.

The effective `checkpoint_sync_enabled` (participant override falling back to global) is now resolved once in `input_parser.star` when building the participant struct, so both EL and CL launchers consume a single resolved boolean; the duplicate resolution in `cl_launcher.star` is removed.

## Testing

- Verified flag names/values against `ethereum/client-go:latest`, `hyperledger/besu:latest`, `nethermind/nethermind:latest`, and `ethpandaops/ethrex:main` `--help` output
- `kurtosis run --dry-run` with a geth/besu/nethermind/ethrex config:
  - `checkpoint_sync_enabled: true` → rendered commands contain `--syncmode=snap`, `--sync-mode=SNAP`, `--Sync.SnapSync=true`, `--syncmode=snap`
  - checkpoint sync off → identical to previous behavior (full sync everywhere, no nethermind flag)