### PR TITLE
chore: bump ethereum-genesis-generator to 6.1.7

### DIFF
--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -114,7 +114,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.1.6"
+    "ethpandaops/ethereum-genesis-generator:6.1.7"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
Bumps the pinned genesis generator image from 6.1.6 to [v6.1.7](https://github.com/ethpandaops/ethereum-genesis-generator/releases/tag/v6.1.7), which includes EIP-8261 `GAS_LIMIT_SCHEDULE` support (ethpandaops/ethereum-genesis-generator#315) needed by #1472.

https://claude.ai/code/session_017jVHwwK1C3h1caJFyabeVm