### PR TITLE
fix: hand genesis-registered builders to buildoor instances

### DIFF
--- a/.github/tests/buildoor-genesis-builder.yaml
+++ b/.github/tests/buildoor-genesis-builder.yaml
@@ -1,0 +1,29 @@
+# A buildoor instance driving a builder that is registered at genesis
+# (network_params.builder_count) rather than onboarded via lifecycle deposit.
+# The first builder_count buildoor instances take the genesis builders'
+# mnemonic indices (0..builder_count-1), so buildoor finds its key in
+# state.builders at startup and skips the deposit path. Requires gloas at genesis.
+participants:
+  - el_type: geth
+    cl_type: lighthouse
+    count: 2
+network_params:
+  preset: minimal
+  gloas_fork_epoch: 0
+  builder_count: 1
+buildoor_params:
+  builder_api: false
+  epbs_builder: true
+  lifecycle: true
+  instances:
+    - participant: 1
+      count: 1
+additional_services:
+  - buildoor
+  - dora
+  - spamoor
+spamoor_params:
+  spammers:
+    - scenario: eoatx
+      config:
+        throughput: 2

--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,11 @@ network_params:
   min_epochs_for_data_column_sidecars_requests: 4096
 
   # Number of ePBS builders to register at genesis with 0xB0 withdrawal credentials
-  # Requires gloas_fork_epoch to be 0 (GLOAS at genesis)
+  # (written to state.builders). Requires gloas_fork_epoch to be 0 (GLOAS at genesis).
+  # Buildoor instances (buildoor_params.instances / mev_type: buildoor) are handed
+  # these builders first, in launch order, so they skip the lifecycle deposit; note
+  # that per spec (is_active_builder) a genesis builder can only bid once epoch 1 is
+  # finalized (deposit_epoch 0 < finalized_checkpoint.epoch), i.e. from ~epoch 3.
   # Default to 0
   builder_count: 0
 
@@ -1085,7 +1089,9 @@ network_params:
   builder_balance: 100
 
   # Mnemonic used to derive builder BLS keys. Genesis-registered builders use
-  # indices 0..builder_count-1; buildoor instances use the following indices.
+  # indices 0..builder_count-1; buildoor instances are assigned indices in launch
+  # order, so the first builder_count of them run the genesis builders and any
+  # further ones derive the next free index and onboard via lifecycle deposit.
   # Deliberately distinct from preregistered_validator_keys_mnemonic so builder
   # keys can never collide with validator keys.
   builder_keys_mnemonic: "baby envelope toddler valid pottery buddy cash spare such hedgehog ring ramp item seminar rely select advance knife cruel cereal left father model tissue"
@@ -1652,7 +1658,9 @@ buildoor_params:
   # cannot be combined with the (deprecated) network-wide `mev_type: buildoor`.
   # Each instance is its own builder; with lifecycle enabled (default) it onboards
   # itself after genesis, so genesis builder registration is not required and gloas
-  # may activate at any epoch.
+  # may activate at any epoch. With network_params.builder_count > 0 the first
+  # builder_count instances (in launch order) instead run the genesis-registered
+  # builders and need no deposit.
   # Each entry may set an optional `image` to override buildoor_params.image for
   # just that instance (A/B testing).
   # Defaults to [] (no per-participant buildoors).

--- a/main.star
+++ b/main.star
@@ -627,11 +627,13 @@ def run(plan, args={}):
     mev_endpoint_names = []
     buildoor_api_urls = []
     # Builder BLS keys derive from the dedicated builder mnemonic (distinct from
-    # the validator mnemonic, so no validator collision is possible): genesis
-    # builders occupy indices 0..builder_count-1 and every buildoor gets the next
-    # index after them. The counter is shared between the mev_type buildoor and
-    # the dedicated buildoor instances so no two buildoors (nor the genesis
-    # builders) ever derive the same key.
+    # the validator mnemonic, so no validator collision is possible). Buildoors
+    # are handed indices in launch order: the first builder_count of them get
+    # the genesis-registered builders (indices 0..builder_count-1, already in
+    # state.builders so no lifecycle deposit is needed) and every further one
+    # gets the next free index and onboards itself via its lifecycle deposit.
+    # The counter is shared between the mev_type buildoor and the dedicated
+    # buildoor instances so no two buildoors ever derive the same key.
     buildoor_builder_index = 0
     # passed external relays get priority
     # perhaps add mev_type External or remove this
@@ -686,7 +688,7 @@ def run(plan, args={}):
             all_el_contexts[0].dns_name,
             all_el_contexts[0].engine_rpc_port_num,
         )
-        mev_buildoor_key_index = network_params.builder_count + buildoor_builder_index
+        mev_buildoor_key_index = buildoor_builder_index
         buildoor_builder_index += 1
         buildoor_endpoints = buildoor.launch_buildoor(
             plan,
@@ -870,12 +872,12 @@ def run(plan, args={}):
             )
             # Each instance is its own builder with its own builder BLS key,
             # derived by buildoor from the builder mnemonic at the next free
-            # index after the genesis-registered builders, so they do not
-            # collide. The builder is onboarded after genesis via its lifecycle
-            # deposit (buildoor_params.lifecycle), not registered at genesis.
-            instance_builder_key_index = (
-                network_params.builder_count + buildoor_builder_index
-            )
+            # index, so they do not collide. Indices below builder_count are
+            # genesis-registered builders (already in state.builders, active as
+            # soon as their deposit_epoch 0 is finalized); any further index is
+            # onboarded after genesis via its lifecycle deposit
+            # (buildoor_params.lifecycle).
+            instance_builder_key_index = buildoor_builder_index
             buildoor_builder_index += 1
             buildoor_endpoints = buildoor.launch_buildoor(
                 plan,

--- a/src/mev/buildoor/buildoor_launcher.star
+++ b/src/mev/buildoor/buildoor_launcher.star
@@ -62,8 +62,9 @@ def launch_buildoor(
     ]
 
     # Builder BLS key: let buildoor derive it from the builder mnemonic at the
-    # given index (allocated after any genesis-registered 0xB0 builders) when
-    # provided, otherwise fall back to the default static secret key.
+    # given index (indices below network_params.builder_count are the
+    # genesis-registered 0xB0 builders) when provided, otherwise fall back to
+    # the default static secret key.
     if builder_mnemonic != None:
         cmd.append("--builder-mnemonic={0}".format(builder_mnemonic))
         cmd.append("--builder-key-index={0}".format(builder_key_index))


### PR DESCRIPTION
## Summary
With `network_params.builder_count > 0` the genesis state carries builders at mnemonic indices `0..builder_count-1` (egg 6.2.1 / eth-beacon-genesis v0.0.7 write them to `state.builders`), but buildoor instances were always allocated indices starting at `builder_count`. No process ever drove the genesis builder key, and every buildoor still had to onboard itself via its lifecycle deposit — so a "genesis builder" config behaved exactly like `builder_count: 0`: buildoor sat in **Registering…** waiting for its own deposit while the genesis builder sat idle in `state.builders`.

Buildoors are now handed indices in launch order: the first `builder_count` of them run the genesis-registered builders (found in `state.builders` at startup, no deposit), any further ones derive the next free index and onboard via lifecycle deposit. The counter stays shared between `mev_type: buildoor` and `buildoor_params.instances`, so no two buildoors derive the same key.

Also documents the spec constraint that trips people up: `is_active_builder` requires `deposit_epoch < finalized_checkpoint.epoch` (strict), so a genesis builder (`deposit_epoch 0`) can only bid once epoch 1 is finalized, i.e. from ~epoch 3. Nothing in the genesis generator can shortcut that.

## Background
The earlier "Prysm keeps a separate builders registry, `state.builders == []`" observation came from the `ethereum-genesis-generator:6.2.0` pin (pre eth-beacon-genesis #99); 6.2.1 populates `state.builders` correctly and Prysm's debug API returns it.

## Test plan
- `kurtosis lint` clean
- Local run, mainnet preset, gloas at genesis, `builder_count: 1`, Prysm `potuz-cb-cherrypick`, one `buildoor_params.instances` entry:
  - before: `--builder-key-index=1`, `Builder not found in beacon state` → deposit path, WebUI stuck on Registering…
  - after: `--builder-key-index=0`, `Builder found in beacon state builder_index=0 state=pending_finalization`, no deposit
- Adds `.github/tests/buildoor-genesis-builder.yaml` (picked up by the nightly matrix)

https://claude.ai/code/session_01F18dc3tXu4QQoyAtxdDRBb