### PR TITLE
feat: add mempool-lens additional service

### DIFF
--- a/.github/tests/mempool-lens.yaml
+++ b/.github/tests/mempool-lens.yaml
@@ -1,0 +1,7 @@
+participants:
+  - el_type: geth
+    cl_type: teku
+
+additional_services:
+  - mempool_lens
+  - dora

--- a/.github/tests/mempool-lens.yaml
+++ b/.github/tests/mempool-lens.yaml
@@ -3,5 +3,5 @@ participants:
     cl_type: teku
 
 additional_services:
-  - mempool_lens
+  - mempool-lens
   - dora

--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ additional_services:
   - forky
   - grafana
   - mempool_bridge
-  - mempool_lens
+  - mempool-lens
   - nginx
   - otel
   - prometheus

--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,7 @@ additional_services:
   - forky
   - grafana
   - mempool_bridge
+  - mempool_lens
   - nginx
   - otel
   - prometheus
@@ -1534,6 +1535,28 @@ mempool_bridge_params:
   # The retry interval duration for retrying failed operations
   # Default: "30s"
   retry_interval: "30s"
+
+# Configuration place for mempool-lens - https://github.com/cskiraly/mempool-lens
+# A live transaction-lifecycle viewer for geth's txtracker/peerstats WS
+# namespaces. Note: those namespaces are only available in the instrumented
+# geth build (https://github.com/cskiraly/go-ethereum branch mempool-lens);
+# against a stock geth the UI works but shows no tracker data.
+mempool_lens_params:
+  # The image to use for mempool-lens
+  image: bbusa/mempool-lens:latest
+
+  # Full ws:// URL of the geth node to watch; overrides target_index
+  # Default: "" (auto-select)
+  target_rpc_url: ""
+
+  # Index into the EL clients to watch
+  # Default: -1 - auto-select a geth node exposing a WS endpoint,
+  # falling back to the first EL client with one
+  target_index: -1
+
+  # Extra args to pass to the lens (auth tokens, --geo-db, ...)
+  # Default: []
+  extra_args: []
 
 # Supports seven values
 # Default: "null" - no mev boost, mev builder, mev flood or relays are spun up

--- a/main.star
+++ b/main.star
@@ -51,6 +51,7 @@ buildoor = import_module("./src/mev/buildoor/buildoor_launcher.star")
 bootnodoor = import_module("./src/bootnodoor/bootnodoor_launcher.star")
 broadcaster = import_module("./src/broadcaster/broadcaster.star")
 mempool_bridge = import_module("./src/mempool_bridge/mempool_bridge_launcher.star")
+mempool_lens = import_module("./src/mempool_lens/mempool_lens_launcher.star")
 assertoor = import_module("./src/assertoor/assertoor_launcher.star")
 get_prefunded_accounts = import_module(
     "./src/prefunded_accounts/get_prefunded_accounts.star"
@@ -1308,6 +1309,19 @@ def run(plan, args={}):
                 args_with_right_defaults.global_log_level,
             )
             plan.print("Successfully launched mempool-bridge")
+        elif additional_service == "mempool_lens":
+            plan.print("Launching mempool-lens")
+            mempool_lens.launch_mempool_lens(
+                plan,
+                all_el_contexts,
+                args_with_right_defaults.mempool_lens_params,
+                global_node_selectors,
+                global_tolerations,
+                args_with_right_defaults.port_publisher,
+                index,
+                args_with_right_defaults.docker_cache_params,
+            )
+            plan.print("Successfully launched mempool-lens")
         elif additional_service == "spamoor":
             plan.print("Launching spamoor")
             spamoor_config_template = read_file(

--- a/main.star
+++ b/main.star
@@ -1307,7 +1307,7 @@ def run(plan, args={}):
                 args_with_right_defaults.global_log_level,
             )
             plan.print("Successfully launched mempool-bridge")
-        elif additional_service == "mempool_lens":
+        elif additional_service == "mempool-lens":
             plan.print("Launching mempool-lens")
             mempool_lens.launch_mempool_lens(
                 plan,

--- a/src/mempool_lens/mempool_lens_launcher.star
+++ b/src/mempool_lens/mempool_lens_launcher.star
@@ -1,0 +1,122 @@
+shared_utils = import_module("../shared_utils/shared_utils.star")
+constants = import_module("../package_io/constants.star")
+
+SERVICE_NAME = "mempool-lens"
+HTTP_PORT_NUMBER = 8670
+
+USED_PORTS = {
+    constants.HTTP_PORT_ID: shared_utils.new_port_spec(
+        HTTP_PORT_NUMBER,
+        shared_utils.TCP_PROTOCOL,
+        shared_utils.HTTP_APPLICATION_PROTOCOL,
+    )
+}
+
+# The lens is a thin WS proxy + static UI
+MIN_CPU = 10
+MAX_CPU = 500
+MIN_MEMORY = 64
+MAX_MEMORY = 512
+
+
+def launch_mempool_lens(
+    plan,
+    all_el_contexts,
+    mempool_lens_params,
+    global_node_selectors,
+    global_tolerations,
+    port_publisher,
+    additional_service_index,
+    docker_cache_params,
+):
+    tolerations = shared_utils.get_tolerations(global_tolerations=global_tolerations)
+
+    rpc_url = _resolve_rpc_url(mempool_lens_params, all_el_contexts)
+
+    config = get_config(
+        mempool_lens_params,
+        rpc_url,
+        global_node_selectors,
+        tolerations,
+        port_publisher,
+        additional_service_index,
+        docker_cache_params,
+    )
+
+    plan.add_service(SERVICE_NAME, config)
+
+
+def get_config(
+    mempool_lens_params,
+    rpc_url,
+    node_selectors,
+    tolerations,
+    port_publisher,
+    additional_service_index,
+    docker_cache_params,
+):
+    public_ports = shared_utils.get_additional_service_standard_public_port(
+        port_publisher,
+        constants.HTTP_PORT_ID,
+        additional_service_index,
+        0,
+    )
+
+    cmd = [
+        "--addr=0.0.0.0:{0}".format(HTTP_PORT_NUMBER),
+        "--rpc={0}".format(rpc_url),
+        "--proxy",
+    ]
+    if len(mempool_lens_params.extra_args) > 0:
+        cmd.extend(mempool_lens_params.extra_args)
+
+    return ServiceConfig(
+        image=shared_utils.docker_cache_image_calc(
+            docker_cache_params,
+            mempool_lens_params.image,
+        ),
+        ports=USED_PORTS,
+        public_ports=public_ports,
+        cmd=cmd,
+        min_cpu=MIN_CPU,
+        max_cpu=MAX_CPU,
+        min_memory=MIN_MEMORY,
+        max_memory=MAX_MEMORY,
+        node_selectors=node_selectors,
+        tolerations=tolerations,
+    )
+
+
+def _resolve_rpc_url(mempool_lens_params, all_el_contexts):
+    if mempool_lens_params.target_rpc_url:
+        return mempool_lens_params.target_rpc_url
+
+    if len(all_el_contexts) == 0:
+        fail("mempool-lens requires at least one EL client or target_rpc_url")
+
+    idx = mempool_lens_params.target_index
+    if idx >= 0:
+        if idx >= len(all_el_contexts):
+            fail(
+                "mempool-lens target_index {0} out of range (0..{1})".format(
+                    idx, len(all_el_contexts) - 1
+                )
+            )
+        el = all_el_contexts[idx]
+        if not el.ws_url:
+            fail(
+                "mempool-lens target_index {0} ({1}) does not expose a WS endpoint".format(
+                    idx, el.service_name
+                )
+            )
+        return el.ws_url
+
+    # Auto-select: prefer a geth node (the txtracker/peerstats namespaces are
+    # a geth patch), otherwise the first EL exposing a WS endpoint.
+    for el in all_el_contexts:
+        if el.client_name == constants.EL_TYPE.geth and el.ws_url:
+            return el.ws_url
+    for el in all_el_contexts:
+        if el.ws_url:
+            return el.ws_url
+    fail("mempool-lens found no EL client exposing a WS endpoint; set target_rpc_url")

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -92,6 +92,7 @@ ATTR_TO_BE_SKIPPED_AT_ROOT = (
     "slashoor_params",
     "bootnodoor_params",
     "mempool_bridge_params",
+    "mempool_lens_params",
     "zkboost_params",
     "buildoor_params",
     "ethereum_genesis_generator_params",
@@ -135,6 +136,7 @@ def input_parser(plan, input_args):
     result["disruptoor_params"] = get_default_disruptoor_params()
     result["slashoor_params"] = get_default_slashoor_params()
     result["mempool_bridge_params"] = get_default_mempool_bridge_params()
+    result["mempool_lens_params"] = get_default_mempool_lens_params()
     result["zkboost_params"] = get_default_zkboost_params()
     result["buildoor_params"] = get_default_buildoor_params()
     result["trueblocks_params"] = get_default_trueblocks_params()
@@ -217,6 +219,10 @@ def input_parser(plan, input_args):
             for sub_attr in input_args["mempool_bridge_params"]:
                 sub_value = input_args["mempool_bridge_params"][sub_attr]
                 result["mempool_bridge_params"][sub_attr] = sub_value
+        elif attr == "mempool_lens_params":
+            for sub_attr in input_args["mempool_lens_params"]:
+                sub_value = input_args["mempool_lens_params"][sub_attr]
+                result["mempool_lens_params"][sub_attr] = sub_value
         elif attr == "bootnodoor_params":
             for sub_attr in input_args["bootnodoor_params"]:
                 sub_value = input_args["bootnodoor_params"][sub_attr]
@@ -1202,6 +1208,12 @@ def input_parser(plan, input_args):
             send_concurrency=result["mempool_bridge_params"]["send_concurrency"],
             polling_interval=result["mempool_bridge_params"]["polling_interval"],
             retry_interval=result["mempool_bridge_params"]["retry_interval"],
+        ),
+        mempool_lens_params=struct(
+            image=result["mempool_lens_params"]["image"],
+            target_rpc_url=result["mempool_lens_params"]["target_rpc_url"],
+            target_index=result["mempool_lens_params"]["target_index"],
+            extra_args=result["mempool_lens_params"]["extra_args"],
         ),
         additional_services=result["additional_services"],
         wait_for_finalization=result["wait_for_finalization"],
@@ -2508,6 +2520,20 @@ def get_default_mempool_bridge_params():
     }
 
 
+def get_default_mempool_lens_params():
+    return {
+        # One-off build from https://github.com/cskiraly/mempool-lens (PR #1
+        # adds the Dockerfile); switch to the upstream image once published.
+        "image": "bbusa/mempool-lens:latest",
+        # Full ws:// URL override for the upstream geth node.
+        "target_rpc_url": "",
+        # Index into the EL clients; -1 auto-selects a geth node with a WS
+        # endpoint (the txtracker/peerstats namespaces are a geth patch).
+        "target_index": -1,
+        "extra_args": [],
+    }
+
+
 def get_default_bootnodoor_params():
     return {
         "image": constants.DEFAULT_BOOTNODOOR_IMAGE,
@@ -2879,6 +2905,7 @@ def docker_cache_image_override(plan, result):
         "tempo_params.image",
         "spamoor_params.image",
         "disruptoor_params.image",
+        "mempool_lens_params.image",
         "ethereum_genesis_generator_params.image",
         "trueblocks_params.image",
     ]

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -450,6 +450,12 @@ SUBCATEGORY_PARAMS = {
         "polling_interval",
         "retry_interval",
     ],
+    "mempool_lens_params": [
+        "image",
+        "target_rpc_url",
+        "target_index",
+        "extra_args",
+    ],
     "ethereum_genesis_generator_params": [
         "image",
         "extra_env",
@@ -508,6 +514,7 @@ ADDITIONAL_SERVICES_PARAMS = [
     "nginx",
     "tracoor",
     "mempool_bridge",
+    "mempool_lens",
     "rakoon",
     "slashoor",
     "spamoor",

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -514,7 +514,7 @@ ADDITIONAL_SERVICES_PARAMS = [
     "nginx",
     "tracoor",
     "mempool_bridge",
-    "mempool_lens",
+    "mempool-lens",
     "rakoon",
     "slashoor",
     "spamoor",


### PR DESCRIPTION
Adds [mempool-lens](https://github.com/cskiraly/mempool-lens) as an additional service — a live transaction-lifecycle viewer for geth's `txtracker`/`peerstats` WebSocket namespaces.

- New `src/mempool_lens/mempool_lens_launcher.star`: runs the lens in `--proxy` mode on port 8670, pointed at a geth node's WS endpoint. Auto-selects a geth EL with a WS endpoint (the txtracker namespaces are a geth patch), falling back to the first EL exposing one; overridable via `mempool_lens_params.target_index` or `target_rpc_url`.
- Wired through `sanity_check`/`input_parser`/`main.star` following the existing additional-service pattern, including `docker_cache` image override support.
- Default image is `bbusa/mempool-lens:latest` (one-off build from cskiraly/mempool-lens#1) — to be switched to the upstream image once it publishes one. Note the tracker tabs only show data when the EL runs the instrumented geth build ([cskiraly/go-ethereum `mempool-lens` branch](https://github.com/cskiraly/go-ethereum/tree/mempool-lens)); against stock geth the UI still works, just without txtracker data.
- README service list + `mempool_lens_params` docs, plus a `.github/tests/mempool-lens.yaml` fixture.

Tested with `kurtosis run . --args-file .github/tests/mempool-lens.yaml` (minus dora): service comes up RUNNING, UI serves HTTP 200 and `/config` reports the proxied WS endpoint.

https://claude.ai/code/session_019FXty3nj4rtVjkeSzSysmh