### PR TITLE
feat: derive builder BLS keys from a dedicated builder mnemonic

### DIFF
--- a/.github/check-consensus-spec-values.py
+++ b/.github/check-consensus-spec-values.py
@@ -34,6 +34,7 @@ EXCLUDED_FIELDS = {
     "GLOAS_FORK_VERSION",
     "HEZE_FORK_VERSION",
     "EIP7928_FORK_VERSION",
+    "EIP8321_FORK_VERSION",
     # Fork activation epochs - testnets activate all forks at epoch 0
     "ALTAIR_FORK_EPOCH",
     "BELLATRIX_FORK_EPOCH",
@@ -44,6 +45,7 @@ EXCLUDED_FIELDS = {
     "GLOAS_FORK_EPOCH",
     "HEZE_FORK_EPOCH",
     "EIP7928_FORK_EPOCH",
+    "EIP8321_FORK_EPOCH",
     # Deposit contract - testnet-configurable
     "DEPOSIT_CHAIN_ID",
     "DEPOSIT_NETWORK_ID",

--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,12 @@ network_params:
   # Default to 100 ETH
   builder_balance: 100
 
+  # Mnemonic used to derive builder BLS keys. Genesis-registered builders use
+  # indices 0..builder_count-1; buildoor instances use the following indices.
+  # Deliberately distinct from preregistered_validator_keys_mnemonic so builder
+  # keys can never collide with validator keys.
+  builder_keys_mnemonic: "baby envelope toddler valid pottery buddy cash spare such hedgehog ring ramp item seminar rely select advance knife cruel cereal left father model tissue"
+
 
 # Global parameters for the network
 

--- a/main.star
+++ b/main.star
@@ -629,6 +629,11 @@ def run(plan, args={}):
     mev_endpoints = []
     mev_endpoint_names = []
     buildoor_api_urls = []
+    # Builder BLS key indices are handed out sequentially after the validators and
+    # any genesis-registered builders. The counter is shared between the mev_type
+    # buildoor and the dedicated buildoor instances so no two buildoors (nor the
+    # genesis builders) ever derive the same key.
+    buildoor_builder_index = 0
     # passed external relays get priority
     # perhaps add mev_type External or remove this
     if (
@@ -682,6 +687,12 @@ def run(plan, args={}):
             all_el_contexts[0].dns_name,
             all_el_contexts[0].engine_rpc_port_num,
         )
+        mev_buildoor_key_index = (
+            network_params.builder_key_start_index
+            + network_params.builder_count
+            + buildoor_builder_index
+        )
+        buildoor_builder_index += 1
         buildoor_endpoints = buildoor.launch_buildoor(
             plan,
             beacon_uri,
@@ -693,7 +704,7 @@ def run(plan, args={}):
             global_node_selectors,
             global_tolerations,
             network_params.preregistered_validator_keys_mnemonic,
-            network_params.builder_key_start_index,
+            mev_buildoor_key_index,
             ranges,
             constants.BUILDOOR_SERVICE_NAME,
         )
@@ -826,7 +837,6 @@ def run(plan, args={}):
         args_with_right_defaults.additional_services.remove(
             constants.BUILDOOR_SERVICE_NAME
         )
-    buildoor_builder_index = 0
     for buildoor_instance in args_with_right_defaults.buildoor_params.instances:
         index = buildoor_instance.participant - 1
         instance_count = buildoor_instance.count

--- a/main.star
+++ b/main.star
@@ -565,12 +565,9 @@ def run(plan, args={}):
             )
         )
         plan.print(
-            "Builder mnemonic: '{0}', keys derived at indices {1}..{2}".format(
-                network_params.preregistered_validator_keys_mnemonic,
-                network_params.builder_key_start_index,
-                network_params.builder_key_start_index
-                + network_params.builder_count
-                - 1,
+            "Builder mnemonic: '{0}', keys derived at indices 0..{1}".format(
+                network_params.builder_keys_mnemonic,
+                network_params.builder_count - 1,
             )
         )
 
@@ -629,10 +626,12 @@ def run(plan, args={}):
     mev_endpoints = []
     mev_endpoint_names = []
     buildoor_api_urls = []
-    # Builder BLS key indices are handed out sequentially after the validators and
-    # any genesis-registered builders. The counter is shared between the mev_type
-    # buildoor and the dedicated buildoor instances so no two buildoors (nor the
-    # genesis builders) ever derive the same key.
+    # Builder BLS keys derive from the dedicated builder mnemonic (distinct from
+    # the validator mnemonic, so no validator collision is possible): genesis
+    # builders occupy indices 0..builder_count-1 and every buildoor gets the next
+    # index after them. The counter is shared between the mev_type buildoor and
+    # the dedicated buildoor instances so no two buildoors (nor the genesis
+    # builders) ever derive the same key.
     buildoor_builder_index = 0
     # passed external relays get priority
     # perhaps add mev_type External or remove this
@@ -687,11 +686,7 @@ def run(plan, args={}):
             all_el_contexts[0].dns_name,
             all_el_contexts[0].engine_rpc_port_num,
         )
-        mev_buildoor_key_index = (
-            network_params.builder_key_start_index
-            + network_params.builder_count
-            + buildoor_builder_index
-        )
+        mev_buildoor_key_index = network_params.builder_count + buildoor_builder_index
         buildoor_builder_index += 1
         buildoor_endpoints = buildoor.launch_buildoor(
             plan,
@@ -703,7 +698,7 @@ def run(plan, args={}):
             args_with_right_defaults.buildoor_params,
             global_node_selectors,
             global_tolerations,
-            network_params.preregistered_validator_keys_mnemonic,
+            network_params.builder_keys_mnemonic,
             mev_buildoor_key_index,
             ranges,
             constants.BUILDOOR_SERVICE_NAME,
@@ -874,14 +869,12 @@ def run(plan, args={}):
                 instance_count,
             )
             # Each instance is its own builder with its own builder BLS key,
-            # derived by buildoor from the builder mnemonic at consecutive indices
-            # after the validators and any genesis-registered builders, so they do
-            # not collide. The builder is onboarded after genesis via its lifecycle
+            # derived by buildoor from the builder mnemonic at the next free
+            # index after the genesis-registered builders, so they do not
+            # collide. The builder is onboarded after genesis via its lifecycle
             # deposit (buildoor_params.lifecycle), not registered at genesis.
             instance_builder_key_index = (
-                network_params.builder_key_start_index
-                + network_params.builder_count
-                + buildoor_builder_index
+                network_params.builder_count + buildoor_builder_index
             )
             buildoor_builder_index += 1
             buildoor_endpoints = buildoor.launch_buildoor(
@@ -894,7 +887,7 @@ def run(plan, args={}):
                 args_with_right_defaults.buildoor_params,
                 global_node_selectors,
                 global_tolerations,
-                network_params.preregistered_validator_keys_mnemonic,
+                network_params.builder_keys_mnemonic,
                 instance_builder_key_index,
                 ranges,
                 buildoor_service_name,

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -62,8 +62,8 @@ def launch_buildoor(
     ]
 
     # Builder BLS key: let buildoor derive it from the mnemonic at the given
-    # index (matching the 0xB0 builder keys registered at genesis) when provided,
-    # otherwise fall back to the default static secret key.
+    # index (allocated after the validators and any genesis-registered 0xB0
+    # builders) when provided, otherwise fall back to the default static secret key.
     if builder_mnemonic != None:
         cmd.append("--builder-mnemonic={0}".format(builder_mnemonic))
         cmd.append("--builder-key-index={0}".format(builder_key_index))

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -61,9 +61,9 @@ def launch_buildoor(
         "--builder-api-url={0}".format(api_url),
     ]
 
-    # Builder BLS key: let buildoor derive it from the mnemonic at the given
-    # index (allocated after the validators and any genesis-registered 0xB0
-    # builders) when provided, otherwise fall back to the default static secret key.
+    # Builder BLS key: let buildoor derive it from the builder mnemonic at the
+    # given index (allocated after any genesis-registered 0xB0 builders) when
+    # provided, otherwise fall back to the default static secret key.
     if builder_mnemonic != None:
         cmd.append("--builder-mnemonic={0}".format(builder_mnemonic))
         cmd.append("--builder-key-index={0}".format(builder_key_index))

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -147,6 +147,9 @@ MEV_BOOST_SERVICE_NAME_PREFIX = "mev-boost"
 COMMIT_BOOST_SERVICE_NAME_PREFIX = "commit-boost"
 MEV_BOOST_PORT = 18550
 DEFAULT_MNEMONIC = "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
+# Mnemonic for builder BLS keys, deliberately distinct from DEFAULT_MNEMONIC so
+# builder keys can never collide with validator keys.
+DEFAULT_BUILDER_MNEMONIC = "baby envelope toddler valid pottery buddy cash spare such hedgehog ring ramp item seminar rely select advance knife cruel cereal left father model tissue"
 
 PRIVATE_IP_ADDRESS_PLACEHOLDER = "KURTOSIS_IP_ADDR_PLACEHOLDER"
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -147,8 +147,6 @@ MEV_BOOST_SERVICE_NAME_PREFIX = "mev-boost"
 COMMIT_BOOST_SERVICE_NAME_PREFIX = "commit-boost"
 MEV_BOOST_PORT = 18550
 DEFAULT_MNEMONIC = "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
-# Mnemonic for builder BLS keys, deliberately distinct from DEFAULT_MNEMONIC so
-# builder keys can never collide with validator keys.
 DEFAULT_BUILDER_MNEMONIC = "baby envelope toddler valid pottery buddy cash spare such hedgehog ring ramp item seminar rely select advance knife cruel cereal left father model tissue"
 
 PRIVATE_IP_ADDRESS_PLACEHOLDER = "KURTOSIS_IP_ADDR_PLACEHOLDER"

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -896,7 +896,7 @@ def input_parser(plan, input_args):
             preregistered_validator_count=result["network_params"][
                 "preregistered_validator_count"
             ],
-            builder_key_start_index=result["network_params"]["builder_key_start_index"],
+            builder_keys_mnemonic=result["network_params"]["builder_keys_mnemonic"],
             num_validator_keys_per_node=result["network_params"][
                 "num_validator_keys_per_node"
             ],
@@ -1803,16 +1803,6 @@ def parse_network_params(plan, input_args):
             + " is not supported, it can only be mainnet or minimal"
         )
 
-    # Base index for builder keys: the first one no genesis validator has claimed.
-    # preregistered_validator_count can exceed the participants' validator sum, and deriving
-    # builders inside that range duplicates a validator's key, which fails genesis. Computed once
-    # here so genesis, the log line and buildoor cannot drift apart. Unconditional: buildoor
-    # instances derive keys even when builder_count is 0.
-    result["network_params"]["builder_key_start_index"] = max(
-        actual_num_validators,
-        result["network_params"]["preregistered_validator_count"],
-    )
-
     if result["network_params"]["builder_count"] > 0:
         if result["network_params"]["gloas_fork_epoch"] != 0:
             fail(
@@ -1822,10 +1812,8 @@ def parse_network_params(plan, input_args):
                 )
             )
         builder_mnemonic_entry = {
-            "mnemonic": result["network_params"][
-                "preregistered_validator_keys_mnemonic"
-            ],
-            "start": result["network_params"]["builder_key_start_index"],
+            "mnemonic": result["network_params"]["builder_keys_mnemonic"],
+            "start": 0,
             "count": result["network_params"]["builder_count"],
             "wd_prefix": "0xB0",
             "wd_address": result["network_params"]["withdrawal_address"],
@@ -2007,6 +1995,7 @@ def default_network_params():
         "min_epochs_for_data_column_sidecars_requests": 4096,
         "builder_count": 0,
         "builder_balance": 100,
+        "builder_keys_mnemonic": constants.DEFAULT_BUILDER_MNEMONIC,
     }
 
 
@@ -2095,6 +2084,7 @@ def default_minimal_network_params():
         "min_epochs_for_data_column_sidecars_requests": 4096,
         "builder_count": 0,
         "builder_balance": 100,
+        "builder_keys_mnemonic": constants.DEFAULT_BUILDER_MNEMONIC,
     }
 
 

--- a/src/package_io/sanity_check.star
+++ b/src/package_io/sanity_check.star
@@ -298,6 +298,7 @@ SUBCATEGORY_PARAMS = {
         "min_epochs_for_data_column_sidecars_requests",
         "builder_count",
         "builder_balance",
+        "builder_keys_mnemonic",
     ],
     "blockscout_params": ["image", "verif_image", "frontend_image", "env"],
     "dora_params": [


### PR DESCRIPTION
## Summary
Fixes the buildoor/builder key collision reported today, by removing its root cause instead of patching the offset.

**Dedicated builder mnemonic** — builder BLS keys previously derived from `preregistered_validator_keys_mnemonic`, which required `builder_key_start_index = max(actual_num_validators, preregistered_validator_count)` to dodge validator keys. That base shifted with validator topology and the `mev_type: buildoor` path additionally derived at the *first genesis builder's slot*, so buildoor ran behind the same pubkey as a genesis builder / external sidecar. Now:

- new `builder_keys_mnemonic` network param, defaulting to a new `DEFAULT_BUILDER_MNEMONIC` constant (distinct from the validator mnemonic, so validator collisions are structurally impossible)
- genesis-registered builders occupy indices `0..builder_count-1` on that mnemonic
- every buildoor (mev_type and dedicated instances) gets the next index after them via one shared counter, so buildoors can't collide with genesis builders or each other
- `builder_key_start_index` is removed entirely; the builder BLS key is a pure signing identity so the separate mnemonic needs no funding
- external sidecars get a stable identity: builder mnemonic, index 0 — independent of validator counts

**Spec value check** — consensus-specs master (v1.7.0-alpha.14) added `EIP8321_FORK_VERSION`/`EPOCH`, which egg intentionally does not render into the generated config (same handling as EIP7928); excluded from the upstream comparison so the "Check consensus spec values" jobs pass again.

## Breaking change
Tooling that derived builder keys from the validator mnemonic at the old computed offset must switch to `builder_keys_mnemonic` (printed in the run summary) at index 0+.

## Test plan
- `kurtosis lint` clean
- CI: mev-buildoor / buildoor-instances jobs exercise both allocation paths