### PR TITLE
feat(cl): add crysm consensus client

### DIFF
--- a/.github/tests/crysm-basic.yaml
+++ b/.github/tests/crysm-basic.yaml
@@ -1,32 +1,22 @@
-# crysm is Gloas-only -- it carries no pre-Gloas containers -- so it can appear only where Gloas is
-# at genesis. That is why this file cannot be folded into one of the mix suites, none of which fork
-# to Gloas at all.
 participants:
-  # devnet-8 rather than a stock geth: Gloas at genesis needs an execution client that speaks ePBS.
   - el_type: geth
     el_image: ethpandaops/geth:glamsterdam-devnet-8
     cl_type: crysm
-    # One binary, no separate VC service, which is also why crysm has no VC_TYPE launcher.
     use_separate_vc: false
     validator_count: 128
 
 network_params:
   gloas_fork_epoch: 0
   preset: mainnet
-  # geth rejects a BPO after amsterdam, which Gloas at genesis puts at genesis too.
   bpo_1_epoch: 0
   bpo_2_epoch: 0
 
 additional_services:
   - dora
 
-# Not dora's `latest`: that one decodes ExecutionRequests as three lists where Gloas has five, so it
-# indexes no block and shows an empty chain.
 dora_params:
   image: ethpandaops/dora:master
 
-# The generator has no glamsterdam-devnet-8 tag -- the series stops at devnet-7 -- so this is the
-# release that was current when devnet-8 was generated.
 ethereum_genesis_generator_params:
   image: ethpandaops/ethereum-genesis-generator:6.2.0
 

--- a/.github/tests/crysm-basic.yaml
+++ b/.github/tests/crysm-basic.yaml
@@ -1,0 +1,40 @@
+# crysm is Gloas-only -- it carries no pre-Gloas containers -- so it can appear only where Gloas is
+# at genesis. That is why this file cannot be folded into one of the mix suites, none of which fork
+# to Gloas at all.
+participants:
+  # devnet-8 rather than a stock geth: Gloas at genesis needs an execution client that speaks ePBS.
+  - el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-8
+    cl_type: crysm
+    # One binary, no separate VC service, which is also why crysm has no VC_TYPE launcher.
+    use_separate_vc: false
+    validator_count: 128
+
+network_params:
+  gloas_fork_epoch: 0
+  preset: mainnet
+  # geth rejects a BPO after amsterdam, which Gloas at genesis puts at genesis too.
+  bpo_1_epoch: 0
+  bpo_2_epoch: 0
+
+additional_services:
+  - dora
+
+# Not dora's `latest`: that one decodes ExecutionRequests as three lists where Gloas has five, so it
+# indexes no block and shows an empty chain.
+dora_params:
+  image: ethpandaops/dora:master
+
+# The generator has no glamsterdam-devnet-8 tag -- the series stops at devnet-7 -- so this is the
+# release that was current when devnet-8 was generated.
+ethereum_genesis_generator_params:
+  image: ethpandaops/ethereum-genesis-generator:6.2.0
+
+global_log_level: debug
+snooper_enabled: true
+
+port_publisher:
+  cl:
+    enabled: true
+  additional_services:
+    enabled: true

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -18,6 +18,8 @@ jobs:
             "./.github/tests/mix-persistence.yaml",
             "./.github/tests/mix-public.yaml",
             "./.github/tests/minimal.yaml",
+            # A Gloas-only client cannot join any of the files above, none of which fork to Gloas.
+            "./.github/tests/crysm-basic.yaml",
             "./network_params.yaml",
             "."
           ]

--- a/.github/workflows/per-pr.yml
+++ b/.github/workflows/per-pr.yml
@@ -18,7 +18,6 @@ jobs:
             "./.github/tests/mix-persistence.yaml",
             "./.github/tests/mix-public.yaml",
             "./.github/tests/minimal.yaml",
-            # A Gloas-only client cannot join any of the files above, none of which fork to Gloas.
             "./.github/tests/crysm-basic.yaml",
             "./network_params.yaml",
             "."

--- a/src/cl/cl_launcher.star
+++ b/src/cl/cl_launcher.star
@@ -8,6 +8,7 @@ teku = import_module("./teku/teku_launcher.star")
 grandine = import_module("./grandine/grandine_launcher.star")
 consensoor = import_module("./consensoor/consensoor_launcher.star")
 caplin = import_module("./caplin/caplin_launcher.star")
+crysm = import_module("./crysm/crysm_launcher.star")
 
 cl_shared = import_module("./cl_shared.star")
 constants = import_module("../package_io/constants.star")
@@ -113,6 +114,15 @@ def launch(
             ),
             "get_beacon_config": caplin.get_beacon_config,
             "get_cl_context": caplin.get_cl_context,
+            "get_blobber_config": cl_shared.get_blobber_config_none,
+        },
+        constants.CL_TYPE.crysm: {
+            "launcher": crysm.new_crysm_launcher(
+                el_cl_data,
+                jwt_file,
+            ),
+            "get_beacon_config": crysm.get_beacon_config,
+            "get_cl_context": crysm.get_cl_context,
             "get_blobber_config": cl_shared.get_blobber_config_none,
         },
     }

--- a/src/cl/crysm/crysm_launcher.star
+++ b/src/cl/crysm/crysm_launcher.star
@@ -1,0 +1,362 @@
+node_metrics = import_module("../../node_metrics_info.star")
+shared_utils = import_module("../../shared_utils/shared_utils.star")
+input_parser = import_module("../../package_io/input_parser.star")
+cl_context = import_module("../../cl/cl_context.star")
+cl_shared = import_module("../cl_shared.star")
+cl_node_ready_conditions = import_module("../cl_node_ready_conditions.star")
+constants = import_module("../../package_io/constants.star")
+
+BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER = "/data/crysm"
+
+BEACON_DISCOVERY_PORT_NUM = 9000
+BEACON_QUIC_PORT_NUM = 9001
+BEACON_HTTP_PORT_NUM = 4000
+BEACON_METRICS_PORT_NUM = 5054
+METRICS_PATH = "/metrics"
+
+# crysm speaks QUIC only. It answers /eth/v1/node/health but not /eth/v1/node/identity, which is
+# why this launcher takes the package's ready condition and still hands back no ENR.
+VERBOSITY_LEVELS = {
+    constants.GLOBAL_LOG_LEVEL.error: "error",
+    constants.GLOBAL_LOG_LEVEL.warn: "warn",
+    constants.GLOBAL_LOG_LEVEL.info: "info",
+    constants.GLOBAL_LOG_LEVEL.debug: "debug",
+    constants.GLOBAL_LOG_LEVEL.trace: "debug",
+}
+
+VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER = "/validator"
+VALIDATOR_SETTINGS_FILENAME = "settings.json"
+
+# crysm's validator client is the same binary behind --validator, and it takes one JSON file rather
+# than a row of flags. Rendered here rather than shipped in the args file because two of its values
+# are only knowable here: the keystore artifact's own directory name carries the participant index.
+VALIDATOR_SETTINGS_TEMPLATE = """{
+  "keystores_dir": "{{.KeysDir}}",
+  "secrets_dir": "{{.SecretsDir}}",
+  "protection_dir": "{{.ProtectionDir}}",
+
+  "beacon": { "host": "127.0.0.1", "port": {{.BeaconPort}} },
+
+  "proposer_settings": {
+    "default_config": {
+      "fee_recipient": "{{.FeeRecipient}}",
+      "gas_limit": "{{.GasLimit}}"
+    },
+    "version": 2
+  }
+}
+"""
+
+# The client takes a host and a port, not a URL.
+def host_port(url):
+    return url.replace("http://", "").replace("https://", "").rstrip("/")
+
+
+def get_beacon_config(
+    plan,
+    launcher,
+    beacon_service_name,
+    participant,
+    global_log_level,
+    bootnode_contexts,
+    el_context,
+    full_name,
+    node_keystore_files,
+    snooper_el_engine_context,
+    persistent,
+    tolerations,
+    node_selectors,
+    checkpoint_sync_enabled,
+    checkpoint_sync_url,
+    port_publisher,
+    participant_index,
+    network_params,
+    extra_files_artifacts,
+    backend,
+    tempo_otlp_grpc_url,
+    otel_otlp_grpc_url=None,
+    bootnode_enr_override=None,
+    cl_binary_artifact=None,
+):
+    log_level = input_parser.get_client_log_level_or_default(
+        participant.cl_log_level, global_log_level, VERBOSITY_LEVELS
+    )
+
+    EXECUTION_ENGINE_ENDPOINT = cl_shared.get_execution_engine_endpoint(
+        participant, el_context, snooper_el_engine_context
+    )
+
+    public_ports = {}
+    public_ports_for_component = None
+    if port_publisher.cl_enabled:
+        public_ports_for_component = shared_utils.get_public_ports_for_component(
+            "cl",
+            port_publisher,
+            participant_index,
+        )
+        # The four this client actually listens on.
+        public_ports = shared_utils.get_port_specs(
+            {
+                constants.UDP_DISCOVERY_PORT_ID: public_ports_for_component[0],
+                constants.HTTP_PORT_ID: public_ports_for_component[1],
+                constants.METRICS_PORT_ID: public_ports_for_component[2],
+                constants.QUIC_DISCOVERY_PORT_ID: public_ports_for_component[3],
+            }
+        )
+
+    discovery_port = (
+        public_ports_for_component[0]
+        if public_ports_for_component
+        else BEACON_DISCOVERY_PORT_NUM
+    )
+    discovery_port_quic = (
+        public_ports_for_component[3]
+        if public_ports_for_component
+        else BEACON_QUIC_PORT_NUM
+    )
+
+    used_port_assignments = {
+        constants.UDP_DISCOVERY_PORT_ID: discovery_port,
+        constants.QUIC_DISCOVERY_PORT_ID: discovery_port_quic,
+        constants.HTTP_PORT_ID: BEACON_HTTP_PORT_NUM,
+        constants.METRICS_PORT_ID: BEACON_METRICS_PORT_NUM,
+    }
+
+    if participant.skip_start:
+        used_ports = shared_utils.get_port_specs(used_port_assignments, wait=None)
+    else:
+        used_ports = shared_utils.get_port_specs(used_port_assignments)
+
+    cmd = [
+        "crysm",
+        "--config",
+        constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER + "/config.yaml",
+        "--datadir",
+        BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER,
+        "--discovery-port",
+        "{0}".format(discovery_port),
+        "--quic-port",
+        "{0}".format(discovery_port_quic),
+        # A container cannot work out its own reachable address, so it is told.
+        "--advertised-ip",
+        constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "--http",
+        "--http-address",
+        "0.0.0.0",
+        "--http-port",
+        "{0}".format(BEACON_HTTP_PORT_NUM),
+        "--metrics",
+        "--metrics-address",
+        "0.0.0.0",
+        "--metrics-port",
+        "{0}".format(BEACON_METRICS_PORT_NUM),
+        # A supernode custodies every column; anyone else keeps the requirement.
+        "--cgc",
+        "128" if participant.supernode else "4",
+        "--log-level",
+        log_level,
+        # A container's stdout is a pipe, so the client would otherwise decide not to colour. Kurtosis
+        # passes the escapes through to whoever is reading the logs.
+        "--log-color",
+        "always",
+    ]
+
+    # Either anchor, never both: GLOAS at genesis is the only way this client can start from slot 0,
+    # since it has no pre-Gloas containers.
+    if checkpoint_sync_enabled and checkpoint_sync_url:
+        cmd.append("--checkpoint")
+        cmd.append(host_port(checkpoint_sync_url))
+        cmd.append("--state-id")
+        cmd.append("finalized")
+    else:
+        cmd.append("--genesis")
+        cmd.append(constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER + "/genesis.ssz")
+
+    if el_context != None:
+        cmd.append("--engine")
+        cmd.append(host_port(EXECUTION_ENGINE_ENDPOINT))
+        cmd.append("--jwt")
+        cmd.append(constants.JWT_MOUNT_PATH_ON_CONTAINER)
+
+    bootnode_arg = bootnode_enr_override
+    if network_params.network not in constants.PUBLIC_NETWORKS:
+        if (
+            network_params.network == constants.NETWORK_NAME.kurtosis
+            or constants.NETWORK_NAME.shadowfork in network_params.network
+        ):
+            if bootnode_arg == None and bootnode_contexts != None:
+                for ctx in bootnode_contexts[: constants.MAX_ENR_ENTRIES]:
+                    if ctx.enr:
+                        cmd.append("--bootnode")
+                        cmd.append(ctx.enr)
+        elif bootnode_arg == None:
+            bootnode_arg = shared_utils.get_devnet_enrs_list(
+                plan, launcher.el_cl_genesis_data.files_artifact_uuid
+            )
+
+    if bootnode_arg != None:
+        cmd.append("--bootnode")
+        cmd.append(bootnode_arg)
+
+    # `use_separate_vc: false` for this client means the beacon node runs the validator, not that
+    # nothing does: they are one binary talking to itself over the Beacon API on loopback.
+    validator_settings = None
+    if node_keystore_files != None and not participant.use_separate_vc:
+        validator_settings = plan.render_templates(
+            {
+                VALIDATOR_SETTINGS_FILENAME: shared_utils.new_template_and_data(
+                    VALIDATOR_SETTINGS_TEMPLATE,
+                    {
+                        # The raw layout, which is lighthouse's and eth2-val-tools':
+                        # keys/<0xpubkey>/voting-keystore.json beside secrets/<0xpubkey>.
+                        "KeysDir": shared_utils.path_join(
+                            constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
+                            node_keystore_files.raw_keys_relative_dirpath,
+                        ),
+                        "SecretsDir": shared_utils.path_join(
+                            constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
+                            node_keystore_files.raw_secrets_relative_dirpath,
+                        ),
+                        # Beside the beacon data, so a persistent participant keeps its slashing
+                        # protection across a restart the way it keeps its blocks.
+                        "ProtectionDir": BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER
+                        + "/validator",
+                        "BeaconPort": BEACON_HTTP_PORT_NUM,
+                        "FeeRecipient": constants.VALIDATING_REWARDS_ACCOUNT,
+                        "GasLimit": network_params.gas_limit,
+                    },
+                )
+            },
+            "crysm-validator-settings-{0}".format(beacon_service_name),
+        )
+        cmd.append("--validator")
+        cmd.append(
+            VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER
+            + "/"
+            + VALIDATOR_SETTINGS_FILENAME
+        )
+
+    if len(participant.cl_extra_params) > 0:
+        cmd.extend([param for param in participant.cl_extra_params])
+
+    files = {
+        constants.GENESIS_DATA_MOUNTPOINT_ON_CLIENTS: launcher.el_cl_genesis_data.files_artifact_uuid,
+    }
+    if el_context != None:
+        files[constants.JWT_MOUNTPOINT_ON_CLIENTS] = launcher.jwt_file
+
+    if validator_settings != None:
+        files[
+            constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER
+        ] = node_keystore_files.files_artifact_uuid
+        files[VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER] = validator_settings
+
+    if persistent:
+        # crysm has no volume-size entry of its own, so it reuses the lighthouse key, as consensoor
+        # does.
+        files[
+            BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER
+        ] = cl_shared.get_beacon_data_directory(
+            beacon_service_name,
+            participant,
+            network_params,
+            constants.CL_TYPE.lighthouse,
+        )
+
+    processed_mounts = shared_utils.process_extra_mounts(
+        plan, participant.cl_extra_mounts, extra_files_artifacts
+    )
+    for mount_path, artifact in processed_mounts.items():
+        files[mount_path] = artifact
+
+    if cl_binary_artifact != None:
+        files["/opt/bin"] = cl_binary_artifact.artifact
+
+    env_vars = shared_utils.with_otel_env_vars(
+        participant.cl_extra_env_vars,
+        otel_otlp_grpc_url,
+        beacon_service_name,
+    )
+
+    # exec, so the client is pid 1's process and gets the SIGTERM Kurtosis sends.
+    cmd_str = "exec " + " ".join(cmd)
+    if cl_binary_artifact != None:
+        cmd_str = (
+            "cp /opt/bin/{0} /usr/local/bin/crysm && ".format(cl_binary_artifact.filename)
+            + cmd_str
+        )
+
+    config_args = {
+        "image": participant.cl_image,
+        "ports": used_ports,
+        "public_ports": public_ports,
+        "entrypoint": ["sh", "-c"],
+        "cmd": [cmd_str],
+        "files": files,
+        "env_vars": env_vars,
+        "private_ip_address_placeholder": constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
+        "labels": shared_utils.label_maker(
+            client=constants.CL_TYPE.crysm,
+            client_type=constants.CLIENT_TYPES.cl,
+            image=participant.cl_image[-constants.MAX_LABEL_LENGTH :],
+            connected_client=el_context.client_name if el_context != None else "none",
+            extra_labels=participant.cl_extra_labels
+            | {constants.NODE_INDEX_LABEL_KEY: str(participant_index + 1)},
+            supernode=participant.supernode,
+        ),
+        "tolerations": tolerations,
+        "node_selectors": node_selectors,
+    }
+
+    if not participant.skip_start:
+        config_args["ready_conditions"] = cl_node_ready_conditions.get_ready_conditions(
+            constants.HTTP_PORT_ID
+        )
+
+    cl_shared.apply_resource_limits(config_args, participant)
+    return ServiceConfig(**config_args)
+
+
+def get_cl_context(
+    plan,
+    service_name,
+    service,
+    participant,
+    snooper_el_engine_context,
+    node_keystore_files,
+    node_selectors,
+):
+    beacon_http_port = service.ports[constants.HTTP_PORT_ID]
+    beacon_metrics_port = service.ports[constants.METRICS_PORT_ID]
+    beacon_node_metrics_info = node_metrics.new_node_metrics_info(
+        service_name,
+        METRICS_PATH,
+        "{0}:{1}".format(service.name, beacon_metrics_port.number),
+    )
+
+    # No identity request, and so no ENR to hand back: /eth/v1/node/identity is not among the
+    # endpoints this client serves, so nothing else can use it as a bootnode. Dialling out is
+    # unaffected, which is what a follower needs.
+    return cl_context.new_cl_context(
+        client_name="crysm",
+        enr="",
+        ip_addr=service.name,
+        ip_address=service.ip_address,
+        http_port=beacon_http_port.number,
+        beacon_http_url="http://{0}:{1}".format(service.name, beacon_http_port.number),
+        cl_nodes_metrics_info=[beacon_node_metrics_info],
+        beacon_service_name=service_name,
+        multiaddr="",
+        peer_id="",
+        snooper_enabled=participant.snooper_enabled,
+        snooper_el_engine_context=snooper_el_engine_context,
+        validator_keystore_files_artifact_uuid="",
+        supernode=participant.supernode,
+    )
+
+
+def new_crysm_launcher(el_cl_genesis_data, jwt_file):
+    return struct(
+        el_cl_genesis_data=el_cl_genesis_data,
+        jwt_file=jwt_file,
+    )

--- a/src/cl/crysm/crysm_launcher.star
+++ b/src/cl/crysm/crysm_launcher.star
@@ -14,7 +14,6 @@ BEACON_HTTP_PORT_NUM = 4000
 BEACON_METRICS_PORT_NUM = 5054
 METRICS_PATH = "/metrics"
 
-# crysm speaks QUIC only, so there is no TCP discovery port to declare.
 VERBOSITY_LEVELS = {
     constants.GLOBAL_LOG_LEVEL.error: "error",
     constants.GLOBAL_LOG_LEVEL.warn: "warn",
@@ -24,7 +23,6 @@ VERBOSITY_LEVELS = {
 }
 
 
-# The client takes a host and a port, not a URL.
 def host_port(url):
     return url.replace("http://", "").replace("https://", "").rstrip("/")
 
@@ -71,7 +69,6 @@ def get_beacon_config(
             port_publisher,
             participant_index,
         )
-        # The four this client actually listens on.
         public_ports = shared_utils.get_port_specs(
             {
                 constants.UDP_DISCOVERY_PORT_ID: public_ports_for_component[0],
@@ -114,7 +111,6 @@ def get_beacon_config(
         "{0}".format(discovery_port),
         "--quic-port",
         "{0}".format(discovery_port_quic),
-        # A container cannot work out its own reachable address, so it is told.
         "--advertised-ip",
         constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "--http",
@@ -127,23 +123,16 @@ def get_beacon_config(
         "0.0.0.0",
         "--metrics-port",
         "{0}".format(BEACON_METRICS_PORT_NUM),
-        # A supernode custodies every column; anyone else keeps the requirement.
         "--cgc",
         "128" if participant.supernode else "4",
-        # Not confined to the built-in validator: a separate client drives proposals through this
-        # node too, and what it does not name a recipient for is paid to whatever this node holds.
         "--suggested-fee-recipient",
         constants.VALIDATING_REWARDS_ACCOUNT,
         "--log-level",
         log_level,
-        # A container's stdout is a pipe, so the client would otherwise decide not to colour. Kurtosis
-        # passes the escapes through to whoever is reading the logs.
         "--log-color",
         "always",
     ]
 
-    # Either anchor, never both: GLOAS at genesis is the only way this client can start from slot 0,
-    # since it has no pre-Gloas containers.
     if checkpoint_sync_enabled and checkpoint_sync_url:
         cmd.append("--checkpoint")
         cmd.append(host_port(checkpoint_sync_url))
@@ -169,8 +158,6 @@ def get_beacon_config(
             network_params.network == constants.NETWORK_NAME.kurtosis
             or constants.NETWORK_NAME.shadowfork in network_params.network
         ):
-            # No multiaddr fallback, unlike the clients either side of this one: --bootnode takes a
-            # record and --peer takes host:port/peer-id, and a libp2p multiaddr is neither.
             if bootnode_arg == None and bootnode_contexts != None:
                 for ctx in bootnode_contexts[: constants.MAX_ENR_ENTRIES]:
                     if ctx.enr:
@@ -181,22 +168,16 @@ def get_beacon_config(
                 plan, launcher.el_cl_genesis_data.files_artifact_uuid
             )
 
-    # The flag is repeatable and takes one record, so the comma-joined list the devnet branch
-    # produces has to be handed over an entry at a time rather than whole.
     if bootnode_arg != None:
         for enr in bootnode_arg.split(","):
             if enr:
                 cmd.append("--bootnode")
                 cmd.append(enr)
 
-    # `use_separate_vc: false` for this client means the beacon node runs the validator, not that
-    # nothing does: they are one binary talking to itself over the Beacon API on loopback.
     mount_validator_keys = (
         node_keystore_files != None and not participant.use_separate_vc
     )
     if mount_validator_keys:
-        # The raw layout, which is lighthouse's and eth2-val-tools': keys/<0xpubkey>/
-        # voting-keystore.json beside secrets/<0xpubkey>.
         cmd.append("--keystores-dir")
         cmd.append(
             shared_utils.path_join(
@@ -227,8 +208,6 @@ def get_beacon_config(
         ] = node_keystore_files.files_artifact_uuid
 
     if persistent:
-        # crysm has no volume-size entry of its own, so it reuses the lighthouse key, as consensoor
-        # does.
         files[
             BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER
         ] = cl_shared.get_beacon_data_directory(
@@ -253,7 +232,6 @@ def get_beacon_config(
         beacon_service_name,
     )
 
-    # exec, so the client is pid 1's process and gets the SIGTERM Kurtosis sends.
     cmd_str = "exec " + " ".join(cmd)
     if cl_binary_artifact != None:
         cmd_str = (

--- a/src/cl/crysm/crysm_launcher.star
+++ b/src/cl/crysm/crysm_launcher.star
@@ -130,6 +130,10 @@ def get_beacon_config(
         # A supernode custodies every column; anyone else keeps the requirement.
         "--cgc",
         "128" if participant.supernode else "4",
+        # Not confined to the built-in validator: a separate client drives proposals through this
+        # node too, and what it does not name a recipient for is paid to whatever this node holds.
+        "--suggested-fee-recipient",
+        constants.VALIDATING_REWARDS_ACCOUNT,
         "--log-level",
         log_level,
         # A container's stdout is a pipe, so the client would otherwise decide not to colour. Kurtosis
@@ -148,6 +152,10 @@ def get_beacon_config(
     else:
         cmd.append("--genesis")
         cmd.append(constants.GENESIS_CONFIG_MOUNT_PATH_ON_CONTAINER + "/genesis.ssz")
+
+    if network_params.gas_limit > 0:
+        cmd.append("--target-gas-limit")
+        cmd.append("{0}".format(network_params.gas_limit))
 
     if el_context != None:
         cmd.append("--engine")
@@ -203,11 +211,6 @@ def get_beacon_config(
                 node_keystore_files.raw_secrets_relative_dirpath,
             )
         )
-        # Both reach the preference the client signs, which is what a Gloas proposal is paid by.
-        cmd.append("--suggested-fee-recipient")
-        cmd.append(constants.VALIDATING_REWARDS_ACCOUNT)
-        cmd.append("--target-gas-limit")
-        cmd.append("{0}".format(network_params.gas_limit))
 
     if len(participant.cl_extra_params) > 0:
         cmd.extend([param for param in participant.cl_extra_params])

--- a/src/cl/crysm/crysm_launcher.star
+++ b/src/cl/crysm/crysm_launcher.star
@@ -14,8 +14,7 @@ BEACON_HTTP_PORT_NUM = 4000
 BEACON_METRICS_PORT_NUM = 5054
 METRICS_PATH = "/metrics"
 
-# crysm speaks QUIC only. It answers /eth/v1/node/health but not /eth/v1/node/identity, which is
-# why this launcher takes the package's ready condition and still hands back no ENR.
+# crysm speaks QUIC only, so there is no TCP discovery port to declare.
 VERBOSITY_LEVELS = {
     constants.GLOBAL_LOG_LEVEL.error: "error",
     constants.GLOBAL_LOG_LEVEL.warn: "warn",
@@ -24,28 +23,6 @@ VERBOSITY_LEVELS = {
     constants.GLOBAL_LOG_LEVEL.trace: "debug",
 }
 
-VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER = "/validator"
-VALIDATOR_SETTINGS_FILENAME = "settings.json"
-
-# crysm's validator client is the same binary behind --validator, and it takes one JSON file rather
-# than a row of flags. Rendered here rather than shipped in the args file because two of its values
-# are only knowable here: the keystore artifact's own directory name carries the participant index.
-VALIDATOR_SETTINGS_TEMPLATE = """{
-  "keystores_dir": "{{.KeysDir}}",
-  "secrets_dir": "{{.SecretsDir}}",
-  "protection_dir": "{{.ProtectionDir}}",
-
-  "beacon": { "host": "127.0.0.1", "port": {{.BeaconPort}} },
-
-  "proposer_settings": {
-    "default_config": {
-      "fee_recipient": "{{.FeeRecipient}}",
-      "gas_limit": "{{.GasLimit}}"
-    },
-    "version": 2
-  }
-}
-"""
 
 # The client takes a host and a port, not a URL.
 def host_port(url):
@@ -184,6 +161,8 @@ def get_beacon_config(
             network_params.network == constants.NETWORK_NAME.kurtosis
             or constants.NETWORK_NAME.shadowfork in network_params.network
         ):
+            # No multiaddr fallback, unlike the clients either side of this one: --bootnode takes a
+            # record and --peer takes host:port/peer-id, and a libp2p multiaddr is neither.
             if bootnode_arg == None and bootnode_contexts != None:
                 for ctx in bootnode_contexts[: constants.MAX_ENR_ENTRIES]:
                     if ctx.enr:
@@ -194,47 +173,41 @@ def get_beacon_config(
                 plan, launcher.el_cl_genesis_data.files_artifact_uuid
             )
 
+    # The flag is repeatable and takes one record, so the comma-joined list the devnet branch
+    # produces has to be handed over an entry at a time rather than whole.
     if bootnode_arg != None:
-        cmd.append("--bootnode")
-        cmd.append(bootnode_arg)
+        for enr in bootnode_arg.split(","):
+            if enr:
+                cmd.append("--bootnode")
+                cmd.append(enr)
 
     # `use_separate_vc: false` for this client means the beacon node runs the validator, not that
     # nothing does: they are one binary talking to itself over the Beacon API on loopback.
-    validator_settings = None
-    if node_keystore_files != None and not participant.use_separate_vc:
-        validator_settings = plan.render_templates(
-            {
-                VALIDATOR_SETTINGS_FILENAME: shared_utils.new_template_and_data(
-                    VALIDATOR_SETTINGS_TEMPLATE,
-                    {
-                        # The raw layout, which is lighthouse's and eth2-val-tools':
-                        # keys/<0xpubkey>/voting-keystore.json beside secrets/<0xpubkey>.
-                        "KeysDir": shared_utils.path_join(
-                            constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
-                            node_keystore_files.raw_keys_relative_dirpath,
-                        ),
-                        "SecretsDir": shared_utils.path_join(
-                            constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
-                            node_keystore_files.raw_secrets_relative_dirpath,
-                        ),
-                        # Beside the beacon data, so a persistent participant keeps its slashing
-                        # protection across a restart the way it keeps its blocks.
-                        "ProtectionDir": BEACON_DATA_DIRPATH_ON_BEACON_SERVICE_CONTAINER
-                        + "/validator",
-                        "BeaconPort": BEACON_HTTP_PORT_NUM,
-                        "FeeRecipient": constants.VALIDATING_REWARDS_ACCOUNT,
-                        "GasLimit": network_params.gas_limit,
-                    },
-                )
-            },
-            "crysm-validator-settings-{0}".format(beacon_service_name),
-        )
-        cmd.append("--validator")
+    mount_validator_keys = (
+        node_keystore_files != None and not participant.use_separate_vc
+    )
+    if mount_validator_keys:
+        # The raw layout, which is lighthouse's and eth2-val-tools': keys/<0xpubkey>/
+        # voting-keystore.json beside secrets/<0xpubkey>.
+        cmd.append("--keystores-dir")
         cmd.append(
-            VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER
-            + "/"
-            + VALIDATOR_SETTINGS_FILENAME
+            shared_utils.path_join(
+                constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
+                node_keystore_files.raw_keys_relative_dirpath,
+            )
         )
+        cmd.append("--secrets-dir")
+        cmd.append(
+            shared_utils.path_join(
+                constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER,
+                node_keystore_files.raw_secrets_relative_dirpath,
+            )
+        )
+        # Both reach the preference the client signs, which is what a Gloas proposal is paid by.
+        cmd.append("--suggested-fee-recipient")
+        cmd.append(constants.VALIDATING_REWARDS_ACCOUNT)
+        cmd.append("--target-gas-limit")
+        cmd.append("{0}".format(network_params.gas_limit))
 
     if len(participant.cl_extra_params) > 0:
         cmd.extend([param for param in participant.cl_extra_params])
@@ -245,11 +218,10 @@ def get_beacon_config(
     if el_context != None:
         files[constants.JWT_MOUNTPOINT_ON_CLIENTS] = launcher.jwt_file
 
-    if validator_settings != None:
+    if mount_validator_keys:
         files[
             constants.VALIDATOR_KEYS_DIRPATH_ON_SERVICE_CONTAINER
         ] = node_keystore_files.files_artifact_uuid
-        files[VALIDATOR_SETTINGS_DIRPATH_ON_BEACON_SERVICE_CONTAINER] = validator_settings
 
     if persistent:
         # crysm has no volume-size entry of its own, so it reuses the lighthouse key, as consensoor
@@ -282,7 +254,9 @@ def get_beacon_config(
     cmd_str = "exec " + " ".join(cmd)
     if cl_binary_artifact != None:
         cmd_str = (
-            "cp /opt/bin/{0} /usr/local/bin/crysm && ".format(cl_binary_artifact.filename)
+            "cp /opt/bin/{0} /usr/local/bin/crysm && ".format(
+                cl_binary_artifact.filename
+            )
             + cmd_str
         )
 
@@ -334,23 +308,28 @@ def get_cl_context(
         "{0}:{1}".format(service.name, beacon_metrics_port.number),
     )
 
-    # No identity request, and so no ENR to hand back: /eth/v1/node/identity is not among the
-    # endpoints this client serves, so nothing else can use it as a bootnode. Dialling out is
-    # unaffected, which is what a follower needs.
+    (
+        beacon_node_enr,
+        beacon_multiaddr,
+        beacon_peer_id,
+    ) = cl_shared.get_beacon_node_identity(plan, service_name, participant)
+
     return cl_context.new_cl_context(
         client_name="crysm",
-        enr="",
+        enr=beacon_node_enr,
         ip_addr=service.name,
         ip_address=service.ip_address,
         http_port=beacon_http_port.number,
         beacon_http_url="http://{0}:{1}".format(service.name, beacon_http_port.number),
         cl_nodes_metrics_info=[beacon_node_metrics_info],
         beacon_service_name=service_name,
-        multiaddr="",
-        peer_id="",
+        multiaddr=beacon_multiaddr,
+        peer_id=beacon_peer_id,
         snooper_enabled=participant.snooper_enabled,
         snooper_el_engine_context=snooper_el_engine_context,
-        validator_keystore_files_artifact_uuid="",
+        validator_keystore_files_artifact_uuid=node_keystore_files.files_artifact_uuid
+        if node_keystore_files
+        else "",
         supernode=participant.supernode,
     )
 

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -20,6 +20,7 @@ CL_TYPE = struct(
     grandine="grandine",
     consensoor="consensoor",
     caplin="caplin",
+    crysm="crysm",
 )
 
 VC_TYPE = struct(

--- a/src/package_io/constants.star
+++ b/src/package_io/constants.star
@@ -32,6 +32,7 @@ VC_TYPE = struct(
     vero="vero",
     grandine="grandine",
     consensoor="consensoor",
+    crysm="crysm",
 )
 
 REMOTE_SIGNER_TYPE = struct(web3signer="web3signer")

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -26,6 +26,7 @@ DEFAULT_CL_IMAGES = {
     "grandine": "sifrai/grandine:stable",
     "consensoor": "ethpandaops/consensoor:main",
     "caplin": "ethpandaops/caplin:main",
+    "crysm": "crysm:mainnet",
 }
 
 DEFAULT_CL_IMAGES_MINIMAL = {
@@ -37,6 +38,7 @@ DEFAULT_CL_IMAGES_MINIMAL = {
     "grandine": "ethpandaops/grandine:develop-minimal",
     "consensoor": "ethpandaops/consensoor:main",
     "caplin": "ethpandaops/caplin:main",
+    "crysm": "crysm:mainnet",
 }
 
 DEFAULT_VC_IMAGES = {

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -26,7 +26,7 @@ DEFAULT_CL_IMAGES = {
     "grandine": "sifrai/grandine:stable",
     "consensoor": "ethpandaops/consensoor:main",
     "caplin": "ethpandaops/caplin:main",
-    "crysm": "crysm:mainnet",
+    "crysm": "ghcr.io/offchainlabs/crysm:stable",
 }
 
 DEFAULT_CL_IMAGES_MINIMAL = {
@@ -38,7 +38,7 @@ DEFAULT_CL_IMAGES_MINIMAL = {
     "grandine": "ethpandaops/grandine:develop-minimal",
     "consensoor": "ethpandaops/consensoor:main",
     "caplin": "ethpandaops/caplin:main",
-    "crysm": "crysm:mainnet",
+    "crysm": "ghcr.io/offchainlabs/crysm:stable-minimal",
 }
 
 DEFAULT_VC_IMAGES = {
@@ -1612,6 +1612,7 @@ def parse_network_params(plan, input_args):
                     constants.CL_TYPE.nimbus,
                     constants.CL_TYPE.teku,
                     constants.CL_TYPE.grandine,
+                    constants.CL_TYPE.crysm,
                 )
                 and vc_type == ""
             ):

--- a/src/vc/vc_launcher.star
+++ b/src/vc/vc_launcher.star
@@ -106,6 +106,8 @@ def get_vc_config(
         fail("Grandine VC is not yet supported")
     elif vc_type == constants.VC_TYPE.consensoor:
         return None
+    elif vc_type == constants.VC_TYPE.crysm:
+        return None
 
     if vc_type not in vc_launchers:
         fail(


### PR DESCRIPTION
Adds `crysm`, a C++ consensus client, as a `cl_type`.

## Shape of the change

A launcher plus registrations, following the consensoor precedent:

- `src/cl/crysm/crysm_launcher.star` — the launcher
- `src/package_io/constants.star` — `crysm` in `CL_TYPE` and `VC_TYPE`
- `src/package_io/input_parser.star` — both image tables, and the in-process-VC default list
- `src/vc/vc_launcher.star` — the `return None` hatch
- `src/cl/cl_launcher.star` — import and dispatch entry
- `.github/tests/crysm-basic.yaml` — one participant, Gloas at genesis, dora

## The validator arrangement

crysm's validator client is the same binary as the beacon node, talking to itself over the Beacon
API on loopback. So there is no VC service to launch: `crysm` is in `VC_TYPE` only to reach the
`return None` hatch, exactly as `consensoor` is, and `use_separate_vc` defaults to `False` for it.

The keys are passed as `--keystores-dir` and `--secrets-dir`. An earlier version of this launcher
rendered a `settings.json` instead, which no other CL launcher does; crysm grew the two flags so this
diff looks like its neighbours.

## crysm is Gloas-only

It carries no pre-Gloas containers — `forks::gloas` is the only fork tag in its type system — so it
can start only where Gloas is at genesis. Two consequences worth stating plainly:

- Its coverage is one file, not the matrix the mature clients enjoy. The ~60 pre-fork test files are
  closed to it.
- **It cannot be added to any existing test file.** None of them sets `gloas_fork_epoch: 0`, so
  folding crysm into `mix-with-tools.yaml` or similar would mean changing that file's fork schedule
  for every other client in it. That is why `crysm-basic.yaml` is a new file, and why this PR adds an
  eighth entry to the `per-pr.yml` matrix rather than reusing one of the seven. I appreciate that
  matrix is deliberately short; I could not find a way to exercise a Gloas-only client without it,
  and am happy to drop the entry and take nightly-only coverage if you would rather.

`crysm-basic.yaml` pins `ethpandaops/geth:glamsterdam-devnet-8`, `ethpandaops/dora:master` and
`ethereum-genesis-generator:6.2.0`. Each is load-bearing for a Gloas-at-genesis enclave and each is
commented in the file.

## The image

`ghcr.io/offchainlabs/crysm:stable` and `:stable-minimal`, published by OffchainLabs — the same
arrangement as `offchainlabs/prysm-beacon-chain:stable`, so this needs nothing from your image
pipeline. Both are multi-arch (`linux/amd64` + `linux/arm64`), built on native runners.

## A latent bug this touches but does not fix

`cl_shared.append_bootnode_arg` joins bootnode ENRs without filtering empties:

```python
bootnode_arg = ",".join([ctx.enr for ctx in bootnode_contexts[: constants.MAX_ENR_ENTRIES]])
```

Any client returning `enr=""` therefore injects a blank entry into the bootnode list handed to
lighthouse, teku, lodestar and grandine; `nimbus_launcher.star` and `prysm_launcher.star` have the
same unguarded loop. Because `""` is not `None`, the devnet ENR-list fallback is skipped too, and
nothing errors — the enclave simply never peers while every service reports healthy.

An early version of this launcher had exactly that defect. It now returns a real ENR, so nothing in
tree triggers this today and the PR leaves the shared helper alone. Happy to send a separate one-line
hardening PR if you want it.

## Known limitations

- **Checkpoint sync over HTTPS does not work.** crysm's `--checkpoint` takes `host:port` and does no
  TLS, so the launcher strips the scheme. Fine against an in-enclave checkpointz, not against a
  public provider.
- **No `tcp-discovery` port.** crysm speaks QUIC only, so the launcher builds its own public-port map
  rather than calling `cl_shared.get_general_cl_public_port_specs()`.
- **No `/eth/v2/beacon/blocks/{block_id}` or rewards endpoints yet**, which some tooling reads.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
