### PR TITLE
chore: bump egg to 6.1.7 in README and network_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1834,7 +1834,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.1.6
+  image: ethpandaops/ethereum-genesis-generator:6.1.7
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -271,7 +271,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.1.6
+  image: ethpandaops/ethereum-genesis-generator:6.1.7
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -114,7 +114,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.1.6"
+    "ethpandaops/ethereum-genesis-generator:6.1.7"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
Follow-up to #1473, which bumped the pin in `constants.star` only — the genesis generator version is referenced in three files. This updates the remaining two (`README.md` and `network_params.yaml`) to 6.1.7.

https://claude.ai/code/session_017jVHwwK1C3h1caJFyabeVm