### PR TITLE
feat: add gas_limit_schedule (EIP-8261 GPO) network param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,8 @@ network_params:
   # Array of entries written to the CL config.yaml as the optional
   # GAS_LIMIT_SCHEDULE field, giving CL clients a per-fork default and
   # recommended maximum gas limit
+  # Requires Gloas: every epoch must be >= gloas_fork_epoch, since the
+  # CL only drives the gas limit post-Gloas
   # Defaults to [] (field is emitted as GAS_LIMIT_SCHEDULE: [])
   # Example:
   # gas_limit_schedule:

--- a/README.md
+++ b/README.md
@@ -1004,6 +1004,19 @@ network_params:
   # Do not confuse with genesis_gaslimit which sets the gas limit at the genesis file level
   gas_limit: 0
 
+  # GPO (Gas Parameter Only) schedule per EIP-8261
+  # Array of entries written to the CL config.yaml as the optional
+  # GAS_LIMIT_SCHEDULE field, giving CL clients a per-fork default and
+  # recommended maximum gas limit
+  # Defaults to [] (field is emitted as GAS_LIMIT_SCHEDULE: [])
+  # Example:
+  # gas_limit_schedule:
+  #   - epoch: 256
+  #     gas_limit: 100000000
+  #   - epoch: 512
+  #     gas_limit: 150000000
+  gas_limit_schedule: []
+
 
   # BPO
   # BPO1-5 epoch (default 0/18446744073709551615)

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -550,6 +550,13 @@ def input_parser(plan, input_args):
                     entry
                 )
             )
+        if entry["epoch"] < result["network_params"]["gloas_fork_epoch"]:
+            fail(
+                "gas_limit_schedule entry at epoch {0} is scheduled before gloas_fork_epoch ({1}). The gas limit schedule requires Gloas, since the CL only drives the gas limit post-Gloas — schedule every entry at an epoch >= gloas_fork_epoch.".format(
+                    entry["epoch"],
+                    result["network_params"]["gloas_fork_epoch"],
+                )
+            )
 
     if result["network_params"]["fulu_fork_epoch"] != constants.FAR_FUTURE_EPOCH:
         has_supernodes = False

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -537,6 +537,20 @@ def input_parser(plan, input_args):
             )
         )
 
+    for entry in result["network_params"]["gas_limit_schedule"]:
+        if type(entry) != "dict" or sorted(entry.keys()) != ["epoch", "gas_limit"]:
+            fail(
+                "gas_limit_schedule entries must be objects with exactly 'epoch' and 'gas_limit' keys, got: {0}".format(
+                    entry
+                )
+            )
+        if type(entry["epoch"]) != "int" or type(entry["gas_limit"]) != "int":
+            fail(
+                "gas_limit_schedule 'epoch' and 'gas_limit' must be integers, got: {0}".format(
+                    entry
+                )
+            )
+
     if result["network_params"]["fulu_fork_epoch"] != constants.FAR_FUTURE_EPOCH:
         has_supernodes = False
         has_node_with_128_plus_validators = False
@@ -998,6 +1012,7 @@ def input_parser(plan, input_args):
             max_payload_size=result["network_params"]["max_payload_size"],
             perfect_peerdas_enabled=result["network_params"]["perfect_peerdas_enabled"],
             gas_limit=result["network_params"]["gas_limit"],
+            gas_limit_schedule=result["network_params"]["gas_limit_schedule"],
             withdrawal_type=result["network_params"]["withdrawal_type"],
             withdrawal_address=result["network_params"]["withdrawal_address"],
             validator_balance=result["network_params"]["validator_balance"],
@@ -1945,6 +1960,7 @@ def default_network_params():
         "max_payload_size": 10485760,
         "perfect_peerdas_enabled": False,
         "gas_limit": 0,
+        "gas_limit_schedule": [],
         "bpo_1_epoch": 0,
         "bpo_1_max_blobs": 15,
         "bpo_1_target_blobs": 10,
@@ -2031,6 +2047,7 @@ def default_minimal_network_params():
         "max_payload_size": 10485760,
         "perfect_peerdas_enabled": False,
         "gas_limit": 0,
+        "gas_limit_schedule": [],
         "bpo_1_epoch": 0,
         "bpo_1_max_blobs": 15,
         "bpo_1_target_blobs": 10,

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -270,6 +270,7 @@ SUBCATEGORY_PARAMS = {
         "max_payload_size",
         "perfect_peerdas_enabled",
         "gas_limit",
+        "gas_limit_schedule",
         "bpo_1_epoch",
         "bpo_1_max_blobs",
         "bpo_1_target_blobs",

--- a/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
+++ b/src/prelaunch_data_generator/el_cl_genesis/el_cl_genesis_generator.star
@@ -221,6 +221,7 @@ def new_env_file_for_el_cl_genesis_data(
         "Bpo5MaxBlobs": network_params.bpo_5_max_blobs,
         "Bpo5TargetBlobs": network_params.bpo_5_target_blobs,
         "Bpo5BaseFeeUpdateFraction": network_params.bpo_5_base_fee_update_fraction,
+        "GasLimitSchedule": json.encode(network_params.gas_limit_schedule),
         "WithdrawalType": "{0}".format(network_params.withdrawal_type),
         "WithdrawalAddress": network_params.withdrawal_address,
         "ValidatorBalance": int(network_params.validator_balance * 1000000000),

--- a/static_files/genesis-generation-config/el-cl/values.env.tmpl
+++ b/static_files/genesis-generation-config/el-cl/values.env.tmpl
@@ -79,6 +79,7 @@ export BPO_5_EPOCH="{{ .Bpo5Epoch }}"
 export BPO_5_MAX_BLOBS={{ .Bpo5MaxBlobs }}
 export BPO_5_TARGET_BLOBS={{ .Bpo5TargetBlobs }}
 export BPO_5_BASE_FEE_UPDATE_FRACTION={{ .Bpo5BaseFeeUpdateFraction }}
+export GAS_LIMIT_SCHEDULE='{{ .GasLimitSchedule }}'
 export MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS={{ .MinEpochsForDataColumnSidecarsRequests }}
 {{ range $key, $value := .ExtraEnvVars }}
 export {{ $key }}={{ $value }}


### PR DESCRIPTION
## Summary

Adds a `gas_limit_schedule` network param — an array of GPO (Gas Parameter Only) entries per [EIP-8261](https://eips.ethereum.org/EIPS/eip-8261) — wired through to the genesis generator, which renders it into the CL `config.yaml` as the optional `GAS_LIMIT_SCHEDULE` field (per-fork default + recommended max gas limit for CL clients).

```yaml
network_params:
  gas_limit_schedule:
    - epoch: 256
      gas_limit: 100000000
    - epoch: 512
      gas_limit: 150000000
```

## Changes

- `input_parser.star`: new `gas_limit_schedule` param (default `[]`) with parse-time validation that every entry is an object with exactly integer `epoch` and `gas_limit` keys.
- `el_cl_genesis_generator.star` + `values.env.tmpl`: the schedule is JSON-encoded and exported as the `GAS_LIMIT_SCHEDULE` env var for the genesis generator.
- `sanity_check.star`: allow the new key.
- README: document the param.

## Dependency

Rendering the field requires ethpandaops/ethereum-genesis-generator#315. Until the pinned generator image (currently `6.1.6`) includes it, the env var is exported but ignored by the generator, so this change is a no-op — the image pin should be bumped once a release containing #315 is cut.

## Testing

`kurtosis lint` passes. Default `[]` keeps behavior identical for all existing test configs.

https://claude.ai/code/session_017jVHwwK1C3h1caJFyabeVm