### PR TITLE
fix: bump ethereum-genesis-generator to 6.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1841,7 +1841,7 @@ slashoor_params:
 # Ethereum genesis generator params
 ethereum_genesis_generator_params:
   # The image to use for ethereum genesis generator
-  image: ethpandaops/ethereum-genesis-generator:6.2.0
+  image: ethpandaops/ethereum-genesis-generator:6.2.1
   # Pass custom environment variables to the genesis generator (e.g. MY_VAR: my_value)
   extra_env: {}
 

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -272,7 +272,7 @@ keymanager_enabled: false
 checkpoint_sync_enabled: false
 checkpoint_sync_url: ""
 ethereum_genesis_generator_params:
-  image: ethpandaops/ethereum-genesis-generator:6.2.0
+  image: ethpandaops/ethereum-genesis-generator:6.2.1
   extra_env: {}
 port_publisher:
   nat_exit_ip: KURTOSIS_IP_ADDR_PLACEHOLDER

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -114,7 +114,7 @@ DEFAULT_ASSERTOOR_IMAGE = "ethpandaops/assertoor:latest"
 DEFAULT_SNOOPER_IMAGE = "ethpandaops/rpc-snooper:latest"
 DEFAULT_BOOTNODOOR_IMAGE = "ethpandaops/bootnodoor:latest"
 DEFAULT_ETHEREUM_GENESIS_GENERATOR_IMAGE = (
-    "ethpandaops/ethereum-genesis-generator:6.2.0"
+    "ethpandaops/ethereum-genesis-generator:6.2.1"
 )
 DEFAULT_YQ_IMAGE = "linuxserver/yq"
 DEFAULT_FLASHBOTS_RELAY_IMAGE = "ethpandaops/mev-boost-relay:main"


### PR DESCRIPTION
## Summary
Bumps ethereum-genesis-generator to `6.2.1`, which pulls in eth-beacon-genesis `v0.0.7` (ethpandaops/ethereum-genesis-generator#317):

- gloas builder withdrawal credential prefix changed from `0x03` to `0xB0` (`BUILDER_WITHDRAWAL_PREFIX`)
- builder registry `Version` set to `PAYLOAD_BUILDER_VERSION` (0)
- gloas presets synced with consensus-specs v1.7.0-alpha.14
- EIP8321 fork config defaults added

Note: the `6.2.1` image is not on Docker Hub yet — this assumes it will be the next egg release once ethereum-genesis-generator#317 is merged and released.